### PR TITLE
Remove Repo token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,5 +60,3 @@ jobs:
 
       - name: Coveralls
         uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
Repo token is not necessary for public repos and does cause problems with external pull requests