### PR TITLE
Fix einsum plugin repo

### DIFF
--- a/include/sdfg/codegen/dispatchers/block_dispatcher.h
+++ b/include/sdfg/codegen/dispatchers/block_dispatcher.h
@@ -40,7 +40,7 @@ class DataFlowDispatcher {
 };
 
 class LibraryNodeDispatcher {
-   private:
+   protected:
     LanguageExtension& language_extension_;
     const Function& function_;
     const data_flow::DataFlowGraph& data_flow_graph_;


### PR DESCRIPTION
This is linked to the pull request [Rework infrastructure for einsum nodes #1](https://github.com/daisytuner/sdfglib-einsum/pull/1) and fixes the access rights of the `LibraryNodeDispatcher` class such that subclasses can use its members.