### PR TITLE
Enable the same compiler warnings for arg-capture-io as used on its c…

### DIFF
--- a/arg-capture-io/CMakeLists.txt
+++ b/arg-capture-io/CMakeLists.txt
@@ -28,6 +28,9 @@ endif()
 find_package(nlohmann_json REQUIRED)
 
 target_link_libraries(arg_capture_io PRIVATE nlohmann_json::nlohmann_json)
+target_compile_options(arg_capture_io PRIVATE
+    -Wall -Wextra -Wpedantic -Werror -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-private-field -Wno-switch -Wno-deprecated-declarations
+)
 
 set_target_properties(arg_capture_io PROPERTIES
     VERSION ${PROJECT_VERSION}

--- a/arg-capture-io/include/arg_capture_io.h
+++ b/arg-capture-io/include/arg_capture_io.h
@@ -42,8 +42,8 @@ struct ArgCapture {
     ) :
         arg_idx(idx),
         after(after),
-        primitive_type(primitive_type),
-        dims(dims)
+        dims(dims),
+        primitive_type(primitive_type)
     {}
 
     ArgCapture(const ArgCapture& other)


### PR DESCRIPTION
…onsumers.

Fixed the one error sdfglib-auto had with the header