### PR TITLE
Skip transformation if not applicable

### DIFF
--- a/include/sdfg/transformations/recorder.h
+++ b/include/sdfg/transformations/recorder.h
@@ -23,10 +23,13 @@ class Recorder {
     template <typename T, typename... Args>
         requires transformation_concept<T>
     void apply(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager,
-               Args&&... args) {
+               bool skip_if_not_applicable, Args&&... args) {
         T transformation(std::forward<Args>(args)...);
 
         if (!transformation.can_be_applied(builder, analysis_manager)) {
+            if (!skip_if_not_applicable) {
+                throw std::runtime_error("Cannot apply transformation: " + transformation.name());
+            }
             return;
         }
 

--- a/include/sdfg/transformations/recorder.h
+++ b/include/sdfg/transformations/recorder.h
@@ -28,7 +28,8 @@ class Recorder {
 
         if (!transformation.can_be_applied(builder, analysis_manager)) {
             if (!skip_if_not_applicable) {
-                throw std::runtime_error("Cannot apply transformation: " + transformation.name());
+                throw transformations::InvalidTransformationException(
+                    "Transformation " + transformation.name() + " cannot be applied.");
             }
             return;
         }
@@ -42,15 +43,19 @@ class Recorder {
     };
 
     void replay(builder::StructuredSDFGBuilder& builder,
-                analysis::AnalysisManager& analysis_manager, const nlohmann::json& desc);
+                analysis::AnalysisManager& analysis_manager, const nlohmann::json& desc,
+                bool skip_if_not_applicable = true);
 
     template <typename T>
         requires transformation_concept<T>
     void apply(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager,
-               const nlohmann::json& desc) {
+               const nlohmann::json& desc, bool skip_if_not_applicable = true) {
         T transformation(T::from_json(builder, desc));
         if (!transformation.can_be_applied(builder, analysis_manager)) {
-            std::cout << "Cannot apply transformation: " << transformation.name() << std::endl;
+            if (!skip_if_not_applicable) {
+                throw transformations::InvalidTransformationException(
+                    "Transformation " + transformation.name() + " cannot be applied.");
+            }
             return;
         }
         transformation.apply(builder, analysis_manager);

--- a/include/sdfg/transformations/recorder.h
+++ b/include/sdfg/transformations/recorder.h
@@ -27,8 +27,7 @@ class Recorder {
         T transformation(std::forward<Args>(args)...);
 
         if (!transformation.can_be_applied(builder, analysis_manager)) {
-            throw transformations::InvalidTransformationException(
-                "Transformation " + transformation.name() + " cannot be applied.");
+            return;
         }
 
         nlohmann::json desc;
@@ -46,12 +45,12 @@ class Recorder {
         requires transformation_concept<T>
     void apply(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager,
                const nlohmann::json& desc) {
-        auto transformation = std::make_unique<T>(T::from_json(builder, desc));
-        if (!transformation->can_be_applied(builder, analysis_manager)) {
-            throw transformations::InvalidTransformationException(
-                "Transformation " + transformation->name() + " cannot be applied.");
+        T transformation(T::from_json(builder, desc));
+        if (!transformation.can_be_applied(builder, analysis_manager)) {
+            std::cout << "Cannot apply transformation: " << transformation.name() << std::endl;
+            return;
         }
-        transformation->apply(builder, analysis_manager);
+        transformation.apply(builder, analysis_manager);
     };
 
     void save(std::filesystem::path path) const;

--- a/src/transformations/recorder.cpp
+++ b/src/transformations/recorder.cpp
@@ -12,20 +12,25 @@ Recorder::Recorder() : history_(nlohmann::json::array()) {}
 
 void Recorder::replay(builder::StructuredSDFGBuilder& builder,
                       analysis::AnalysisManager& analysis_manager,
-                      const nlohmann::json& transformation_data) {
+                      const nlohmann::json& transformation_data, bool skip_if_not_applicable) {
     for (const auto& desc : transformation_data) {
         auto transformation_name = desc["transformation_type"];
 
         if (transformation_name == "LoopTiling") {
-            this->apply<transformations::LoopTiling>(builder, analysis_manager, desc);
+            this->apply<transformations::LoopTiling>(builder, analysis_manager, desc,
+                                                     skip_if_not_applicable);
         } else if (transformation_name == "LoopDistribute") {
-            this->apply<transformations::LoopDistribute>(builder, analysis_manager, desc);
+            this->apply<transformations::LoopDistribute>(builder, analysis_manager, desc,
+                                                         skip_if_not_applicable);
         } else if (transformation_name == "LoopInterchange") {
-            this->apply<transformations::LoopInterchange>(builder, analysis_manager, desc);
+            this->apply<transformations::LoopInterchange>(builder, analysis_manager, desc,
+                                                          skip_if_not_applicable);
         } else if (transformation_name == "LoopSlicing") {
-            this->apply<transformations::LoopSlicing>(builder, analysis_manager, desc);
+            this->apply<transformations::LoopSlicing>(builder, analysis_manager, desc,
+                                                      skip_if_not_applicable);
         } else if (transformation_name == "OutLocalStorage") {
-            this->apply<transformations::OutLocalStorage>(builder, analysis_manager, desc);
+            this->apply<transformations::OutLocalStorage>(builder, analysis_manager, desc,
+                                                          skip_if_not_applicable);
         } else {
             throw transformations::InvalidTransformationDescriptionException(
                 "Unknown transformation: " + transformation_name.get<std::string>());

--- a/tests/transformations/recorder_test.cpp
+++ b/tests/transformations/recorder_test.cpp
@@ -67,15 +67,15 @@ TEST_F(RecorderLoopTilingTest, Apply_LoopTiling) {
 
     EXPECT_TRUE(loop_ != nullptr);
     EXPECT_TRUE(analysis_manager_ != nullptr);
-    EXPECT_NO_THROW(
-        recorder.apply<transformations::LoopTiling>(*builder_, *analysis_manager_, *loop_, 32));
+    EXPECT_NO_THROW(recorder.apply<transformations::LoopTiling>(*builder_, *analysis_manager_, true,
+                                                                *loop_, 32));
 }
 
 TEST_F(RecorderLoopTilingTest, Apply_InvalidTransformation) {
     transformations::Recorder recorder;
 
     EXPECT_THROW(
-        recorder.apply<transformations::LoopTiling>(*builder_, *analysis_manager_, *loop_, 0),
+        recorder.apply<transformations::LoopTiling>(*builder_, *analysis_manager_, true, *loop_, 0),
         transformations::InvalidTransformationException);
 }
 
@@ -84,8 +84,8 @@ TEST_F(RecorderLoopTilingTest, Save_SingleTransformation) {
 
     size_t loop_id = loop_->element_id();
 
-    EXPECT_NO_THROW(
-        recorder.apply<transformations::LoopTiling>(*builder_, *analysis_manager_, *loop_, 32));
+    EXPECT_NO_THROW(recorder.apply<transformations::LoopTiling>(*builder_, *analysis_manager_, true,
+                                                                *loop_, 32));
 
     // Use temporary file to save the transformation
     std::filesystem::path tmp_file =
@@ -164,7 +164,7 @@ TEST_F(RecorderLoopSlicingTest, Apply_LoopSlicing) {
     transformations::Recorder recorder;
 
     EXPECT_NO_THROW(
-        recorder.apply<transformations::LoopSlicing>(*builder_, *analysis_manager_, *loop_));
+        recorder.apply<transformations::LoopSlicing>(*builder_, *analysis_manager_, true, *loop_));
 }
 
 TEST_F(RecorderLoopSlicingTest, Save_SingleTransformation) {
@@ -173,7 +173,7 @@ TEST_F(RecorderLoopSlicingTest, Save_SingleTransformation) {
     size_t loop_id = loop_->element_id();
 
     EXPECT_NO_THROW(
-        recorder.apply<transformations::LoopSlicing>(*builder_, *analysis_manager_, *loop_));
+        recorder.apply<transformations::LoopSlicing>(*builder_, *analysis_manager_, true, *loop_));
 
     // Use temporary file to save the transformation
     std::filesystem::path tmp_file =
@@ -292,7 +292,7 @@ TEST_F(RecorderMultiTransformationTest, Apply_LoopInterchange) {
     EXPECT_TRUE((loop_1_ != nullptr && loop_2_ != nullptr));
 
     EXPECT_NO_THROW(recorder.apply<transformations::LoopInterchange>(*builder_, *analysis_manager_,
-                                                                     *loop_1_, *loop_2_));
+                                                                     true, *loop_1_, *loop_2_));
 }
 
 TEST_F(RecorderMultiTransformationTest, Apply_Transformations) {
@@ -315,7 +315,7 @@ TEST_F(RecorderMultiTransformationTest, Apply_Transformations) {
         }
     }
     EXPECT_TRUE(loop_1_ != nullptr);
-    recorder.apply<transformations::LoopTiling>(*builder_, *analysis_manager_, *loop_1_, 32);
+    recorder.apply<transformations::LoopTiling>(*builder_, *analysis_manager_, true, *loop_1_, 32);
 
     analysis_manager_->invalidate_all();
 
@@ -329,7 +329,7 @@ TEST_F(RecorderMultiTransformationTest, Apply_Transformations) {
     }
 
     EXPECT_TRUE(loop_2_ != nullptr);
-    recorder.apply<transformations::LoopTiling>(*builder_, *analysis_manager_, *loop_2_, 16);
+    recorder.apply<transformations::LoopTiling>(*builder_, *analysis_manager_, true, *loop_2_, 16);
 
     analysis_manager_->invalidate_all();
 
@@ -353,8 +353,8 @@ TEST_F(RecorderMultiTransformationTest, Apply_Transformations) {
     EXPECT_TRUE(loop_i_tile_id != 0);
     EXPECT_TRUE(loop_j_outer_id != 0);
 
-    EXPECT_NO_THROW(recorder.apply<transformations::LoopInterchange>(*builder_, *analysis_manager_,
-                                                                     *loop_i_tile, *loop_j_outer));
+    EXPECT_NO_THROW(recorder.apply<transformations::LoopInterchange>(
+        *builder_, *analysis_manager_, true, *loop_i_tile, *loop_j_outer));
 
     /**** Save ****/
 

--- a/tests/transformations/recorder_test.cpp
+++ b/tests/transformations/recorder_test.cpp
@@ -74,9 +74,9 @@ TEST_F(RecorderLoopTilingTest, Apply_LoopTiling) {
 TEST_F(RecorderLoopTilingTest, Apply_InvalidTransformation) {
     transformations::Recorder recorder;
 
-    EXPECT_THROW(
-        recorder.apply<transformations::LoopTiling>(*builder_, *analysis_manager_, true, *loop_, 0),
-        transformations::InvalidTransformationException);
+    EXPECT_THROW(recorder.apply<transformations::LoopTiling>(*builder_, *analysis_manager_, false,
+                                                             *loop_, 0),
+                 transformations::InvalidTransformationException);
 }
 
 TEST_F(RecorderLoopTilingTest, Save_SingleTransformation) {
@@ -397,4 +397,14 @@ TEST_F(RecorderMultiTransformationTest, Replay_Transformations) {
                  {"transformation_type", "LoopInterchange"}});
 
     EXPECT_NO_THROW(recorder.replay(*builder_, *analysis_manager_, j));
+}
+
+TEST_F(RecorderMultiTransformationTest, Replay_InvalidTransformation) {
+    nlohmann::json j = nlohmann::json::array();
+    j.push_back({{"loop_element_id", 1}, {"tile_size", 0}, {"transformation_type", "LoopTiling"}});
+
+    transformations::Recorder recorder;
+
+    EXPECT_THROW(recorder.replay(*builder_, *analysis_manager_, j, false),
+                 transformations::InvalidTransformationException);
 }


### PR DESCRIPTION
Simply skips a transformation applied through the recorder if not applicable. Simplifies the setup of search spaces in the autotuner.

Also puts transformations on the stack.