### PR TITLE
limits block fusion to purely computational dataflow

### DIFF
--- a/src/data_flow/access_node.cpp
+++ b/src/data_flow/access_node.cpp
@@ -1,5 +1,6 @@
 #include "sdfg/data_flow/access_node.h"
 
+#include "sdfg/data_flow/data_flow_graph.h"
 #include "sdfg/function.h"
 
 namespace sdfg {
@@ -16,7 +17,27 @@ AccessNode::AccessNode(
 
       };
 
-void AccessNode::validate(const Function& function) const {}
+void AccessNode::validate(const Function& function) const {
+    auto& graph = this->get_parent();
+
+    if (graph.out_degree(*this) > 1) {
+        MemletType type = (*graph.out_edges(*this).begin()).type();
+        for (auto& oedge : graph.out_edges(*this)) {
+            if (oedge.type() != type) {
+                throw InvalidSDFGException("Access node " + this->data() + " used with multiple memlet types");
+            }
+        }
+    }
+
+    if (graph.in_degree(*this) > 1) {
+        MemletType type = (*graph.in_edges(*this).begin()).type();
+        for (auto& iedge : graph.in_edges(*this)) {
+            if (iedge.type() != type) {
+                throw InvalidSDFGException("Access node " + this->data() + " used with multiple memlet types");
+            }
+        }
+    }
+}
 
 const std::string& AccessNode::data() const { return this->data_; };
 

--- a/src/passes/structured_control_flow/block_fusion.cpp
+++ b/src/passes/structured_control_flow/block_fusion.cpp
@@ -40,6 +40,18 @@ bool BlockFusion::can_be_applied(
         return false;
     }
 
+    // Criterion: Keep references and dereference in separate blocks
+    for (auto& edge : first_graph.edges()) {
+        if (edge.type() != data_flow::MemletType::Computational) {
+            return false;
+        }
+    }
+    for (auto& edge : second_graph.edges()) {
+        if (edge.type() != data_flow::MemletType::Computational) {
+            return false;
+        }
+    }
+
     // Numerical stability: Unique order of nodes
     auto pdoms = first_graph.post_dominators();
     std::unordered_map<std::string, const data_flow::AccessNode*> connectors;


### PR DESCRIPTION
Limits block fusion to computational blocks. When we use access nodes with multiple edge types, the user analysis fails and only returns one use but not the mixed use. I don't see a big advantage of more blocks