### PR TITLE
Extends arg-capturing to opaque pointers (on the first level)

### DIFF
--- a/include/sdfg/codegen/code_generator.h
+++ b/include/sdfg/codegen/code_generator.h
@@ -53,7 +53,10 @@ protected:
         int dim_idx,
         const types::IType& type,
         int arg_idx,
-        const analysis::MemAccessRange* range
+        const analysis::MemAccessRange* range,
+        analysis::AnalysisManager& analysis_manager,
+        const StructuredSDFG& sdfg,
+        std::string var_name
     );
 
     bool add_capture_plan(

--- a/src/analysis/mem_access_range_analysis.cpp
+++ b/src/analysis/mem_access_range_analysis.cpp
@@ -125,7 +125,6 @@ const std::vector<std::pair<symbolic::Expression, symbolic::Expression>>& MemAcc
 
 void MemAccessRangesBuilder::process_workItem(WorkItem* item) {
     const auto* varName = item->var_name;
-    const auto& type = sdfg_.type(*varName);
 
     const auto& reads = users_.reads(*varName);
     process_direct_users(item, false, reads);

--- a/src/codegen/code_generator.cpp
+++ b/src/codegen/code_generator.cpp
@@ -30,17 +30,12 @@ std::tuple<int, types::PrimitiveType> CodeGenerator::analyze_type_rec(
     }
 
     if (auto* scalarType = dynamic_cast<const types::Scalar*>(&type)) {
-        // std::cerr << "In '" << sdfg_.name() << "', arg" << argIdx << " dim" << dimIdx << ": scalar" << std::endl;
         return std::make_tuple(dimIdx, scalarType->primitive_type());
     } else if (auto structureType = dynamic_cast<const sdfg::types::Structure*>(&type)) {
-        // std::cerr << "In '" << sdfg_.name() << "', arg" << argIdx << " dim" << dimIdx << ": struct" << std::endl;
         return std::make_tuple(dimIdx, types::Void);
     } else if (auto* arrayType = dynamic_cast<const types::Array*>(&type)) {
         dims[dimIdx] = arrayType->num_elements();
         auto& inner = arrayType->element_type();
-
-        // std::cerr << "In '" << sdfg_.name() << "', arg" << argIdx << " dim" << dimIdx << ": " <<
-        // language_extension_.expression(dims[dimIdx]) << std::endl;
 
         return analyze_type_rec(dims, maxDim, dimIdx + 1, inner, argIdx, range, analysis_manager, sdfg, var_name);
     } else if (auto* ptrType = dynamic_cast<const types::Pointer*>(&type)) {

--- a/src/codegen/code_generator.cpp
+++ b/src/codegen/code_generator.cpp
@@ -7,6 +7,7 @@
 #include "sdfg/codegen/instrumentation/capture_var_plan.h"
 #include "sdfg/symbolic/symbolic.h"
 #include "sdfg/types/structure.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg {
 namespace codegen {
@@ -17,7 +18,10 @@ std::tuple<int, types::PrimitiveType> CodeGenerator::analyze_type_rec(
     int dimIdx,
     const types::IType& type,
     int argIdx,
-    const analysis::MemAccessRange* range
+    const analysis::MemAccessRange* range,
+    analysis::AnalysisManager& analysis_manager,
+    const StructuredSDFG& sdfg,
+    std::string var_name
 ) {
     if (dimIdx > maxDim) {
         std::cerr << "In '" << sdfg_.name() << "', arg" << argIdx << ": data nesting deeper than " << maxDim
@@ -38,17 +42,47 @@ std::tuple<int, types::PrimitiveType> CodeGenerator::analyze_type_rec(
         // std::cerr << "In '" << sdfg_.name() << "', arg" << argIdx << " dim" << dimIdx << ": " <<
         // language_extension_.expression(dims[dimIdx]) << std::endl;
 
-        return analyze_type_rec(dims, maxDim, dimIdx + 1, inner, argIdx, range);
+        return analyze_type_rec(dims, maxDim, dimIdx + 1, inner, argIdx, range, analysis_manager, sdfg, var_name);
     } else if (auto* ptrType = dynamic_cast<const types::Pointer*>(&type)) {
-        if (ptrType->has_pointee_type() && range && !range->is_undefined()) {
+        if (range && !range->is_undefined()) {
             const auto& dim = range->dims()[dimIdx];
 
             if (symbolic::eq(symbolic::zero(), dim.first)) {
                 dims[dimIdx] = symbolic::add(dim.second, symbolic::one());
+                const types::IType* inner = nullptr;
+                if (ptrType->has_pointee_type()) {
+                    inner = &(ptrType->pointee_type());
+                } else {
+                    if (dimIdx > 0) {
+                        std::cerr << "In '" << sdfg_.name() << "', arg" << argIdx << " dim" << dimIdx
+                                  << ": missing pointee type for dim > 0, cannot capture!" << std::endl;
+                        return std::make_tuple(-2, types::Void);
+                    } else {
+                        auto outer = types::infer_type_from_container(analysis_manager, sdfg, var_name);
+                        if (outer != nullptr) {
+                            if (auto* ptrType_new = dynamic_cast<const types::Pointer*>(outer)) {
+                                if (ptrType_new->has_pointee_type()) {
+                                    inner = &(ptrType_new->pointee_type());
+                                } else {
+                                    std::cerr << "In '" << sdfg_.name() << "', arg" << argIdx << " dim" << dimIdx
+                                              << ": missing pointee type, cannot capture!" << std::endl;
+                                    return std::make_tuple(-2, types::Void);
+                                }
+                            }
+                        } else {
+                            std::cerr << "In '" << sdfg_.name() << "', arg" << argIdx << " dim" << dimIdx
+                                      << ": could not infer type from container, cannot capture!" << std::endl;
+                            return std::make_tuple(-2, types::Void);
+                        }
+                    }
+                    if (inner == nullptr) {
+                        std::cerr << "In '" << sdfg_.name() << "', arg" << argIdx << " dim" << dimIdx
+                                  << ": could not infer type from container, cannot capture!" << std::endl;
+                        return std::make_tuple(-2, types::Void);
+                    }
+                }
 
-                auto& inner = ptrType->pointee_type();
-
-                return analyze_type_rec(dims, maxDim, dimIdx + 1, inner, argIdx, range);
+                return analyze_type_rec(dims, maxDim, dimIdx + 1, *inner, argIdx, range, analysis_manager, sdfg, var_name);
             } else {
                 std::cerr << "In '" << sdfg_.name() << "', arg" << argIdx << " dim" << dimIdx << ": has upper bound "
                           << dim.second->__str__() << ", but does not start at 0, cannot capture" << std::endl;
@@ -77,11 +111,14 @@ bool CodeGenerator::add_capture_plan(
 
     const auto* range = ranges.get(varName);
 
+    analysis::AnalysisManager analysis_manager(sdfg_);
+
     symbolic::Expression dims[3];
 
-    int dimCount;
+    int dimCount = 0;
     types::PrimitiveType innerPrim;
-    std::tie(dimCount, innerPrim) = analyze_type_rec(dims, 3, 0, type, argIdx, range);
+
+    std::tie(dimCount, innerPrim) = analyze_type_rec(dims, 3, 0, type, argIdx, range, analysis_manager, sdfg_, varName);
 
     bool isRead = range ? range->saw_read() : true;
     bool isWritten = range ? range->saw_write() : true;
@@ -126,6 +163,11 @@ std::unique_ptr<std::vector<CaptureVarPlan>> CodeGenerator::create_capture_plans
         ++argIdx;
 
         working &= add_capture_plan(argName, argIdx, true, *plan.get(), ranges);
+    }
+
+    if (!working) {
+        std::cerr << "In '" << name << "': could not create capture plan, returning empty plan" << std::endl;
+        return std::make_unique<std::vector<CaptureVarPlan>>();
     }
 
     return plan;


### PR DESCRIPTION
This is a hot fix to extend arg-capturing to opaque pointers (on the first level). This should be re-done in a clean way once there is an analysis for pointer type inference.

How it works:
- In case that a the argument type is pointer and it does not have a pointee-type, @Atrisan util function is called to infer the type. For that, the sdfg, analysis_manager and container name are necessary. As of right now, this only works if the opaque pointer in on the first nesting level.

How has this been tested:
- Arguments for matmul can be captured
-  Captured arguments can be consumed by the autotuner

Once there is an analysis, maybe we can remove all type inference functionality specific to arg-capturing and base everything on the new analysis.

Question is, if we want this hack in main in the meantime, if I should spend time on improving it now even though everything will change again next week, if we want it broken until we can fix it properly..