### PR TITLE
Bugfix: StructuredSDFGBuilder::parent did not handle Maps

### DIFF
--- a/include/sdfg/builder/structured_sdfg_builder.h
+++ b/include/sdfg/builder/structured_sdfg_builder.h
@@ -244,6 +244,7 @@ public:
 
     void clear_sequence(Sequence& parent);
 
+    [[deprecated("use ScopeAnalysis instead")]]
     Sequence& parent(const ControlFlowNode& node);
 
     /***** Section: Dataflow Graph *****/

--- a/src/builder/structured_sdfg_builder.cpp
+++ b/src/builder/structured_sdfg_builder.cpp
@@ -7,6 +7,7 @@
 #include "sdfg/data_flow/library_node.h"
 #include "sdfg/structured_control_flow/map.h"
 #include "sdfg/structured_control_flow/sequence.h"
+#include "sdfg/structured_control_flow/structured_loop.h"
 #include "sdfg/types/utils.h"
 
 using namespace sdfg::control_flow;
@@ -1073,8 +1074,8 @@ Sequence& StructuredSDFGBuilder::parent(const ControlFlowNode& node) {
             }
         } else if (auto while_stmt = dynamic_cast<structured_control_flow::While*>(current)) {
             queue.push_back(&while_stmt->root());
-        } else if (auto for_stmt = dynamic_cast<structured_control_flow::For*>(current)) {
-            queue.push_back(&for_stmt->root());
+        } else if (auto loop_stmt = dynamic_cast<structured_control_flow::StructuredLoop*>(current)) {
+            queue.push_back(&loop_stmt->root());
         }
     }
 


### PR DESCRIPTION
The `parent` method of the `StructuredSDFGBuilder` only handels `For` loops. When trying to get the parent of a child of a `Map`, the method returns the root node.
Fixed the code to handle `StructuredLoop`, implicitly handling `Map`.