### PR TITLE
Add constness

### DIFF
--- a/include/sdfg/analysis/users.h
+++ b/include/sdfg/analysis/users.h
@@ -83,8 +83,8 @@ class Users : public Analysis {
     graph::Graph graph_;
     std::unordered_map<graph::Vertex, std::unique_ptr<User>, boost::hash<graph::Vertex>> users_;
 
-    std::unordered_map<structured_control_flow::ControlFlowNode*, User*> entries_;
-    std::unordered_map<structured_control_flow::ControlFlowNode*, User*> exits_;
+    std::unordered_map<const structured_control_flow::ControlFlowNode*, User*> entries_;
+    std::unordered_map<const structured_control_flow::ControlFlowNode*, User*> exits_;
 
     std::unordered_map<std::string, std::unordered_map<Element*, std::unordered_map<Use, User*>>>
         users_by_sdfg_;
@@ -178,7 +178,7 @@ class UsersView {
     std::unordered_map<User*, User*> sub_pdom_tree_;
 
    public:
-    UsersView(Users& users, structured_control_flow::ControlFlowNode& node);
+    UsersView(Users& users, const structured_control_flow::ControlFlowNode& node);
 
     /**** Users ****/
 

--- a/include/sdfg/structured_control_flow/if_else.h
+++ b/include/sdfg/structured_control_flow/if_else.h
@@ -34,7 +34,7 @@ public:
 
     std::pair<Sequence&, symbolic::Condition&> at(size_t i);
 
-    bool is_complete();
+    bool is_complete() const;
 
     void replace(const symbolic::Expression& old_expression, const symbolic::Expression& new_expression) override;
 };

--- a/src/analysis/users.cpp
+++ b/src/analysis/users.cpp
@@ -773,7 +773,7 @@ const std::unordered_set<User*> Users::all_uses_after(User& user) {
     return uses;
 };
 
-UsersView::UsersView(Users& users, structured_control_flow::ControlFlowNode& node) : users_(users) {
+UsersView::UsersView(Users& users, const structured_control_flow::ControlFlowNode& node) : users_(users) {
     this->entry_ = users.entries_.at(&node);
     this->exit_ = users.exits_.at(&node);
 

--- a/src/structured_control_flow/if_else.cpp
+++ b/src/structured_control_flow/if_else.cpp
@@ -26,7 +26,7 @@ std::pair<Sequence&, symbolic::Condition&> IfElse::at(size_t i) {
     return {*this->cases_.at(i), this->conditions_.at(i)};
 };
 
-bool IfElse::is_complete() {
+bool IfElse::is_complete() const{
     auto condition = symbolic::__false__();
     for (auto& entry : this->conditions_) {
         condition = symbolic::Or(condition, entry);

--- a/src/structured_control_flow/if_else.cpp
+++ b/src/structured_control_flow/if_else.cpp
@@ -26,7 +26,7 @@ std::pair<Sequence&, symbolic::Condition&> IfElse::at(size_t i) {
     return {*this->cases_.at(i), this->conditions_.at(i)};
 };
 
-bool IfElse::is_complete() const{
+bool IfElse::is_complete() const {
     auto condition = symbolic::__false__();
     for (auto& entry : this->conditions_) {
         condition = symbolic::Or(condition, entry);


### PR DESCRIPTION
Adds constness to nodes handed to the analysis.

I need it to be able to hand in (const) outer loops to the feature extractor. And it makes sense anyways since the analysis should never alter any nodes.