### PR TITLE
Prevent crash in Visualizer when accessing subsets on opaque pointers…

### DIFF
--- a/include/sdfg/visualizer/visualizer.h
+++ b/include/sdfg/visualizer/visualizer.h
@@ -49,14 +49,6 @@ protected:
         symbolic::Expression const& update
     );
 
-    virtual void visualizeSubset(
-        Function const& function,
-        data_flow::Subset const& begin_sub,
-        data_flow::Subset const& end_sub,
-        types::IType const* type = nullptr,
-        int subIdx = 0
-    );
-
     std::string subsetRangeString(data_flow::Subset const& begin_subset, data_flow::Subset const& end_subset, int subIdx);
 
 public:
@@ -65,6 +57,14 @@ public:
     virtual void visualize() = 0;
 
     codegen::PrettyPrinter const& getStream() const { return this->stream_; }
+
+    virtual void visualizeSubset(
+        Function const& function,
+        data_flow::Subset const& begin_sub,
+        data_flow::Subset const& end_sub,
+        types::IType const* type = nullptr,
+        int subIdx = 0
+    );
 };
 
 } // namespace visualizer

--- a/src/visualizer/visualizer.cpp
+++ b/src/visualizer/visualizer.cpp
@@ -492,10 +492,19 @@ void Visualizer::visualizeSubset(
         this->visualizeSubset(function, begin_sub, end_sub, &element_type, subIdx + 1);
     } else if (auto pointer_type = dynamic_cast<const types::Pointer*>(type)) {
         this->stream_ << "[" << subsetRangeString(begin_sub, end_sub, subIdx) << "]";
-        types::IType const& pointee_type = pointer_type->pointee_type();
-        this->visualizeSubset(function, begin_sub, end_sub, &pointee_type, subIdx + 1);
+        const types::IType* pointee_type;
+        if (pointer_type->has_pointee_type()) {
+            pointee_type = &pointer_type->pointee_type();
+        } else {
+            auto z = symbolic::zero();
+            if (!symbolic::eq(begin_sub.at(subIdx), z) || !symbolic::eq(end_sub.at(subIdx), z)) {
+                this->stream_ << "#illgl";
+            }
+            pointee_type = nullptr;
+        }
+        this->visualizeSubset(function, begin_sub, end_sub, pointee_type, subIdx + 1);
     } else {
-        if (type != nullptr) {
+        if (type == nullptr) {
             this->stream_ << "(rogue)";
         }
         this->stream_ << "[" << subsetRangeString(begin_sub, end_sub, subIdx) << "]";

--- a/tests/visualizer/dot_visualizer_test.cpp
+++ b/tests/visualizer/dot_visualizer_test.cpp
@@ -893,3 +893,44 @@ TEST(DotVisualizerTest, test_handleTasklet) {
         EXPECT_EQ(dot.getStream().str(), exp.str());
     }
 }
+
+TEST(DotVisualizerTest, visualizeSubset_does_not_fail_on_incomplete_opaque_ptr) {
+    builder::StructuredSDFGBuilder builder("dummy", FunctionType_CPU);
+
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Array arr_of_float(base_desc, symbolic::symbol("M"));
+    types::Pointer ptr_of_arr_of_float(arr_of_float);
+
+    types::Pointer ptr_of_float(base_desc);
+
+    types::Pointer opaque_desc;
+
+    {
+        visualizer::DotVisualizer dot(sdfg);
+
+        dot.visualizeSubset(sdfg, {symbolic::zero()}, {symbolic::zero()}, &opaque_desc);
+
+        EXPECT_EQ(dot.getStream().str(), "[0]");
+    }
+
+    {
+        visualizer::DotVisualizer dot(sdfg);
+
+        dot.visualizeSubset(sdfg, {symbolic::one()}, {symbolic::one()}, &opaque_desc);
+
+        EXPECT_EQ(dot.getStream().str(), "[1]#illgl");
+    }
+
+    {
+        visualizer::DotVisualizer dot(sdfg);
+
+        dot.visualizeSubset(sdfg, {symbolic::zero(), symbolic::one()}, {symbolic::zero(), symbolic::one()}, &opaque_desc);
+
+        EXPECT_EQ(dot.getStream().str(), "[0](rogue)[1]");
+    }
+}


### PR DESCRIPTION
…. More diagnostic output into .dot files on subset issues

 + Valid case: [0] is the address itself, which can work on an opaque ptr, even if our builder does not allow emitting this into a SDFG directly. Some pass of ours creates it. ! Happens for example multiple times in polybench ADI -docc-tune=cuda. Not easily testable as builder prevents us from generating such memlets directly
 + emitting subsets as postfix '#illgl' or prefix '(rogue)' if type does not match up with subset (more subset dims than nested types)
 + test case for this