### PR TITLE
Revert "Write loopnest index to instrumentation"

### DIFF
--- a/include/sdfg/codegen/instrumentation/instrumentation_plan.h
+++ b/include/sdfg/codegen/instrumentation/instrumentation_plan.h
@@ -15,15 +15,13 @@ class InstrumentationPlan {
 protected:
     StructuredSDFG& sdfg_;
     std::unordered_map<const structured_control_flow::ControlFlowNode*, InstrumentationEventType> nodes_;
-    std::unordered_map<const structured_control_flow::ControlFlowNode*, size_t> loopnest_indices_;
 
 public:
     InstrumentationPlan(
         StructuredSDFG& sdfg,
-        const std::unordered_map<const structured_control_flow::ControlFlowNode*, InstrumentationEventType>& nodes,
-        const std::unordered_map<const structured_control_flow::ControlFlowNode*, size_t>& loopnest_indices = {}
+        const std::unordered_map<const structured_control_flow::ControlFlowNode*, InstrumentationEventType>& nodes
     )
-        : sdfg_(sdfg), nodes_(nodes), loopnest_indices_(loopnest_indices) {}
+        : sdfg_(sdfg), nodes_(nodes) {}
 
     InstrumentationPlan(const InstrumentationPlan& other) = delete;
     InstrumentationPlan(InstrumentationPlan&& other) = delete;

--- a/rtl/include/daisy_rtl/daisy_rtl.h
+++ b/rtl/include/daisy_rtl/daisy_rtl.h
@@ -4,7 +4,6 @@
 #include <stddef.h>
 
 #ifdef __cplusplus
-#include <cstddef>
 extern "C" {
 #endif
 
@@ -21,7 +20,6 @@ typedef struct __daisy_metadata {
     long column_begin;
     long column_end;
     const char* region_name;
-    size_t loopnest_index;
 } __daisy_metadata_t;
 
 typedef struct __daisy_instrumentation __daisy_instrumentation_t;

--- a/rtl/src/instrumentation.cpp
+++ b/rtl/src/instrumentation.cpp
@@ -169,7 +169,6 @@ void write_event_json(
     // "args": {
     // "region_id": "__daisy_correlation18122842100848744318_0_0_1396",
     // "function": "main",
-    // "loopnest_index": 0,
     // "module": "correlation",
     // "build_id": "",
     // "source_ranges": [
@@ -192,7 +191,6 @@ void write_event_json(
     entry << "\"args\":{";
     entry << "\"region_id\":\"" << md->region_name << "\",";
     entry << "\"function\":\"" << md->function_name << "\",";
-    entry << "\"loopnest_index\":" << md->loopnest_index << ",";
     entry << "\"module\":\"" << std::filesystem::path(md->file_name).filename().string() << "\",";
     entry << "\"build_id\":\"\",";
     entry << "\"source_ranges\":[";

--- a/rtl/tests/rtl_tests.py
+++ b/rtl/tests/rtl_tests.py
@@ -73,7 +73,6 @@ def test_instrumentation(event):
         assert events[i]["args"]["source_ranges"][0]["to"]["line"] == 31
         assert events[i]["args"]["source_ranges"][0]["from"]["col"] == 4
         assert events[i]["args"]["source_ranges"][0]["to"]["col"] == 5
-        assert events[i]["args"]["loopnest_index"] == 0
         for event_name in event_names:
             assert event_name in events[i]["args"]["metrics"]
 
@@ -143,6 +142,5 @@ def test_instrumentation_cuda(event):
         assert events[i]["args"]["source_ranges"][0]["to"]["line"] == 31
         assert events[i]["args"]["source_ranges"][0]["from"]["col"] == 4
         assert events[i]["args"]["source_ranges"][0]["to"]["col"] == 5
-        assert events[i]["args"]["loopnest_index"] == 0
         for event_name in event_names:
             assert event_name in events[i]["args"]["metrics"]


### PR DESCRIPTION
Reverts daisytuner/sdfglib#213

Loop Nest Indices are an internal name used by the Autotuner. It should be limited to the internals of the Autotuner. The SDFG API is the element ID.