### PR TITLE
Fixes for Global State Handling of RTL Instrumentation

### DIFF
--- a/rtl/include/daisy_rtl/daisy_rtl.h
+++ b/rtl/include/daisy_rtl/daisy_rtl.h
@@ -24,22 +24,24 @@ typedef struct __daisy_metadata {
     size_t loopnest_index;
 } __daisy_metadata_t;
 
-typedef struct __daisy_instrumentation __daisy_instrumentation_t;
+// Registers a region and returns a region ID
+size_t __daisy_instrumentation_init(__daisy_metadata_t* metadata, enum __daisy_event_set event_set);
 
-__daisy_instrumentation_t* __daisy_instrumentation_init();
-void __daisy_instrumentation_finalize(__daisy_instrumentation_t* context);
-void __daisy_instrumentation_enter(
-    __daisy_instrumentation_t* context, __daisy_metadata_t* metadata, enum __daisy_event_set event_set
-);
-void __daisy_instrumentation_exit(
-    __daisy_instrumentation_t* context, __daisy_metadata_t* metadata, enum __daisy_event_set event_set
-);
+// Finalizes a region (may be a no-op or free resources for the region)
+void __daisy_instrumentation_finalize(size_t region_id);
+
+// Enter a region, resetting counters for the given event set
+void __daisy_instrumentation_enter(size_t region_id);
+
+// Exit a region, storing values for the given event set into the cache
+void __daisy_instrumentation_exit(size_t region_id);
 
 typedef struct __daisy_capture __daisy_capture_t;
 
 __daisy_capture_t* __daisy_capture_init(const char* name);
 
 bool __daisy_capture_enter(__daisy_capture_t* context);
+
 void __daisy_capture_end(__daisy_capture_t* context);
 
 void __daisy_capture_raw(

--- a/rtl/tests/applications/instrumentation_test.c
+++ b/rtl/tests/applications/instrumentation_test.c
@@ -3,8 +3,6 @@
 #include <daisy_rtl/daisy_rtl.h>
 
 void main(int argc, char** argv) {
-    __daisy_instrumentation_t* context = __daisy_instrumentation_init();
-
     __daisy_metadata_t metadata = {
         .file_name = "instrumentation_test.c",
         .function_name = "main",
@@ -14,9 +12,10 @@ void main(int argc, char** argv) {
         .column_end = 5,
         .region_name = "instrumentation_test_main",
     };
+    unsigned long long region_id = __daisy_instrumentation_init(&metadata, __DAISY_EVENT_SET_CPU);
 
     for (size_t rep = 0; rep < 10; rep++) {
-        __daisy_instrumentation_enter(context, &metadata, __DAISY_EVENT_SET_CPU);
+        __daisy_instrumentation_enter(region_id);
 
         double A[1000];
         double B[1000];
@@ -32,12 +31,12 @@ void main(int argc, char** argv) {
             C[i] = A[i] + B[i];
         }
 
-        __daisy_instrumentation_exit(context, &metadata, __DAISY_EVENT_SET_CPU);
+        __daisy_instrumentation_exit(region_id);
 
         for (int i = 0; i < 1000; i++) {
             printf("%f\n", C[i]);
         }
     }
 
-    __daisy_instrumentation_finalize(context);
+    __daisy_instrumentation_finalize(region_id);
 }

--- a/rtl/tests/rtl_tests.py
+++ b/rtl/tests/rtl_tests.py
@@ -63,6 +63,7 @@ def test_instrumentation(event):
 
     result = json.load(open(workdir / "data_cpu.json"))
     events = result["traceEvents"]
+    assert(len(events) > 0)
     for i in range(len(events)):
         assert events[i]["name"].startswith("main")
         assert events[i]["cat"] == "region,daisy"
@@ -133,6 +134,7 @@ def test_instrumentation_cuda(event):
 
     result = json.load(open(workdir / "data_cuda.json"))
     events = result["traceEvents"]
+    assert(len(events) > 0)
     for i in range(len(events)):
         assert events[i]["name"].startswith("main")
         assert events[i]["cat"] == "region,daisy"

--- a/src/codegen/code_generators/c_style_base_code_generator.cpp
+++ b/src/codegen/code_generators/c_style_base_code_generator.cpp
@@ -64,11 +64,6 @@ void CStyleBaseCodeGenerator::append_function_source(std::ofstream& ofs_source) 
     ofs_source << this->function_definition() << std::endl;
     ofs_source << "{" << std::endl;
 
-    if (!instrumentation_plan_.is_empty()) {
-        ofs_source << "__daisy_instrumentation_t* __daisy_instrumentation_ctx = __daisy_instrumentation_init();"
-                   << std::endl;
-    }
-
     if (capturePlan) {
         this->emit_arg_captures(ofs_source, *capturePlan, false);
     }
@@ -87,10 +82,6 @@ void CStyleBaseCodeGenerator::append_function_source(std::ofstream& ofs_source) 
 
     if (capturePlan) {
         this->emit_arg_captures(ofs_source, *capturePlan, true);
-    }
-
-    if (!instrumentation_plan_.is_empty()) {
-        ofs_source << "__daisy_instrumentation_finalize(__daisy_instrumentation_ctx);" << std::endl;
     }
 
     ofs_source << "}" << std::endl;


### PR DESCRIPTION
RTL had a bug/design problem, where multiple regions would call finalize, which we generate multiple closing strings for the JSON file. Furthermore, it was slow as the counters were dumped immediately to file. It is now refactored into a single global state which is destructed at the end of the lifetime making sure the file is not corrupted