### PR TITLE
Adds for each node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ set(SOURCE_FILES
     src/codegen/dispatchers/if_else_dispatcher.cpp
     src/codegen/dispatchers/sequence_dispatcher.cpp
     src/codegen/dispatchers/for_dispatcher.cpp
+    src/codegen/dispatchers/for_each_dispatcher.cpp
     src/codegen/dispatchers/map_dispatcher.cpp
     src/codegen/dispatchers/while_dispatcher.cpp
     src/control_flow/interstate_edge.cpp
@@ -155,6 +156,7 @@ set(SOURCE_FILES
     src/structured_control_flow/block.cpp
     src/structured_control_flow/control_flow_node.cpp
     src/structured_control_flow/for.cpp
+    src/structured_control_flow/for_each.cpp
     src/structured_control_flow/if_else.cpp
     src/structured_control_flow/map.cpp
     src/structured_control_flow/return.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,7 @@ set(SOURCE_FILES
     src/passes/structured_control_flow/loop_normalization.cpp
     src/passes/structured_control_flow/sequence_fusion.cpp
     src/passes/structured_control_flow/while_to_for_conversion.cpp
+    src/passes/structured_control_flow/while_to_for_each_conversion.cpp
     src/passes/debug_info_propagation.cpp
     src/serializer/json_serializer.cpp
     src/structured_control_flow/block.cpp

--- a/include/sdfg/analysis/data_dependency_analysis.h
+++ b/include/sdfg/analysis/data_dependency_analysis.h
@@ -79,6 +79,15 @@ public:
         std::unordered_map<User*, std::unordered_set<User*>>& closed_definitions
     );
 
+    void visit_for_each(
+        analysis::Users& users,
+        analysis::AssumptionsAnalysis& assumptions_analysis,
+        structured_control_flow::ForEach& for_each,
+        std::unordered_set<User*>& undefined,
+        std::unordered_map<User*, std::unordered_set<User*>>& open_definitions,
+        std::unordered_map<User*, std::unordered_set<User*>>& closed_definitions
+    );
+
     void visit_if_else(
         analysis::Users& users,
         analysis::AssumptionsAnalysis& assumptions_analysis,

--- a/include/sdfg/builder/structured_sdfg_builder.h
+++ b/include/sdfg/builder/structured_sdfg_builder.h
@@ -14,6 +14,7 @@
 #include "sdfg/structured_control_flow/return.h"
 #include "sdfg/structured_control_flow/sequence.h"
 #include "sdfg/structured_control_flow/while.h"
+#include "sdfg/structured_control_flow/for_each.h"
 #include "sdfg/structured_sdfg.h"
 #include "sdfg/types/scalar.h"
 
@@ -284,6 +285,32 @@ public:
         const symbolic::Expression init,
         const symbolic::Expression update,
         const ScheduleType& schedule_type,
+        const sdfg::control_flow::Assignments& assignments = {},
+        const DebugInfo& debug_info = DebugInfo()
+    );
+
+    ForEach& add_for_each(
+        Sequence& parent,
+        const symbolic::Symbol iterator,
+        const symbolic::Symbol end,
+        const sdfg::control_flow::Assignments& assignments = {},
+        const DebugInfo& debug_info = DebugInfo()
+    );
+
+    ForEach& add_for_each_after(
+        Sequence& parent,
+        ControlFlowNode& child,
+        const symbolic::Symbol iterator,
+        const symbolic::Symbol end,
+        const sdfg::control_flow::Assignments& assignments = {},
+        const DebugInfo& debug_info = DebugInfo()
+    );
+
+    ForEach& add_for_each_before(
+        Sequence& parent,
+        ControlFlowNode& child,
+        const symbolic::Symbol iterator,
+        const symbolic::Symbol end,
         const sdfg::control_flow::Assignments& assignments = {},
         const DebugInfo& debug_info = DebugInfo()
     );

--- a/include/sdfg/builder/structured_sdfg_builder.h
+++ b/include/sdfg/builder/structured_sdfg_builder.h
@@ -293,6 +293,8 @@ public:
         Sequence& parent,
         const symbolic::Symbol iterator,
         const symbolic::Symbol end,
+        const symbolic::Symbol update,
+        const symbolic::Symbol init = SymEngine::null,
         const sdfg::control_flow::Assignments& assignments = {},
         const DebugInfo& debug_info = DebugInfo()
     );
@@ -302,6 +304,8 @@ public:
         ControlFlowNode& child,
         const symbolic::Symbol iterator,
         const symbolic::Symbol end,
+        const symbolic::Symbol update,
+        const symbolic::Symbol init = SymEngine::null,
         const sdfg::control_flow::Assignments& assignments = {},
         const DebugInfo& debug_info = DebugInfo()
     );
@@ -311,6 +315,8 @@ public:
         ControlFlowNode& child,
         const symbolic::Symbol iterator,
         const symbolic::Symbol end,
+        const symbolic::Symbol update,
+        const symbolic::Symbol init = SymEngine::null,
         const sdfg::control_flow::Assignments& assignments = {},
         const DebugInfo& debug_info = DebugInfo()
     );

--- a/include/sdfg/codegen/dispatchers/for_each_dispatcher.h
+++ b/include/sdfg/codegen/dispatchers/for_each_dispatcher.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "sdfg/codegen/dispatchers/block_dispatcher.h"
+#include "sdfg/codegen/dispatchers/node_dispatcher_registry.h"
+#include "sdfg/codegen/dispatchers/sequence_dispatcher.h"
+
+namespace sdfg {
+namespace codegen {
+
+class ForEachDispatcher : public NodeDispatcher {
+private:
+    structured_control_flow::ForEach& node_;
+
+public:
+    ForEachDispatcher(
+        LanguageExtension& language_extension,
+        StructuredSDFG& sdfg,
+        structured_control_flow::ForEach& node,
+        InstrumentationPlan& instrumentation_plan
+    );
+
+    void dispatch_node(
+        PrettyPrinter& main_stream, PrettyPrinter& globals_stream, CodeSnippetFactory& library_snippet_factory
+    ) override;
+};
+
+} // namespace codegen
+} // namespace sdfg

--- a/include/sdfg/passes/structured_control_flow/while_to_for_each_conversion.h
+++ b/include/sdfg/passes/structured_control_flow/while_to_for_each_conversion.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "sdfg/passes/pass.h"
+
+namespace sdfg {
+namespace passes {
+
+class WhileToForEachConversion : public Pass {
+   private:
+    bool can_be_applied(builder::StructuredSDFGBuilder& builder,
+                        analysis::AnalysisManager& analysis_manager,
+                        structured_control_flow::While& loop);
+
+    void apply(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager,
+               structured_control_flow::Sequence& parent, structured_control_flow::While& loop);
+
+   public:
+    WhileToForEachConversion();
+
+    std::string name() override;
+
+    virtual bool run_pass(builder::StructuredSDFGBuilder& builder,
+                          analysis::AnalysisManager& analysis_manager) override;
+};
+
+}  // namespace passes
+}  // namespace sdfg

--- a/include/sdfg/serializer/json_serializer.h
+++ b/include/sdfg/serializer/json_serializer.h
@@ -8,6 +8,7 @@
 #include "sdfg/structured_control_flow/block.h"
 #include "sdfg/structured_control_flow/control_flow_node.h"
 #include "sdfg/structured_control_flow/map.h"
+#include "sdfg/structured_control_flow/for_each.h"
 #include "sdfg/structured_control_flow/sequence.h"
 #include "sdfg/structured_control_flow/while.h"
 #include "sdfg/structured_sdfg.h"
@@ -39,6 +40,7 @@ public:
     void continue_node_to_json(nlohmann::json& j, const sdfg::structured_control_flow::Continue& continue_node);
     void return_node_to_json(nlohmann::json& j, const sdfg::structured_control_flow::Return& return_node);
     void map_to_json(nlohmann::json& j, const sdfg::structured_control_flow::Map& map_node);
+    void for_each_to_json(nlohmann::json& j, const sdfg::structured_control_flow::ForEach& for_each_node);
 
     void debug_info_to_json(nlohmann::json& j, const sdfg::DebugInfo& debug_info);
 
@@ -99,6 +101,12 @@ public:
         control_flow::Assignments& assignments
     );
     void json_to_map_node(
+        const nlohmann::json& j,
+        sdfg::builder::StructuredSDFGBuilder& builder,
+        sdfg::structured_control_flow::Sequence& parent,
+        control_flow::Assignments& assignments
+    );
+    void json_to_for_each_node(
         const nlohmann::json& j,
         sdfg::builder::StructuredSDFGBuilder& builder,
         sdfg::structured_control_flow::Sequence& parent,

--- a/include/sdfg/structured_control_flow/for_each.h
+++ b/include/sdfg/structured_control_flow/for_each.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "sdfg/structured_control_flow/control_flow_node.h"
+#include "sdfg/structured_control_flow/sequence.h"
+#include "sdfg/symbolic/symbolic.h"
+
+namespace sdfg {
+
+namespace builder {
+class StructuredSDFGBuilder;
+}
+
+namespace structured_control_flow {
+
+class ForEach : public ControlFlowNode {
+    friend class sdfg::builder::StructuredSDFGBuilder;
+
+protected:
+    symbolic::Symbol iterator_;
+    symbolic::Symbol end_;
+
+    std::unique_ptr<Sequence> root_;
+
+    ForEach(
+        size_t element_id,
+        const DebugInfo& debug_info,
+        symbolic::Symbol iterator,
+        symbolic::Symbol end
+    );
+
+public:
+    virtual ~ForEach() = default;
+
+    ForEach(const ForEach& node) = delete;
+    ForEach& operator=(const ForEach&) = delete;
+
+    void validate(const Function& function) const override;
+
+    const symbolic::Symbol iterator() const;
+
+    const symbolic::Symbol end() const;
+
+    Sequence& root() const;
+
+    void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+
+};
+
+} // namespace structured_control_flow
+} // namespace sdfg

--- a/include/sdfg/structured_control_flow/for_each.h
+++ b/include/sdfg/structured_control_flow/for_each.h
@@ -18,6 +18,8 @@ class ForEach : public ControlFlowNode {
 protected:
     symbolic::Symbol iterator_;
     symbolic::Symbol end_;
+    symbolic::Symbol update_;
+    symbolic::Symbol init_;
 
     std::unique_ptr<Sequence> root_;
 
@@ -25,7 +27,9 @@ protected:
         size_t element_id,
         const DebugInfo& debug_info,
         symbolic::Symbol iterator,
-        symbolic::Symbol end
+        symbolic::Symbol end,
+        symbolic::Symbol update,
+        symbolic::Symbol init = SymEngine::null
     );
 
 public:
@@ -39,6 +43,12 @@ public:
     const symbolic::Symbol iterator() const;
 
     const symbolic::Symbol end() const;
+
+    const symbolic::Symbol update() const;
+
+    const symbolic::Symbol init() const;
+
+    bool has_init() const;
 
     Sequence& root() const;
 

--- a/include/sdfg/structured_control_flow/sequence.h
+++ b/include/sdfg/structured_control_flow/sequence.h
@@ -15,6 +15,7 @@ class StructuredSDFGBuilder;
 
 namespace structured_control_flow {
 
+class ForEach;
 class While;
 class StructuredLoop;
 class Sequence;
@@ -58,6 +59,7 @@ class Sequence : public ControlFlowNode {
 
     friend class sdfg::StructuredSDFG;
 
+    friend class sdfg::structured_control_flow::ForEach;
     friend class sdfg::structured_control_flow::While;
     friend class sdfg::structured_control_flow::StructuredLoop;
 

--- a/include/sdfg/structured_sdfg.h
+++ b/include/sdfg/structured_sdfg.h
@@ -14,6 +14,7 @@
 #include "sdfg/structured_control_flow/block.h"
 #include "sdfg/structured_control_flow/control_flow_node.h"
 #include "sdfg/structured_control_flow/for.h"
+#include "sdfg/structured_control_flow/for_each.h"
 #include "sdfg/structured_control_flow/if_else.h"
 #include "sdfg/structured_control_flow/map.h"
 #include "sdfg/structured_control_flow/return.h"

--- a/include/sdfg/visitor/structured_sdfg_visitor.h
+++ b/include/sdfg/visitor/structured_sdfg_visitor.h
@@ -31,6 +31,8 @@ public:
 
     virtual bool accept(structured_control_flow::For& node);
 
+    virtual bool accept(structured_control_flow::ForEach& node);
+
     virtual bool accept(structured_control_flow::While& node);
 
     virtual bool accept(structured_control_flow::Continue& node);

--- a/src/analysis/data_dependency_analysis.cpp
+++ b/src/analysis/data_dependency_analysis.cpp
@@ -423,7 +423,7 @@ void DataDependencyAnalysis::visit_for_each(
     }
 
     // Condition - Read
-    if (!symbolic::eq(for_each.end(), symbolic::__nullptr__())){
+    if (!symbolic::eq(for_each.end(), symbolic::__nullptr__())) {
         auto end = for_each.end();
         auto current_user = users.get_user(end->get_name(), &for_each, Use::READ);
 
@@ -445,7 +445,12 @@ void DataDependencyAnalysis::visit_for_each(
 
     // Add assumptions for body
     visit_sequence(
-        users, assumptions_analysis, for_each.root(), undefined_for_each, open_definitions_for_each, closed_definitions_for_each
+        users,
+        assumptions_analysis,
+        for_each.root(),
+        undefined_for_each,
+        open_definitions_for_each,
+        closed_definitions_for_each
     );
 
     // Update - Read
@@ -497,7 +502,6 @@ void DataDependencyAnalysis::visit_for_each(
     for (auto& entry : open_definitions_for_each) {
         open_definitions.insert(entry);
     }
-
 }
 
 void DataDependencyAnalysis::visit_if_else(

--- a/src/analysis/loop_analysis.cpp
+++ b/src/analysis/loop_analysis.cpp
@@ -26,6 +26,9 @@ void LoopAnalysis::
         } else if (auto loop_stmt = dynamic_cast<structured_control_flow::StructuredLoop*>(current)) {
             this->loops_.push_back(loop_stmt);
             this->loop_tree_[loop_stmt] = parent_loop;
+        } else if (auto for_each_stmt = dynamic_cast<structured_control_flow::ForEach*>(current)) {
+            this->loops_.push_back(for_each_stmt);
+            this->loop_tree_[for_each_stmt] = parent_loop;
         }
 
         if (dynamic_cast<structured_control_flow::Block*>(current)) {
@@ -42,6 +45,8 @@ void LoopAnalysis::
             this->run(while_stmt->root(), while_stmt);
         } else if (auto for_stmt = dynamic_cast<structured_control_flow::StructuredLoop*>(current)) {
             this->run(for_stmt->root(), for_stmt);
+        } else if (auto for_each_stmt = dynamic_cast<structured_control_flow::ForEach*>(current)) {
+            this->run(for_each_stmt->root(), for_each_stmt);
         } else if (dynamic_cast<structured_control_flow::Break*>(current)) {
             continue;
         } else if (dynamic_cast<structured_control_flow::Continue*>(current)) {
@@ -66,6 +71,10 @@ structured_control_flow::ControlFlowNode* LoopAnalysis::find_loop_by_indvar(cons
     for (auto& loop : this->loops_) {
         if (auto loop_stmt = dynamic_cast<structured_control_flow::StructuredLoop*>(loop)) {
             if (loop_stmt->indvar()->get_name() == indvar) {
+                return loop;
+            }
+        } else if (auto for_each_stmt = dynamic_cast<structured_control_flow::ForEach*>(loop)) {
+            if (for_each_stmt->iterator()->get_name() == indvar) {
                 return loop;
             }
         }

--- a/src/analysis/scope_analysis.cpp
+++ b/src/analysis/scope_analysis.cpp
@@ -25,6 +25,9 @@ void ScopeAnalysis::
     } else if (auto for_stmt = dynamic_cast<structured_control_flow::StructuredLoop*>(current)) {
         this->scope_tree_[current] = parent_scope;
         this->run(&for_stmt->root(), current);
+    } else if (auto for_each_stmt = dynamic_cast<structured_control_flow::ForEach*>(current)) {
+        this->scope_tree_[current] = parent_scope;
+        this->run(&for_each_stmt->root(), current);
     } else if (dynamic_cast<structured_control_flow::Break*>(current)) {
         this->scope_tree_[current] = parent_scope;
     } else if (dynamic_cast<structured_control_flow::Continue*>(current)) {

--- a/src/analysis/users.cpp
+++ b/src/analysis/users.cpp
@@ -479,14 +479,16 @@ std::pair<graph::Vertex, graph::Vertex> Users::traverse(structured_control_flow:
             last = v_init;
 
             auto v_iter = boost::add_vertex(this->graph_);
-            this->add_user(std::make_unique<User>(v_iter, for_each_stmt->iterator()->get_name(), for_each_stmt, Use::MOVE));
+            this->add_user(std::make_unique<User>(v_iter, for_each_stmt->iterator()->get_name(), for_each_stmt, Use::MOVE)
+            );
             boost::add_edge(last, v_iter, this->graph_);
             last = v_iter;
         }
 
         // Condition
         auto v_cond_iterator = boost::add_vertex(this->graph_);
-        this->add_user(std::make_unique<User>(v_cond_iterator, for_each_stmt->iterator()->get_name(), for_each_stmt, Use::READ));
+        this->add_user(std::make_unique<
+                       User>(v_cond_iterator, for_each_stmt->iterator()->get_name(), for_each_stmt, Use::READ));
         boost::add_edge(last, v_cond_iterator, this->graph_);
         last = v_cond_iterator;
 
@@ -515,7 +517,8 @@ std::pair<graph::Vertex, graph::Vertex> Users::traverse(structured_control_flow:
         last = v_update;
 
         auto v_update_iter = boost::add_vertex(this->graph_);
-        this->add_user(std::make_unique<User>(v_update_iter, for_each_stmt->iterator()->get_name(), for_each_stmt, Use::MOVE));
+        this->add_user(std::make_unique<
+                       User>(v_update_iter, for_each_stmt->iterator()->get_name(), for_each_stmt, Use::MOVE));
         boost::add_edge(last, v_update_iter, this->graph_);
         last = v_update_iter;
 

--- a/src/builder/structured_sdfg_builder.cpp
+++ b/src/builder/structured_sdfg_builder.cpp
@@ -1053,6 +1053,85 @@ Map& StructuredSDFGBuilder::add_map_after(
     return static_cast<Map&>(*parent.children_.at(index + 1).get());
 };
 
+ForEach& StructuredSDFGBuilder::add_for_each(
+    Sequence& parent,
+    const symbolic::Symbol iterator,
+    const symbolic::Symbol end,
+    const sdfg::control_flow::Assignments& assignments,
+    const DebugInfo& debug_info
+) {
+    parent.children_
+        .push_back(std::unique_ptr<
+                   ForEach>(new ForEach(this->new_element_id(), debug_info, iterator, end)));
+
+    // Increment element id for body node
+    this->new_element_id();
+
+    parent.transitions_
+        .push_back(std::unique_ptr<Transition>(new Transition(this->new_element_id(), debug_info, parent, assignments))
+        );
+
+    return static_cast<ForEach&>(*parent.children_.back().get());
+};
+
+ForEach& StructuredSDFGBuilder::add_for_each_before(
+    Sequence& parent,
+    ControlFlowNode& child,
+    const symbolic::Symbol iterator,
+    const symbolic::Symbol end,
+    const sdfg::control_flow::Assignments& assignments,
+    const DebugInfo& debug_info
+) {
+    int index = parent.index(child);
+    if (index == -1) {
+        throw InvalidSDFGException("StructuredSDFGBuilder: Child not found");
+    }
+
+    parent.children_.insert(
+        parent.children_.begin() + index,
+        std::unique_ptr<ForEach>(new ForEach(this->new_element_id(), debug_info, iterator, end))
+    );
+
+    // Increment element id for body node
+    this->new_element_id();
+
+    parent.transitions_.insert(
+        parent.transitions_.begin() + index,
+        std::unique_ptr<Transition>(new Transition(this->new_element_id(), debug_info, parent, assignments))
+    );
+
+    return static_cast<ForEach&>(*parent.children_.at(index).get());
+};
+
+ForEach& StructuredSDFGBuilder::add_for_each_after(
+    Sequence& parent,
+    ControlFlowNode& child,
+    const symbolic::Symbol iterator,
+    const symbolic::Symbol end,
+    const sdfg::control_flow::Assignments& assignments,
+    const DebugInfo& debug_info
+) {
+    int index = parent.index(child);
+    if (index == -1) {
+        throw InvalidSDFGException("StructuredSDFGBuilder: Child not found");
+    }
+
+    parent.children_.insert(
+        parent.children_.begin() + index + 1,
+        std::unique_ptr<ForEach>(new ForEach(this->new_element_id(), debug_info, iterator, end))
+    );
+
+    // Increment element id for body node
+    this->new_element_id();
+
+    parent.transitions_.insert(
+        parent.transitions_.begin() + index + 1,
+        std::unique_ptr<Transition>(new Transition(this->new_element_id(), debug_info, parent, assignments))
+    );
+
+    return static_cast<ForEach&>(*parent.children_.at(index + 1).get());
+};
+
 Continue& StructuredSDFGBuilder::
     add_continue(Sequence& parent, const sdfg::control_flow::Assignments& assignments, const DebugInfo& debug_info) {
     // Check if continue is in a loop

--- a/src/builder/structured_sdfg_builder.cpp
+++ b/src/builder/structured_sdfg_builder.cpp
@@ -1057,12 +1057,14 @@ ForEach& StructuredSDFGBuilder::add_for_each(
     Sequence& parent,
     const symbolic::Symbol iterator,
     const symbolic::Symbol end,
+    const symbolic::Symbol update,
+    const symbolic::Symbol init,
     const sdfg::control_flow::Assignments& assignments,
     const DebugInfo& debug_info
 ) {
     parent.children_
         .push_back(std::unique_ptr<
-                   ForEach>(new ForEach(this->new_element_id(), debug_info, iterator, end)));
+                   ForEach>(new ForEach(this->new_element_id(), debug_info, iterator, end, update, init)));
 
     // Increment element id for body node
     this->new_element_id();
@@ -1079,6 +1081,8 @@ ForEach& StructuredSDFGBuilder::add_for_each_before(
     ControlFlowNode& child,
     const symbolic::Symbol iterator,
     const symbolic::Symbol end,
+    const symbolic::Symbol update,
+    const symbolic::Symbol init,
     const sdfg::control_flow::Assignments& assignments,
     const DebugInfo& debug_info
 ) {
@@ -1089,7 +1093,7 @@ ForEach& StructuredSDFGBuilder::add_for_each_before(
 
     parent.children_.insert(
         parent.children_.begin() + index,
-        std::unique_ptr<ForEach>(new ForEach(this->new_element_id(), debug_info, iterator, end))
+        std::unique_ptr<ForEach>(new ForEach(this->new_element_id(), debug_info, iterator, end, update, init))
     );
 
     // Increment element id for body node
@@ -1108,6 +1112,8 @@ ForEach& StructuredSDFGBuilder::add_for_each_after(
     ControlFlowNode& child,
     const symbolic::Symbol iterator,
     const symbolic::Symbol end,
+    const symbolic::Symbol update,
+    const symbolic::Symbol init,
     const sdfg::control_flow::Assignments& assignments,
     const DebugInfo& debug_info
 ) {
@@ -1118,7 +1124,7 @@ ForEach& StructuredSDFGBuilder::add_for_each_after(
 
     parent.children_.insert(
         parent.children_.begin() + index + 1,
-        std::unique_ptr<ForEach>(new ForEach(this->new_element_id(), debug_info, iterator, end))
+        std::unique_ptr<ForEach>(new ForEach(this->new_element_id(), debug_info, iterator, end, update, init))
     );
 
     // Increment element id for body node

--- a/src/builder/structured_sdfg_builder.cpp
+++ b/src/builder/structured_sdfg_builder.cpp
@@ -1063,8 +1063,8 @@ ForEach& StructuredSDFGBuilder::add_for_each(
     const DebugInfo& debug_info
 ) {
     parent.children_
-        .push_back(std::unique_ptr<
-                   ForEach>(new ForEach(this->new_element_id(), debug_info, iterator, end, update, init)));
+        .push_back(std::unique_ptr<ForEach>(new ForEach(this->new_element_id(), debug_info, iterator, end, update, init)
+        ));
 
     // Increment element id for body node
     this->new_element_id();

--- a/src/codegen/dispatchers/for_each_dispatcher.cpp
+++ b/src/codegen/dispatchers/for_each_dispatcher.cpp
@@ -21,16 +21,14 @@ void ForEachDispatcher::dispatch_node(
 
     std::string iterator = language_extension_.expression(node_.iterator());
 
-    // Update
-    // Offset to 'next' element pointer
-    std::string iterator_offseted = iterator + " + 0";
-    // Reinterpret as pointer to pointer
-    std::string iterator_ptr = language_extension_.type_cast(iterator_offseted, ptr_ptr_type);
-    // Dereference to get next element
-    std::string update = "*(" + iterator_ptr + " + 1)";
-
     main_stream << "for";
     main_stream << "(";
+    if (node_.has_init()) {
+        main_stream << iterator;
+        main_stream << " = ";
+        main_stream << "*(" << language_extension_.type_cast(language_extension_.expression(node_.init()), ptr_ptr_type) << ")";
+        main_stream << "; ";
+    }
     main_stream << ";";
     main_stream << iterator;
     main_stream << " != ";
@@ -38,7 +36,7 @@ void ForEachDispatcher::dispatch_node(
     main_stream << ";";
     main_stream << iterator;
     main_stream << " = ";
-    main_stream << update;
+    main_stream << "*(" << language_extension_.type_cast(language_extension_.expression(node_.update()), ptr_ptr_type) << ")";
     main_stream << ")" << std::endl;
     main_stream << "{" << std::endl;
 

--- a/src/codegen/dispatchers/for_each_dispatcher.cpp
+++ b/src/codegen/dispatchers/for_each_dispatcher.cpp
@@ -27,7 +27,6 @@ void ForEachDispatcher::dispatch_node(
         main_stream << iterator;
         main_stream << " = ";
         main_stream << "*(" << language_extension_.type_cast(language_extension_.expression(node_.init()), ptr_ptr_type) << ")";
-        main_stream << "; ";
     }
     main_stream << ";";
     main_stream << iterator;

--- a/src/codegen/dispatchers/for_each_dispatcher.cpp
+++ b/src/codegen/dispatchers/for_each_dispatcher.cpp
@@ -1,0 +1,54 @@
+#include "sdfg/codegen/dispatchers/for_each_dispatcher.h"
+
+namespace sdfg {
+namespace codegen {
+
+ForEachDispatcher::ForEachDispatcher(
+    LanguageExtension& language_extension,
+    StructuredSDFG& sdfg,
+    structured_control_flow::ForEach& node,
+    InstrumentationPlan& instrumentation_plan
+)
+    : NodeDispatcher(language_extension, sdfg, node, instrumentation_plan), node_(node) {
+
+      };
+
+void ForEachDispatcher::dispatch_node(
+    PrettyPrinter& main_stream, PrettyPrinter& globals_stream, CodeSnippetFactory& library_snippet_factory
+) {
+    types::Pointer ptr_type;
+    types::Pointer ptr_ptr_type(static_cast<const types::IType&>(ptr_type));
+
+    std::string iterator = language_extension_.expression(node_.iterator());
+
+    // Update
+    // Offset to 'next' element pointer
+    std::string iterator_offseted = iterator + " + 0";
+    // Reinterpret as pointer to pointer
+    std::string iterator_ptr = language_extension_.type_cast(iterator_offseted, ptr_ptr_type);
+    // Dereference to get next element
+    std::string update = "*(" + iterator_ptr + " + 1)";
+
+    main_stream << "for";
+    main_stream << "(";
+    main_stream << ";";
+    main_stream << iterator;
+    main_stream << " != ";
+    main_stream << language_extension_.expression(node_.end());
+    main_stream << ";";
+    main_stream << iterator;
+    main_stream << " = ";
+    main_stream << update;
+    main_stream << ")" << std::endl;
+    main_stream << "{" << std::endl;
+
+    main_stream.setIndent(main_stream.indent() + 4);
+    SequenceDispatcher dispatcher(language_extension_, sdfg_, node_.root(), instrumentation_plan_);
+    dispatcher.dispatch(main_stream, globals_stream, library_snippet_factory);
+    main_stream.setIndent(main_stream.indent() - 4);
+
+    main_stream << "}" << std::endl;
+};
+
+} // namespace codegen
+} // namespace sdfg

--- a/src/codegen/dispatchers/node_dispatcher_registry.cpp
+++ b/src/codegen/dispatchers/node_dispatcher_registry.cpp
@@ -2,6 +2,7 @@
 
 #include "sdfg/codegen/dispatchers/block_dispatcher.h"
 #include "sdfg/codegen/dispatchers/for_dispatcher.h"
+#include "sdfg/codegen/dispatchers/for_each_dispatcher.h"
 #include "sdfg/codegen/dispatchers/if_else_dispatcher.h"
 #include "sdfg/codegen/dispatchers/map_dispatcher.h"
 #include "sdfg/codegen/dispatchers/sequence_dispatcher.h"
@@ -84,6 +85,17 @@ void register_default_dispatchers() {
            InstrumentationPlan& instrumentation) {
             return std::make_unique<ForDispatcher>(
                 language_extension, sdfg, static_cast<structured_control_flow::For&>(node), instrumentation
+            );
+        }
+    );
+    NodeDispatcherRegistry::instance().register_dispatcher(
+        typeid(structured_control_flow::ForEach),
+        [](LanguageExtension& language_extension,
+           StructuredSDFG& sdfg,
+           structured_control_flow::ControlFlowNode& node,
+           InstrumentationPlan& instrumentation) {
+            return std::make_unique<ForEachDispatcher>(
+                language_extension, sdfg, static_cast<structured_control_flow::ForEach&>(node), instrumentation
             );
         }
     );

--- a/src/passes/dataflow/byte_reference_elimination.cpp
+++ b/src/passes/dataflow/byte_reference_elimination.cpp
@@ -34,6 +34,9 @@ bool ByteReferenceElimination::
         }
         auto move = *moves.begin();
         auto move_node = dynamic_cast<data_flow::AccessNode*>(move->element());
+        if (!move_node) {
+            continue;
+        }
         auto& move_graph = move_node->get_parent();
         auto& move_edge = *move_graph.in_edges(*move_node).begin();
         auto& move_type = move_edge.base_type();

--- a/src/passes/dataflow/dead_reference_elimination.cpp
+++ b/src/passes/dataflow/dead_reference_elimination.cpp
@@ -41,6 +41,9 @@ bool DeadReferenceElimination::
 
         for (auto& move : moves) {
             auto access_node = dynamic_cast<data_flow::AccessNode*>(move->element());
+            if (!access_node) {
+                continue;
+            }
             auto& graph = dynamic_cast<data_flow::DataFlowGraph&>(access_node->get_parent());
             auto& block = dynamic_cast<structured_control_flow::Block&>(*graph.get_parent());
             builder.clear_node(block, *access_node);

--- a/src/passes/dataflow/reference_propagation.cpp
+++ b/src/passes/dataflow/reference_propagation.cpp
@@ -44,9 +44,12 @@ bool ReferencePropagation::run_pass(builder::StructuredSDFGBuilder& builder, ana
         // Eliminate views
         auto uses = users.uses(container);
         for (auto& move : moves) {
-            auto& access_node = static_cast<data_flow::AccessNode&>(*move->element());
+            auto access_node = dynamic_cast<data_flow::AccessNode*>(move->element());
+            if (!access_node) {
+                continue;
+            }
             auto& dataflow = *move->parent();
-            auto& move_edge = *dataflow.in_edges(access_node).begin();
+            auto& move_edge = *dataflow.in_edges(*access_node).begin();
 
             // Criterion: Must be a reference memlet
             if (move_edge.type() != data_flow::MemletType::Reference) {

--- a/src/passes/debug_info_propagation.cpp
+++ b/src/passes/debug_info_propagation.cpp
@@ -33,6 +33,9 @@ void DebugInfoPropagation::propagate(structured_control_flow::ControlFlowNode* c
     } else if (auto loop_stmt = dynamic_cast<structured_control_flow::StructuredLoop*>(current)) {
         this->propagate(&loop_stmt->root());
         current_debug_info = DebugInfo::merge(current_debug_info, loop_stmt->root().debug_info());
+    } else if (auto for_each_stmt = dynamic_cast<structured_control_flow::ForEach*>(current)) {
+        this->propagate(&for_each_stmt->root());
+        current_debug_info = DebugInfo::merge(current_debug_info, for_each_stmt->root().debug_info());
     } else if (auto break_stmt = dynamic_cast<structured_control_flow::Break*>(current)) {
         current_debug_info = DebugInfo::merge(current_debug_info, break_stmt->debug_info());
     } else if (auto continue_stmt = dynamic_cast<structured_control_flow::Continue*>(current)) {

--- a/src/passes/structured_control_flow/dead_cfg_elimination.cpp
+++ b/src/passes/structured_control_flow/dead_cfg_elimination.cpp
@@ -154,6 +154,9 @@ bool DeadCFGElimination::run_pass(builder::StructuredSDFGBuilder& builder, analy
         } else if (auto map_stmt = dynamic_cast<structured_control_flow::Map*>(curr)) {
             auto& root = map_stmt->root();
             queue.push_back(&root);
+        } else if (auto for_each_stmt = dynamic_cast<structured_control_flow::ForEach*>(curr)) {
+            auto& root = for_each_stmt->root();
+            queue.push_back(&root);
         }
     }
 

--- a/src/passes/structured_control_flow/sequence_fusion.cpp
+++ b/src/passes/structured_control_flow/sequence_fusion.cpp
@@ -50,6 +50,8 @@ bool SequenceFusion::run_pass(builder::StructuredSDFGBuilder& builder, analysis:
             queue.push_back(&loop_stmt->root());
         } else if (auto sloop_stmt = dynamic_cast<structured_control_flow::StructuredLoop*>(current)) {
             queue.push_back(&sloop_stmt->root());
+        } else if (auto for_each_stmt = dynamic_cast<structured_control_flow::ForEach*>(current)) {
+            queue.push_back(&for_each_stmt->root());
         }
     }
 

--- a/src/passes/structured_control_flow/while_to_for_each_conversion.cpp
+++ b/src/passes/structured_control_flow/while_to_for_each_conversion.cpp
@@ -1,12 +1,12 @@
-#include "sdfg/passes/structured_control_flow/while_to_for_conversion.h"
+#include "sdfg/passes/structured_control_flow/while_to_for_each_conversion.h"
 
 #include "sdfg/analysis/data_dependency_analysis.h"
-#include "sdfg/structured_control_flow/structured_loop.h"
+#include "sdfg/builder/structured_sdfg_builder.h"
 
 namespace sdfg {
 namespace passes {
 
-bool WhileToForConversion::can_be_applied(
+bool WhileToForEachConversion::can_be_applied(
     builder::StructuredSDFGBuilder& builder,
     analysis::AnalysisManager& analysis_manager,
     structured_control_flow::While& loop
@@ -62,60 +62,79 @@ bool WhileToForConversion::can_be_applied(
         return false;
     }
 
-    // Check symbolic expressions
-    if (!symbolic::is_true(symbolic::Eq(symbolic::Not(first_condition), second_condition))) {
+    if (symbolic::atoms(first_condition).size() != 2 || 
+        symbolic::atoms(second_condition).size() != 2) {
         return false;
     }
 
-    // Criterion: Exactly one moving iterator, which is written once
+    // Criterion: Continue condition is an equality between two symbols
+    auto sym1 = *symbolic::atoms(first_condition).begin();
+    auto sym2 = *(++symbolic::atoms(first_condition).begin());
+    auto cont_condition = symbolic::Ne(sym1, sym2);
+    auto cont_condition_alt = symbolic::Eq(symbolic::__false__(), symbolic::Eq(sym1, sym2));
+    if (first_is_continue && !(symbolic::eq(cont_condition, first_condition) || symbolic::eq(cont_condition_alt, first_condition))) {
+        return false;
+    }
+    if (second_is_continue && !(symbolic::eq(cont_condition, second_condition) || symbolic::eq(cont_condition_alt, second_condition))) {
+        return false;
+    }
+    if (!symbolic::eq(first_condition, symbolic::Not(second_condition))) {
+        return false;
+    }
+
+    // We know that the while body ends with an if-else continue-break structure
+    // We now check that there is exactly one iterator, which is moved once per
+    // iteration
+    // All other variables in the condition must be constants
+
     auto& all_users = analysis_manager.get<analysis::Users>();
     analysis::UsersView body_users(all_users, body);
-    analysis::User* update_write = nullptr;
-    for (auto& atom : symbolic::atoms(first_condition)) {
-        auto sym = SymEngine::rcp_static_cast<const SymEngine::Symbol>(atom);
-        if (symbolic::is_pointer(sym)) {
-            return false;
-        }
-        auto& type = sdfg.type(sym->get_name());
-        if (!dynamic_cast<const types::Scalar*>(&type)) {
-            return false;
-        }
 
-        auto writes = body_users.writes(sym->get_name());
-        if (writes.size() > 1) {
-            return false;
-        } else if (writes.size() == 1) {
-            if (update_write != nullptr) {
-                return false;
-            }
-            if (!dynamic_cast<structured_control_flow::Transition*>(writes.at(0)->element())) {
-                return false;
-            }
-            update_write = writes.at(0);
-        } else {
+    // Candidates: all symbols in the condition which are pointers
+    analysis::User* update = nullptr;
+    for (auto& sym : symbolic::atoms(first_condition)) {
+        if (symbolic::eq(sym, symbolic::__nullptr__())) {
             continue;
         }
-    }
-    if (update_write == nullptr) {
-        return false;
-    }
-    auto indvar = symbolic::symbol(update_write->container());
-    auto update_element = dynamic_cast<structured_control_flow::Transition*>(update_write->element());
-    ;
-    auto update = update_element->assignments().at(indvar);
-
-    std::unordered_set<std::string> update_symbols;
-    for (auto atom : symbolic::atoms(update)) {
-        auto sym = SymEngine::rcp_static_cast<const SymEngine::Symbol>(atom);
-        update_symbols.insert(sym->get_name());
-    }
-
-    // Check that we can replace all post-usages of iterator (after increment)
-    auto users_after = body_users.all_uses_after(*update_write);
-    for (auto use : users_after) {
-        if (use->use() == analysis::Use::WRITE && update_symbols.find(use->container()) != update_symbols.end()) {
+        auto& type = sdfg.type(sym->get_name());
+        if (!dynamic_cast<const types::Pointer*>(&type)) {
             return false;
         }
+
+        auto moves = body_users.moves(sym->get_name());
+        // Not an iterator
+        if (moves.empty()) {
+            continue;
+        }
+        // Not well-formed
+        if (moves.size() > 1) {
+            return false;
+        }
+        // Exactly one iterator
+        if (update != nullptr) {
+            return false;
+        }
+        update = moves.at(0);
+    }
+    if (update == nullptr) {
+        return false;
+    }
+    auto iterator = symbolic::symbol(update->container());
+
+    // Criterion: Update is a dereference memlet
+    // iterator = *ptr
+    auto move_dst = dynamic_cast<data_flow::AccessNode*>(update->element());
+    auto& graph = move_dst->get_parent();
+    auto& block = static_cast<const structured_control_flow::Block&>(*graph.get_parent());
+    auto& move_edge = *graph.in_edges(*move_dst).begin();
+    auto& move_src = static_cast<data_flow::AccessNode&>(move_edge.src());
+    if (move_edge.type() != data_flow::MemletType::Dereference_Src) {
+        return false;
+    }
+
+    // Criterion: Update happens right before the condition
+    if (body.index(block) != body.size() - 2) {
+        return false;
     }
 
     // No other continue, break or return inside loop body
@@ -149,7 +168,7 @@ bool WhileToForConversion::can_be_applied(
     return true;
 }
 
-void WhileToForConversion::apply(
+void WhileToForEachConversion::apply(
     builder::StructuredSDFGBuilder& builder,
     analysis::AnalysisManager& analysis_manager,
     structured_control_flow::Sequence& parent,
@@ -163,65 +182,78 @@ void WhileToForConversion::apply(
     auto if_else_stmt = dynamic_cast<structured_control_flow::IfElse*>(&last_element.first);
 
     auto first_condition = if_else_stmt->at(0).second;
+    auto second_condition = if_else_stmt->at(1).second;
 
     bool second_is_break = false;
     auto& second_branch = if_else_stmt->at(1).first;
-    auto second_condition = if_else_stmt->at(1).second;
     if (dynamic_cast<structured_control_flow::Break*>(&second_branch.at(0).first)) {
         second_is_break = true;
     }
+    
+    // Identify iterator
     auto& all_users = analysis_manager.get<analysis::Users>();
     analysis::UsersView body_users(all_users, body);
-    analysis::User* write_to_indvar = nullptr;
-    for (auto& atom : symbolic::atoms(first_condition)) {
-        auto sym = SymEngine::rcp_static_cast<const SymEngine::Symbol>(atom);
-        auto writes = body_users.writes(sym->get_name());
-        if (writes.size() == 1) {
-            write_to_indvar = writes.at(0);
-        } else {
+    analysis::User* update = nullptr;
+    for (auto& sym : symbolic::atoms(first_condition)) {
+        if (symbolic::eq(sym, symbolic::__nullptr__())) {
             continue;
         }
-    }
-    auto update_element = dynamic_cast<structured_control_flow::Transition*>(write_to_indvar->element());
-
-    auto indvar = symbolic::symbol(write_to_indvar->container());
-    auto update = update_element->assignments().at(indvar);
-
-    // Add temporary symbol for uses after increment
-    auto pseudo_indvar = symbolic::symbol(builder.find_new_name(indvar->get_name()));
-    builder.add_container(pseudo_indvar->get_name(), sdfg.type(indvar->get_name()));
-
-    // All usages after increment of indvar must be replaced with pseudo_indvar
-    auto users_after = body_users.all_uses_after(*write_to_indvar);
-    for (auto use : users_after) {
-        if (use->container() != indvar->get_name()) {
-            continue;
+        auto moves = body_users.moves(sym->get_name());
+        if (moves.size() == 1) {
+            update = moves.at(0);
+            break;
         }
-
-        use->element()->replace(indvar, pseudo_indvar);
+    }
+    symbolic::Symbol iterator = symbolic::symbol(update->container());
+    symbolic::Symbol end = SymEngine::null;
+    for (auto& atom : symbolic::atoms(second_condition)) {
+        if (atom->get_name() != iterator->get_name()) {
+            end = atom;
+            break;
+        }
     }
 
-    // Remove update from transition
-    update_element->assignments().erase(indvar);
-    update_element->assignments()[pseudo_indvar] = update;
+    // Identify update / move statement
+    auto move_dst = dynamic_cast<data_flow::AccessNode*>(update->element());
+    auto& graph = move_dst->get_parent();
+    auto& move_edge = *graph.in_edges(*move_dst).begin();
+    auto& move_src = static_cast<data_flow::AccessNode&>(move_edge.src());
+    symbolic::Symbol update_ptr = symbolic::symbol(move_src.data());
 
-    if (second_is_break) {
-        auto& for_loop = builder.convert_while(parent, loop, indvar, first_condition, indvar, update);
-        builder.remove_child(for_loop.root(), for_loop.root().size() - 1);
-    } else {
-        auto& for_loop = builder.convert_while(parent, loop, indvar, second_condition, indvar, update);
-        builder.remove_child(for_loop.root(), for_loop.root().size() - 1);
-    }
+    // Remove update from block
+    builder.remove_child(body, body.size() - 2);
+    // Remove the if-else statement
+    builder.remove_child(body, body.size() - 1);
+
+    // find index of while
+    int while_index = parent.index(loop);
+    auto& transition = parent.at(while_index).second;
+
+    // Create for-each loop
+    auto& for_each = builder.add_for_each_after(
+        parent,
+        loop,
+        iterator,
+        end,
+        update_ptr,
+        SymEngine::null,
+        transition.assignments(),
+        loop.debug_info()
+    );
+    builder.move_children(body, for_each.root());
+
+    // Remove while loop
+    builder.remove_child(parent, while_index);
 };
 
-WhileToForConversion::WhileToForConversion()
+WhileToForEachConversion::WhileToForEachConversion()
     : Pass() {
 
       };
 
-std::string WhileToForConversion::name() { return "WhileToForConversion"; };
+std::string WhileToForEachConversion::name() { return "WhileToForEachConversion"; };
 
-bool WhileToForConversion::run_pass(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {
+bool WhileToForEachConversion::run_pass(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {
     bool applied = false;
 
     // Traverse structured SDFG
@@ -236,7 +268,7 @@ bool WhileToForConversion::run_pass(builder::StructuredSDFGBuilder& builder, ana
                 if (auto match = dynamic_cast<structured_control_flow::While*>(&sequence_stmt->at(i).first)) {
                     if (this->can_be_applied(builder, analysis_manager, *match)) {
                         this->apply(builder, analysis_manager, *sequence_stmt, *match);
-                        applied = true;
+                        return true;
                     }
                 }
 
@@ -250,8 +282,8 @@ bool WhileToForConversion::run_pass(builder::StructuredSDFGBuilder& builder, ana
             queue.push_back(&loop_stmt->root());
         } else if (auto sloop_stmt = dynamic_cast<structured_control_flow::StructuredLoop*>(current)) {
             queue.push_back(&sloop_stmt->root());
-        } else if (auto for_each_stmt = dynamic_cast<structured_control_flow::ForEach*>(current)) {
-            queue.push_back(&for_each_stmt->root());
+        } else if (auto for_each = dynamic_cast<structured_control_flow::ForEach*>(current)) {
+            queue.push_back(&for_each->root());
         }
     }
 

--- a/src/passes/symbolic/symbol_evolution.cpp
+++ b/src/passes/symbolic/symbol_evolution.cpp
@@ -244,6 +244,8 @@ bool SymbolEvolution::run_pass(builder::StructuredSDFGBuilder& builder, analysis
             queue.push_back(&loop_stmt->root());
         } else if (auto sloop_stmt = dynamic_cast<structured_control_flow::StructuredLoop*>(current)) {
             queue.push_back(&sloop_stmt->root());
+        } else if (auto for_each_stmt = dynamic_cast<structured_control_flow::ForEach*>(current)) {
+            queue.push_back(&for_each_stmt->root());
         }
     }
 

--- a/src/passes/symbolic/symbol_promotion.cpp
+++ b/src/passes/symbolic/symbol_promotion.cpp
@@ -289,6 +289,8 @@ bool SymbolPromotion::run_pass(builder::StructuredSDFGBuilder& builder, analysis
             queue.push_back(&loop_stmt->root());
         } else if (auto sloop_stmt = dynamic_cast<structured_control_flow::StructuredLoop*>(current)) {
             queue.push_back(&sloop_stmt->root());
+        } else if (auto for_each_stmt = dynamic_cast<structured_control_flow::ForEach*>(current)) {
+            queue.push_back(&for_each_stmt->root());
         }
     }
 

--- a/src/serializer/json_serializer.cpp
+++ b/src/serializer/json_serializer.cpp
@@ -967,9 +967,8 @@ void JSONSerializer::json_to_for_each_node(
         init = symbolic::symbol(j["init"]);
     }
 
-    auto& for_each_node = builder.add_for_each(
-        parent, iterator, end, update, init, assignments, json_to_debug_info(j["debug_info"])
-    );
+    auto& for_each_node =
+        builder.add_for_each(parent, iterator, end, update, init, assignments, json_to_debug_info(j["debug_info"]));
     for_each_node.element_id_ = j["element_id"];
 
     assert(j["root"].contains("type"));

--- a/src/structured_control_flow/for_each.cpp
+++ b/src/structured_control_flow/for_each.cpp
@@ -5,19 +5,19 @@
 namespace sdfg {
 namespace structured_control_flow {
 
-ForEach::
-    ForEach(size_t element_id,
-        const DebugInfo& debug_info,
-        symbolic::Symbol iterator,
-        symbolic::Symbol end,
-        symbolic::Symbol update,
-        symbolic::Symbol init
-    )
+ForEach::ForEach(
+    size_t element_id,
+    const DebugInfo& debug_info,
+    symbolic::Symbol iterator,
+    symbolic::Symbol end,
+    symbolic::Symbol update,
+    symbolic::Symbol init
+)
     : ControlFlowNode(element_id, debug_info), iterator_(iterator), update_(update), end_(end), init_(init) {
-        this->root_ = std::unique_ptr<Sequence>(new Sequence(++element_id, debug_info));
-    }
+    this->root_ = std::unique_ptr<Sequence>(new Sequence(++element_id, debug_info));
+}
 
-void ForEach::validate(const Function& function) const { 
+void ForEach::validate(const Function& function) const {
     root_->validate(function);
 
     if (iterator_.is_null()) {
@@ -59,29 +59,17 @@ void ForEach::validate(const Function& function) const {
     }
 };
 
-const symbolic::Symbol ForEach::iterator() const {
-    return iterator_;
-}
+const symbolic::Symbol ForEach::iterator() const { return iterator_; }
 
-const symbolic::Symbol ForEach::end() const {
-    return end_;
-}
+const symbolic::Symbol ForEach::end() const { return end_; }
 
-const symbolic::Symbol ForEach::update() const {
-    return update_;
-}
+const symbolic::Symbol ForEach::update() const { return update_; }
 
-const symbolic::Symbol ForEach::init() const {
-    return init_;
-}
+const symbolic::Symbol ForEach::init() const { return init_; }
 
-bool ForEach::has_init() const {
-    return !init_.is_null();
-}
+bool ForEach::has_init() const { return !init_.is_null(); }
 
-Sequence& ForEach::root() const {
-    return *root_;
-}
+Sequence& ForEach::root() const { return *root_; }
 
 void ForEach::replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {
     root_->replace(old_expression, new_expression);

--- a/src/structured_control_flow/for_each.cpp
+++ b/src/structured_control_flow/for_each.cpp
@@ -1,0 +1,67 @@
+#include "sdfg/structured_control_flow/for_each.h"
+
+#include "sdfg/function.h"
+
+namespace sdfg {
+namespace structured_control_flow {
+
+ForEach::
+    ForEach(size_t element_id,
+        const DebugInfo& debug_info,
+        symbolic::Symbol iterator,
+        symbolic::Symbol end)
+    : ControlFlowNode(element_id, debug_info), iterator_(iterator), end_(end) {
+        this->root_ = std::unique_ptr<Sequence>(new Sequence(++element_id, debug_info));
+    }
+
+void ForEach::validate(const Function& function) const { 
+    root_->validate(function);
+
+    if (iterator_.is_null()) {
+        throw InvalidSDFGException("ForEach node has a null iterator.");
+    }
+    if (end_.is_null()) {
+        throw InvalidSDFGException("ForEach node has a null end.");
+    }
+
+    // Criterion: Iterator must be pointer
+    auto& iterator_type = function.type(iterator_->get_name());
+    if (iterator_type.type_id() != types::TypeID::Pointer) {
+        throw InvalidSDFGException("ForEach iterator must be of pointer type.");
+    }
+
+    // Criterion: End must be pointer
+    if (!symbolic::eq(end_, symbolic::__nullptr__())) {
+        auto& end_type = function.type(end_->get_name());
+        if (end_type.type_id() != types::TypeID::Pointer) {
+            throw InvalidSDFGException("ForEach end must be of pointer type.");
+        }
+    }
+};
+
+const symbolic::Symbol ForEach::iterator() const {
+    return iterator_;
+}
+
+const symbolic::Symbol ForEach::end() const {
+    return end_;
+}
+
+Sequence& ForEach::root() const {
+    return *root_;
+}
+
+void ForEach::replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {
+    root_->replace(old_expression, new_expression);
+
+    if (symbolic::eq(iterator_, old_expression)) {
+        iterator_ = SymEngine::rcp_dynamic_cast<const SymEngine::Symbol>(new_expression);
+    }
+
+    if (symbolic::eq(end_, old_expression)) {
+        end_ = SymEngine::rcp_dynamic_cast<const SymEngine::Symbol>(new_expression);
+    }
+}
+
+} // namespace structured_control_flow
+} // namespace sdfg

--- a/src/structured_control_flow/for_each.cpp
+++ b/src/structured_control_flow/for_each.cpp
@@ -29,9 +29,6 @@ void ForEach::validate(const Function& function) const {
     if (update_.is_null()) {
         throw InvalidSDFGException("ForEach node has a null update.");
     }
-    if (!init_.is_null() && symbolic::eq(init_, end_)) {
-        throw InvalidSDFGException("ForEach node has identical init and end symbols.");
-    }
 
     // Criterion: Iterator must be pointer
     auto& iterator_type = function.type(iterator_->get_name());

--- a/src/visitor/structured_sdfg_visitor.cpp
+++ b/src/visitor/structured_sdfg_visitor.cpp
@@ -43,6 +43,14 @@ bool StructuredSDFGVisitor::visit(structured_control_flow::Sequence& parent) {
             if (this->visit(for_stmt->root())) {
                 return true;
             }
+        } else if (auto for_each_stmt = dynamic_cast<structured_control_flow::ForEach*>(&current)) {
+            if (this->accept(*for_each_stmt)) {
+                return true;
+            }
+
+            if (this->visit(for_each_stmt->root())) {
+                return true;
+            }
         } else if (auto map_stmt = dynamic_cast<structured_control_flow::Map*>(&current)) {
             if (this->accept(*map_stmt)) {
                 return true;
@@ -92,6 +100,8 @@ bool StructuredSDFGVisitor::accept(structured_control_flow::Continue& node) { re
 bool StructuredSDFGVisitor::accept(structured_control_flow::Break& node) { return false; };
 
 bool StructuredSDFGVisitor::accept(structured_control_flow::For& node) { return false; };
+
+bool StructuredSDFGVisitor::accept(structured_control_flow::ForEach& node) { return false; };
 
 bool StructuredSDFGVisitor::accept(structured_control_flow::Map& node) { return false; };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ set(TEST_FILES
     replace/symbol_replace_test.cpp
     sdfg_test.cpp
     serializer/json_serializer_test.cpp
+    structured_control_flow/for_each_test.cpp
     structured_control_flow/map_test.cpp
     structured_sdfg_test.cpp
     symbolic/assumptions_test.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ set(TEST_FILES
     passes/structured_control_flow/dead_cfg_elimination_test.cpp
     passes/structured_control_flow/for2map_test.cpp
     passes/structured_control_flow/loop_normalization_test.cpp
+    passes/structured_control_flow/while_to_for_each_conversion_test.cpp
     passes/debug_info_propagation_test.cpp
     passes/symbolic/symbol_promotion_test.cpp
     passes/symbolic/symbol_propagation_test.cpp

--- a/tests/builder/structured_sdfg_builder_test.cpp
+++ b/tests/builder/structured_sdfg_builder_test.cpp
@@ -688,17 +688,11 @@ TEST(StructuredSDFGBuilderTest, addForEach) {
      *  value: ...
      * }
      * for (auto iter = *list; iter != list; iter = *iter) {
-     * 
+     *
      * }
      */
 
-    auto& scope = builder.add_for_each(
-        root,
-        sym_iter,
-        sym_list,
-        sym_iter,
-        sym_list
-    );
+    auto& scope = builder.add_for_each(root, sym_iter, sym_list, sym_iter, sym_list);
     EXPECT_EQ(scope.element_id(), 1);
     EXPECT_EQ(scope.root().element_id(), 2);
     EXPECT_EQ(root.at(0).second.element_id(), 3);
@@ -740,18 +734,12 @@ TEST(StructuredSDFGBuilderTest, addForEach_Transition) {
      *  value: ...
      * }
      * for (auto iter = *list; iter != list; iter = *iter) {
-     * 
+     *
      * }
      */
 
-    auto& scope = builder.add_for_each(
-        root,
-        sym_iter,
-        sym_list,
-        sym_iter,
-        sym_list,
-        {{symbolic::symbol("N"), symbolic::zero()}}
-    );
+    auto& scope =
+        builder.add_for_each(root, sym_iter, sym_list, sym_iter, sym_list, {{symbolic::symbol("N"), symbolic::zero()}});
     EXPECT_EQ(scope.element_id(), 1);
     EXPECT_EQ(scope.root().element_id(), 2);
     EXPECT_EQ(root.at(0).second.element_id(), 3);
@@ -789,15 +777,9 @@ TEST(StructuredSDFGBuilderTest, addForEachBefore) {
 
     auto& block_base =
         builder.add_block(root, control_flow::Assignments{{symbolic::symbol("N"), SymEngine::integer(10)}});
-    
+
     auto& scope = builder.add_for_each_before(
-        root,
-        block_base,
-        sym_iter,
-        sym_list,
-        sym_iter,
-        SymEngine::null,
-        {{symbolic::symbol("N"), symbolic::zero()}}
+        root, block_base, sym_iter, sym_list, sym_iter, SymEngine::null, {{symbolic::symbol("N"), symbolic::zero()}}
     );
 
     EXPECT_EQ(scope.has_init(), false);
@@ -833,7 +815,7 @@ TEST(StructuredSDFGBuilderTest, addForEachAfter) {
         builder.add_block(root, control_flow::Assignments{{symbolic::symbol("N"), SymEngine::integer(10)}});
     auto& block_base2 =
         builder.add_block(root, control_flow::Assignments{{symbolic::symbol("N"), SymEngine::integer(10)}});
-    
+
     /**
      * Doubled linked list with start and end 'list'
      * iter: {
@@ -841,18 +823,12 @@ TEST(StructuredSDFGBuilderTest, addForEachAfter) {
      *  value: ...
      * }
      * for (auto iter = *list; iter != list; iter = *iter) {
-     * 
+     *
      * }
      */
 
     auto& scope = builder.add_for_each_after(
-        root,
-        block_base,
-        sym_iter,
-        sym_list,
-        sym_iter,
-        SymEngine::null,
-        {{symbolic::symbol("N"), symbolic::zero()}}
+        root, block_base, sym_iter, sym_list, sym_iter, SymEngine::null, {{symbolic::symbol("N"), symbolic::zero()}}
     );
 
     EXPECT_EQ(scope.has_init(), false);

--- a/tests/builder/structured_sdfg_builder_test.cpp
+++ b/tests/builder/structured_sdfg_builder_test.cpp
@@ -667,3 +667,203 @@ TEST(StructuredSDFGBuilderTest, FindElementById_Block) {
 
     EXPECT_EQ(builder.find_element_by_id(block.element_id()), &block);
 }
+
+TEST(StructuredSDFGBuilderTest, addForEach) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+
+    types::Pointer opaque_desc;
+    builder.add_container("list", opaque_desc, true);
+    builder.add_container("iter", opaque_desc);
+
+    auto sym_list = symbolic::symbol("list");
+    auto sym_iter = symbolic::symbol("iter");
+
+    auto& root = builder.subject().root();
+    EXPECT_EQ(root.element_id(), 0);
+
+    /**
+     * Doubled linked list with start and end 'list'
+     * iter: {
+     *  next: ptr;
+     *  value: ...
+     * }
+     * for (auto iter = *list; iter != list; iter = *iter) {
+     * 
+     * }
+     */
+
+    auto& scope = builder.add_for_each(
+        root,
+        sym_iter,
+        sym_list,
+        sym_iter,
+        sym_list
+    );
+    EXPECT_EQ(scope.element_id(), 1);
+    EXPECT_EQ(scope.root().element_id(), 2);
+    EXPECT_EQ(root.at(0).second.element_id(), 3);
+
+    EXPECT_EQ(scope.has_init(), true);
+    EXPECT_TRUE(symbolic::eq(scope.init(), sym_list));
+    EXPECT_TRUE(symbolic::eq(scope.iterator(), sym_iter));
+    EXPECT_TRUE(symbolic::eq(scope.end(), sym_list));
+    EXPECT_TRUE(symbolic::eq(scope.update(), sym_iter));
+
+    auto sdfg = builder.move();
+
+    EXPECT_EQ(sdfg->root().size(), 1);
+    auto child = sdfg->root().at(0);
+    EXPECT_EQ(&child.first, &scope);
+    EXPECT_EQ(child.second.size(), 0);
+}
+
+TEST(StructuredSDFGBuilderTest, addForEach_Transition) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+
+    types::Pointer opaque_desc;
+    builder.add_container("list", opaque_desc, true);
+    builder.add_container("iter", opaque_desc);
+
+    types::Scalar int_desc(types::PrimitiveType::Int64);
+    builder.add_container("N", int_desc, true);
+
+    auto sym_list = symbolic::symbol("list");
+    auto sym_iter = symbolic::symbol("iter");
+
+    auto& root = builder.subject().root();
+    EXPECT_EQ(root.element_id(), 0);
+
+    /**
+     * Doubled linked list with start and end 'list'
+     * iter: {
+     *  next: ptr;
+     *  value: ...
+     * }
+     * for (auto iter = *list; iter != list; iter = *iter) {
+     * 
+     * }
+     */
+
+    auto& scope = builder.add_for_each(
+        root,
+        sym_iter,
+        sym_list,
+        sym_iter,
+        sym_list,
+        {{symbolic::symbol("N"), symbolic::zero()}}
+    );
+    EXPECT_EQ(scope.element_id(), 1);
+    EXPECT_EQ(scope.root().element_id(), 2);
+    EXPECT_EQ(root.at(0).second.element_id(), 3);
+
+    EXPECT_EQ(scope.has_init(), true);
+    EXPECT_TRUE(symbolic::eq(scope.init(), sym_list));
+    EXPECT_TRUE(symbolic::eq(scope.iterator(), sym_iter));
+    EXPECT_TRUE(symbolic::eq(scope.end(), sym_list));
+    EXPECT_TRUE(symbolic::eq(scope.update(), sym_iter));
+
+    auto sdfg = builder.move();
+
+    EXPECT_EQ(sdfg->root().size(), 1);
+    auto child = sdfg->root().at(0);
+    EXPECT_EQ(&child.first, &scope);
+    EXPECT_EQ(child.second.size(), 1);
+    EXPECT_TRUE(symbolic::eq(child.second.assignments().at(symbolic::symbol("N")), symbolic::zero()));
+}
+
+TEST(StructuredSDFGBuilderTest, addForEachBefore) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+
+    types::Pointer opaque_desc;
+    builder.add_container("list", opaque_desc, true);
+    builder.add_container("iter", opaque_desc);
+
+    types::Scalar int_desc(types::PrimitiveType::Int64);
+    builder.add_container("N", int_desc, true);
+
+    auto sym_list = symbolic::symbol("list");
+    auto sym_iter = symbolic::symbol("iter");
+
+    auto& root = builder.subject().root();
+    EXPECT_EQ(root.element_id(), 0);
+
+    auto& block_base =
+        builder.add_block(root, control_flow::Assignments{{symbolic::symbol("N"), SymEngine::integer(10)}});
+    
+    auto& scope = builder.add_for_each_before(
+        root,
+        block_base,
+        sym_iter,
+        sym_list,
+        sym_iter,
+        SymEngine::null,
+        {{symbolic::symbol("N"), symbolic::zero()}}
+    );
+
+    EXPECT_EQ(scope.has_init(), false);
+    EXPECT_TRUE(symbolic::eq(scope.iterator(), sym_iter));
+    EXPECT_TRUE(symbolic::eq(scope.end(), sym_list));
+    EXPECT_TRUE(symbolic::eq(scope.update(), sym_iter));
+
+    auto sdfg = builder.move();
+
+    auto child = sdfg->root().at(0);
+    EXPECT_EQ(&child.first, &scope);
+    EXPECT_EQ(child.second.size(), 1);
+    EXPECT_TRUE(symbolic::eq(child.second.assignments().at(symbolic::symbol("N")), symbolic::zero()));
+}
+
+TEST(StructuredSDFGBuilderTest, addForEachAfter) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+
+    types::Pointer opaque_desc;
+    builder.add_container("list", opaque_desc, true);
+    builder.add_container("iter", opaque_desc);
+
+    types::Scalar int_desc(types::PrimitiveType::Int64);
+    builder.add_container("N", int_desc, true);
+
+    auto sym_list = symbolic::symbol("list");
+    auto sym_iter = symbolic::symbol("iter");
+
+    auto& root = builder.subject().root();
+    EXPECT_EQ(root.element_id(), 0);
+
+    auto& block_base =
+        builder.add_block(root, control_flow::Assignments{{symbolic::symbol("N"), SymEngine::integer(10)}});
+    auto& block_base2 =
+        builder.add_block(root, control_flow::Assignments{{symbolic::symbol("N"), SymEngine::integer(10)}});
+    
+    /**
+     * Doubled linked list with start and end 'list'
+     * iter: {
+     *  next: ptr;
+     *  value: ...
+     * }
+     * for (auto iter = *list; iter != list; iter = *iter) {
+     * 
+     * }
+     */
+
+    auto& scope = builder.add_for_each_after(
+        root,
+        block_base,
+        sym_iter,
+        sym_list,
+        sym_iter,
+        SymEngine::null,
+        {{symbolic::symbol("N"), symbolic::zero()}}
+    );
+
+    EXPECT_EQ(scope.has_init(), false);
+    EXPECT_TRUE(symbolic::eq(scope.iterator(), sym_iter));
+    EXPECT_TRUE(symbolic::eq(scope.end(), sym_list));
+    EXPECT_TRUE(symbolic::eq(scope.update(), sym_iter));
+
+    auto sdfg = builder.move();
+
+    auto child = sdfg->root().at(1);
+    EXPECT_EQ(&child.first, &scope);
+    EXPECT_EQ(child.second.size(), 1);
+    EXPECT_TRUE(symbolic::eq(child.second.assignments().at(symbolic::symbol("N")), symbolic::zero()));
+}

--- a/tests/passes/structured_control_flow/while_to_for_each_conversion_test.cpp
+++ b/tests/passes/structured_control_flow/while_to_for_each_conversion_test.cpp
@@ -1,0 +1,192 @@
+#include "sdfg/passes/structured_control_flow/while_to_for_each_conversion.h"
+
+#include <gtest/gtest.h>
+
+#include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/symbolic/symbolic.h"
+
+using namespace sdfg;
+
+TEST(WhileToForEachConversionTest, LinkedList) {
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    // Add containers
+    types::Pointer opaque_desc;
+    builder.add_container("list", opaque_desc, true);
+    builder.add_container("iter", opaque_desc);
+
+    auto sym_iter = symbolic::symbol("iter");
+    auto sym_list = symbolic::symbol("list");
+    auto sym_nullptr = symbolic::__nullptr__();
+
+    // Reinterpret cast pointers to pointer(pointer) for dereferencing
+    types::Pointer ptr_ptr_desc(static_cast<const types::IType&>(opaque_desc));
+
+    // Init: iter = *list
+    {
+        auto& block = builder.add_block(root);
+        auto& list = builder.add_access(block, "list");
+        auto& iter = builder.add_access(block, "iter");
+        builder.add_dereference_memlet(block, list, iter, true, ptr_ptr_desc);
+    }
+
+    auto& loop = builder.add_while(root);
+    auto& body = loop.root();
+
+    // Update: iter = *iter
+    auto& block = builder.add_block(body);
+    auto& iter_in = builder.add_access(block, "iter");
+    auto& iter_out = builder.add_access(block, "iter");
+    builder.add_dereference_memlet(block, iter_in, iter_out, true, ptr_ptr_desc);
+
+    // Condition: iter != nullptr -> continue
+    auto& ifelse = builder.add_if_else(body);
+    auto& continue_scope = builder.add_case(ifelse, symbolic::Ne(sym_iter, sym_nullptr));
+    builder.add_continue(continue_scope);
+    auto& break_scope = builder.add_case(ifelse, symbolic::Eq(sym_iter, sym_nullptr));
+    builder.add_break(break_scope);
+
+    // Analysis
+    analysis::AnalysisManager analysis_manager(builder.subject());
+    passes::WhileToForEachConversion conversion_pass;
+    EXPECT_TRUE(conversion_pass.run(builder, analysis_manager));
+
+    // Check
+    auto for_each_node = dynamic_cast<const structured_control_flow::ForEach*>(&builder.subject().root().at(1).first);
+    EXPECT_TRUE(for_each_node != nullptr);
+    EXPECT_FALSE(for_each_node->has_init());
+    EXPECT_TRUE(symbolic::eq(for_each_node->iterator(), sym_iter));
+    EXPECT_TRUE(symbolic::eq(for_each_node->end(), sym_nullptr));
+    EXPECT_TRUE(symbolic::eq(for_each_node->update(), sym_iter));
+}
+
+TEST(WhileToForEachConversionTest, DoubleLinkedList) {
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    // Add containers
+    types::Pointer opaque_desc;
+    builder.add_container("list", opaque_desc, true);
+    builder.add_container("iter", opaque_desc);
+
+    auto sym_iter = symbolic::symbol("iter");
+    auto sym_list = symbolic::symbol("list");
+
+    // Reinterpret cast pointers to pointer(pointer) for dereferencing
+    types::Pointer ptr_ptr_desc(static_cast<const types::IType&>(opaque_desc));
+
+    // Init: iter = *list
+    {
+        auto& block = builder.add_block(root);
+        auto& list = builder.add_access(block, "list");
+        auto& iter = builder.add_access(block, "iter");
+        builder.add_dereference_memlet(block, list, iter, true, ptr_ptr_desc);
+    }
+
+    auto& loop = builder.add_while(root);
+    auto& body = loop.root();
+
+    // Update: iter = *iter
+    auto& block = builder.add_block(body);
+    auto& iter_in = builder.add_access(block, "iter");
+    auto& iter_out = builder.add_access(block, "iter");
+    builder.add_dereference_memlet(block, iter_in, iter_out, true, ptr_ptr_desc);
+
+    // Condition: iter != nullptr -> continue
+    auto& ifelse = builder.add_if_else(body);
+    auto& continue_scope = builder.add_case(ifelse, symbolic::Ne(sym_iter, sym_list));
+    builder.add_continue(continue_scope);
+    auto& break_scope = builder.add_case(ifelse, symbolic::Eq(sym_iter, sym_list));
+    builder.add_break(break_scope);
+
+    // Analysis
+    analysis::AnalysisManager analysis_manager(builder.subject());
+    passes::WhileToForEachConversion conversion_pass;
+    EXPECT_TRUE(conversion_pass.run(builder, analysis_manager));
+
+    // Check
+    auto for_each_node = dynamic_cast<const structured_control_flow::ForEach*>(&builder.subject().root().at(1).first);
+    EXPECT_TRUE(for_each_node != nullptr);
+    EXPECT_FALSE(for_each_node->has_init());
+    EXPECT_TRUE(symbolic::eq(for_each_node->iterator(), sym_iter));
+    EXPECT_TRUE(symbolic::eq(for_each_node->end(), sym_list));
+    EXPECT_TRUE(symbolic::eq(for_each_node->update(), sym_iter));
+}
+
+TEST(WhileToForEachConversionTest, DoubleLinkedList_NextPtrWithOffset) {
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    // Add containers
+    types::Pointer opaque_desc;
+    builder.add_container("list", opaque_desc, true);
+    builder.add_container("iter", opaque_desc);
+    builder.add_container("next_ptr", opaque_desc);
+
+    auto sym_iter = symbolic::symbol("iter");
+    auto sym_list = symbolic::symbol("list");
+    auto sym_next_ptr = symbolic::symbol("next_ptr");
+
+    // Reinterpret cast pointers to pointer(pointer) for dereferencing
+    types::Pointer ptr_ptr_desc(static_cast<const types::IType&>(opaque_desc));
+
+    // Init
+    {
+        // next_ptr = list + offset
+        auto& block1 = builder.add_block(root);
+        auto& list = builder.add_access(block1, "list");
+        auto& next_ptr = builder.add_access(block1, "next_ptr");
+        builder.add_reference_memlet(block1, list, next_ptr, {symbolic::integer(4)}, ptr_ptr_desc);
+
+        auto& block2 = builder.add_block(root);
+        auto& next_ptr2 = builder.add_access(block2, "next_ptr");
+        auto& iter = builder.add_access(block2, "iter");
+        builder.add_dereference_memlet(block2, next_ptr2, iter, true, ptr_ptr_desc);
+
+    }
+
+    auto& loop = builder.add_while(root);
+    auto& body = loop.root();
+
+    // Update
+    {
+        // next_ptr = iter + offset
+        auto& block1 = builder.add_block(body);
+        auto& iter_in = builder.add_access(block1, "iter");
+        auto& next_ptr = builder.add_access(block1, "next_ptr");
+        builder.add_reference_memlet(block1, iter_in, next_ptr, {symbolic::integer(4)}, ptr_ptr_desc);
+
+        // iter = *next_ptr
+        auto& block2 = builder.add_block(body);
+        auto& next_ptr2 = builder.add_access(block2, "next_ptr");
+        auto& iter_out = builder.add_access(block2, "iter");
+        builder.add_dereference_memlet(block2, next_ptr2, iter_out, true, ptr_ptr_desc);
+    }
+
+    // Condition: iter != nullptr -> continue
+    auto& ifelse = builder.add_if_else(body);
+    auto& continue_scope = builder.add_case(ifelse, symbolic::Ne(sym_iter, sym_list));
+    builder.add_continue(continue_scope);
+    auto& break_scope = builder.add_case(ifelse, symbolic::Eq(sym_iter, sym_list));
+    builder.add_break(break_scope);
+
+    // Analysis
+    analysis::AnalysisManager analysis_manager(builder.subject());
+    passes::WhileToForEachConversion conversion_pass;
+    EXPECT_TRUE(conversion_pass.run(builder, analysis_manager));
+
+    // Check
+    auto for_each_node = dynamic_cast<const structured_control_flow::ForEach*>(&builder.subject().root().at(2).first);
+    EXPECT_TRUE(for_each_node != nullptr);
+    EXPECT_FALSE(for_each_node->has_init());
+    EXPECT_TRUE(symbolic::eq(for_each_node->iterator(), sym_iter));
+    EXPECT_TRUE(symbolic::eq(for_each_node->end(), sym_list));
+    EXPECT_TRUE(symbolic::eq(for_each_node->update(), sym_next_ptr));
+}

--- a/tests/structured_control_flow/for_each_test.cpp
+++ b/tests/structured_control_flow/for_each_test.cpp
@@ -5,6 +5,7 @@
 #include "sdfg/codegen/language_extensions/c_language_extension.h"
 #include "sdfg/serializer/json_serializer.h"
 #include "sdfg/symbolic/symbolic.h"
+#include "sdfg/visitor/structured_sdfg_visitor.h"
 
 using namespace sdfg;
 
@@ -68,4 +69,34 @@ TEST(ForEachTest, Dispatch) {
     EXPECT_EQ(globals_stream.str(), "");
     EXPECT_TRUE(library_factory.snippets().empty());
     EXPECT_EQ(main_stream.str(), "for(iter = *((void* *) list);iter != NULL;iter = *((void* *) iter))\n{\n}\n");
+}
+
+class ForEachVisitor : public visitor::StructuredSDFGVisitor {
+public:
+    ForEachVisitor(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager)
+        : visitor::StructuredSDFGVisitor(builder, analysis_manager) {}
+
+    bool accept(structured_control_flow::ForEach& node) override { return true; };
+};
+
+TEST(StructuredSDFGVisitorTest, ForEach) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    // Add containers
+    types::Pointer opaque_desc;
+    builder.add_container("list", opaque_desc, true);
+    builder.add_container("iter", opaque_desc);
+
+    auto sym_iter = symbolic::symbol("iter");
+    auto sym_list = symbolic::symbol("list");
+    auto sym_nullptr = symbolic::__nullptr__();
+
+    auto& for_each = builder.add_for_each(root, sym_iter, sym_nullptr, sym_iter, sym_list);
+
+    analysis::AnalysisManager analysis_manager(builder.subject());
+    ForEachVisitor visitor(builder, analysis_manager);
+    EXPECT_TRUE(visitor.visit());
 }

--- a/tests/structured_control_flow/for_each_test.cpp
+++ b/tests/structured_control_flow/for_each_test.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+#include "sdfg/structured_control_flow/map.h"
+
+#include "sdfg/codegen/dispatchers/for_each_dispatcher.h"
+#include "sdfg/codegen/language_extensions/c_language_extension.h"
+#include "sdfg/serializer/json_serializer.h"
+#include "sdfg/symbolic/symbolic.h"
+
+using namespace sdfg;
+
+TEST(ForEachTest, SerializeDeserialize) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    // Add containers
+    types::Pointer opaque_desc;
+    builder.add_container("list", opaque_desc, true);
+    builder.add_container("iter", opaque_desc);
+
+    auto sym_iter = symbolic::symbol("iter");
+    auto sym_list = symbolic::symbol("list");
+    auto sym_nullptr = symbolic::__nullptr__();
+
+    auto& for_each = builder.add_for_each(root, sym_iter, sym_nullptr, sym_iter, sym_list);
+
+    serializer::JSONSerializer serializer;
+    auto json = serializer.serialize(sdfg);
+    auto deserialized_sdfg = serializer.deserialize(json);
+
+    auto& deserialized_root = deserialized_sdfg->root();
+    auto deserialized_for_each = dynamic_cast<const structured_control_flow::ForEach*>(&deserialized_root.at(0).first);
+    EXPECT_TRUE(deserialized_for_each != nullptr);
+    EXPECT_TRUE(deserialized_for_each->has_init());
+    EXPECT_TRUE(symbolic::eq(deserialized_for_each->init(), sym_list));
+    EXPECT_TRUE(symbolic::eq(deserialized_for_each->iterator(), sym_iter));
+    EXPECT_TRUE(symbolic::eq(deserialized_for_each->end(), sym_nullptr));
+    EXPECT_TRUE(symbolic::eq(deserialized_for_each->update(), sym_iter));
+}
+
+TEST(ForEachTest, Dispatch) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    // Add containers
+    types::Pointer opaque_desc;
+    builder.add_container("list", opaque_desc, true);
+    builder.add_container("iter", opaque_desc);
+
+    auto sym_iter = symbolic::symbol("iter");
+    auto sym_list = symbolic::symbol("list");
+    auto sym_nullptr = symbolic::__nullptr__();
+
+    auto& for_each = builder.add_for_each(root, sym_iter, sym_nullptr, sym_iter, sym_list);
+
+    codegen::CLanguageExtension language_extension;
+    auto instrumentation = codegen::InstrumentationPlan::none(sdfg);
+    codegen::ForEachDispatcher dispatcher(language_extension, sdfg, for_each, *instrumentation);
+
+    codegen::PrettyPrinter main_stream;
+    codegen::PrettyPrinter globals_stream;
+    codegen::CodeSnippetFactory library_factory;
+    dispatcher.dispatch_node(main_stream, globals_stream, library_factory);
+
+    EXPECT_EQ(globals_stream.str(), "");
+    EXPECT_TRUE(library_factory.snippets().empty());
+    EXPECT_EQ(main_stream.str(), "for(iter = *((void* *) list);iter != NULL;iter = *((void* *) iter))\n{\n}\n");
+}


### PR DESCRIPTION
A for-each node needs four pointers:

- iterator: opaque_ptr
- init: opaque_ptr (optional)
- end: opaque_ptr (may be null)
- update: opaque_ptr (may be identical to iterator)

It is basically implemented as follows:
```
for (iterator = *((void**)init); iterator != end; iter = *((void**)update)) { ... }
```
Since we have opaque pointer, the C/C++ codegen needs to do the cast to a ptr(ptr).

Example: std::list in C++

- init: iter = *list_ptr
- end: iter != list_ptr
- update: iter = *iter

The next-element-ptr of a node in the std::list is at the start of the node (from a byte/struct perspective), hence there is no separate offset calculation via get_element_ptr/reference_memlet necessary.