### PR TITLE
Makes fasterrcnn backbone run

### DIFF
--- a/.github/workflows/unit_tests_linux.yml
+++ b/.github/workflows/unit_tests_linux.yml
@@ -288,6 +288,16 @@ jobs:
           cd mlir/
           pytest -v integration/
 
+      - name: Model Zoo Tests (Nightly only)
+        if: (matrix.python-version == '3.11' || matrix.python-version == '3.12') && github.event_name == 'schedule'
+        run: |
+          # Install additional dependencies for model zoo tests
+          pip install transformers pillow requests matplotlib
+
+          # Run fasterrcnn test (will fail if assertions don't pass)
+          cd mlir/benchmarks/torch/model_zoo/
+          python fasterrcnn_resnet50.py
+
   finish:
     needs: [cpp-tests-linux, python-tests-linux, mlir-tests-linux]
     runs-on: ubuntu-latest

--- a/mlir/benchmarks/torch/model_zoo/fasterrcnn_resnet50.py
+++ b/mlir/benchmarks/torch/model_zoo/fasterrcnn_resnet50.py
@@ -1,0 +1,108 @@
+import torch
+import torchvision.models as models
+import time
+import matplotlib.pyplot as plt
+import PIL.Image as Image
+import requests
+
+import docc.torch
+
+# Load a pre-trained Faster R-CNN model
+weights = models.detection.FasterRCNN_ResNet50_FPN_Weights.DEFAULT
+model = models.detection.fasterrcnn_resnet50_fpn(weights=weights)
+model.eval()
+transforms = weights.transforms()
+
+print("\n=== Selective Compilation Strategy ===")
+print("Strategy: Compile ONLY the backbone with docc backend")
+print("          RPN and ROI heads run eagerly through PyTorch")
+print()
+
+# Compile only the backbone with docc
+print("--- Compile Times ---")
+start = time.perf_counter()
+compiled_backbone = torch.compile(model.backbone, backend="docc")
+docc_compile_time = time.perf_counter() - start
+print(f"Backbone compile (docc): {docc_compile_time:.4f} s")
+
+# Replace the backbone with compiled version
+# Now model.backbone is compiled with docc, rest of model runs eagerly
+model.backbone = compiled_backbone
+
+# Create reference model for comparison
+model_ref = models.detection.fasterrcnn_resnet50_fpn(weights=weights)
+model_ref.eval()
+start = time.perf_counter()
+program_ref = torch.compile(model_ref)
+torch_compile_time = time.perf_counter() - start
+print(f"Full model compile (torch inductor): {torch_compile_time:.4f} s")
+
+url = "https://github.com/pytorch/hub/raw/master/images/dog.jpg"  # dog (Samoyed)
+
+image = Image.open(requests.get(url, stream=True).raw)
+
+
+input_tensor = transforms(image)
+input_batch = input_tensor.unsqueeze(0)  # create a mini-batch as expected by the model
+
+_ = plt.imshow(image)
+plt.title("Input Image")
+plt.axis("off")
+
+# Force dynamo (inference) backend
+with torch.no_grad():
+    print("\n--- Execution Times ---")
+    print("Mixed compilation (docc backbone + eager RPN/ROI):")
+    start = time.perf_counter()
+    res = model(input_batch)
+    mixed_exec_time = time.perf_counter() - start
+    print(f"  First execution: {mixed_exec_time:.4f} s")
+
+    print("\nTorch inductor (full model):")
+    start = time.perf_counter()
+    ref = program_ref(input_batch)
+    torch_exec_time = time.perf_counter() - start
+    print(f"  First execution: {torch_exec_time:.4f} s")
+
+    print("\n--- Results Comparison ---")
+    # Compare outputs
+    if torch.allclose(res[0]['boxes'], ref[0]['boxes'], rtol=1e-2):
+        print("✓ Boxes match between docc and torch")
+    else:
+        print("✗ Boxes differ with a relative difference of:")
+        print((res[0]['boxes'] - ref[0]['boxes']) / ref[0]['boxes'])
+    
+    if torch.allclose(res[0]['scores'], ref[0]['scores'], rtol=1e-2):
+        print("✓ Scores match between docc and torch")
+    else:
+        print("✗ Scores differ with a relative difference of:")
+        print((res[0]['scores'] - ref[0]['scores']) / ref[0]['scores'])
+    
+    print(f"\nDetected {len(res[0]['boxes'])} objects with docc")
+    print(f"Detected {len(ref[0]['boxes'])} objects with torch inductor")
+
+
+# Draw the predicted bounding boxes
+def draw_boxes(image, boxes, classes ,labels, scores, threshold=0.4, title="Predicted Bounding Boxes"):
+    plt.figure(figsize=(8, 8))
+    plt.imshow(image)
+    ax = plt.gca()
+
+    box_labels = [labels[min(i, len(labels) - 1)] for i in classes]
+
+    for box, label, score in zip(boxes, box_labels, scores):
+        if score >= threshold:
+            x1, y1, x2, y2 = box
+            rect = plt.Rectangle(
+                (x1, y1), x2 - x1, y2 - y1, fill=False, color="red", linewidth=2
+            )
+            ax.add_patch(rect)
+            ax.text(x1, y1 - 10, f"{label}: {score:.2f}", color="red", fontsize=12)
+
+    plt.axis("off")
+    plt.title(title)
+    plt.show()
+
+
+draw_boxes(image, ref[0]["boxes"].cpu().numpy(), ref[0]["labels"].cpu().numpy(), labels, ref[0]["scores"].cpu().numpy(), threshold=0.5, title="Torch Detections")
+draw_boxes(image, res[0]["boxes"].cpu().numpy(), res[0]["labels"].cpu().numpy(), labels, res[0]["scores"].cpu().numpy(), threshold=0.5, title="Q.ANT Detections")

--- a/mlir/benchmarks/torch/model_zoo/fasterrcnn_resnet50.py
+++ b/mlir/benchmarks/torch/model_zoo/fasterrcnn_resnet50.py
@@ -1,6 +1,14 @@
 import torch
 import torchvision.models as models
 import time
+import os
+import sys
+
+# Use Agg backend for headless CI environments
+if os.environ.get('CI') or os.environ.get('GITHUB_ACTIONS'):
+    import matplotlib
+    matplotlib.use('Agg')
+
 import matplotlib.pyplot as plt
 import PIL.Image as Image
 import requests
@@ -45,9 +53,10 @@ image = Image.open(requests.get(url, stream=True).raw)
 input_tensor = transforms(image)
 input_batch = input_tensor.unsqueeze(0)  # create a mini-batch as expected by the model
 
-_ = plt.imshow(image)
-plt.title("Input Image")
-plt.axis("off")
+if not (os.environ.get('CI') or os.environ.get('GITHUB_ACTIONS')):
+    _ = plt.imshow(image)
+    plt.title("Input Image")
+    plt.axis("off")
 
 # Force dynamo (inference) backend
 with torch.no_grad():
@@ -65,44 +74,56 @@ with torch.no_grad():
     print(f"  First execution: {torch_exec_time:.4f} s")
 
     print("\n--- Results Comparison ---")
-    # Compare outputs
-    if torch.allclose(res[0]['boxes'], ref[0]['boxes'], rtol=1e-2):
+    # Compare outputs - these assertions will fail the test if results don't match
+    boxes_match = torch.allclose(res[0]['boxes'], ref[0]['boxes'], rtol=1e-2)
+    if boxes_match:
         print("✓ Boxes match between docc and torch")
     else:
         print("✗ Boxes differ with a relative difference of:")
         print((res[0]['boxes'] - ref[0]['boxes']) / ref[0]['boxes'])
-    
-    if torch.allclose(res[0]['scores'], ref[0]['scores'], rtol=1e-2):
+
+    scores_match = torch.allclose(res[0]['scores'], ref[0]['scores'], rtol=1e-2)
+    if scores_match:
         print("✓ Scores match between docc and torch")
     else:
         print("✗ Scores differ with a relative difference of:")
         print((res[0]['scores'] - ref[0]['scores']) / ref[0]['scores'])
-    
+
     print(f"\nDetected {len(res[0]['boxes'])} objects with docc")
     print(f"Detected {len(ref[0]['boxes'])} objects with torch inductor")
 
-
-# Draw the predicted bounding boxes
-def draw_boxes(image, boxes, classes ,labels, scores, threshold=0.4, title="Predicted Bounding Boxes"):
-    plt.figure(figsize=(8, 8))
-    plt.imshow(image)
-    ax = plt.gca()
-
-    box_labels = [labels[min(i, len(labels) - 1)] for i in classes]
-
-    for box, label, score in zip(boxes, box_labels, scores):
-        if score >= threshold:
-            x1, y1, x2, y2 = box
-            rect = plt.Rectangle(
-                (x1, y1), x2 - x1, y2 - y1, fill=False, color="red", linewidth=2
-            )
-            ax.add_patch(rect)
-            ax.text(x1, y1 - 10, f"{label}: {score:.2f}", color="red", fontsize=12)
-
-    plt.axis("off")
-    plt.title(title)
-    plt.show()
+    # Assert for CI - fail if results don't match
+    assert boxes_match, "Bounding boxes don't match between docc and torch inductor"
+    assert scores_match, "Detection scores don't match between docc and torch inductor"
+    print("\n✓ All assertions passed!")
 
 
-draw_boxes(image, ref[0]["boxes"].cpu().numpy(), ref[0]["labels"].cpu().numpy(), labels, ref[0]["scores"].cpu().numpy(), threshold=0.5, title="Torch Detections")
-draw_boxes(image, res[0]["boxes"].cpu().numpy(), res[0]["labels"].cpu().numpy(), labels, res[0]["scores"].cpu().numpy(), threshold=0.5, title="Q.ANT Detections")
+# Draw the predicted bounding boxes (only in interactive mode, not CI)
+if not (os.environ.get('CI') or os.environ.get('GITHUB_ACTIONS')):
+    # COCO labels for object detection
+    labels = weights.meta["categories"]
+
+    def draw_boxes(image, boxes, classes, labels, scores, threshold=0.4, title="Predicted Bounding Boxes"):
+        plt.figure(figsize=(8, 8))
+        plt.imshow(image)
+        ax = plt.gca()
+
+        box_labels = [labels[min(i, len(labels) - 1)] for i in classes]
+
+        for box, label, score in zip(boxes, box_labels, scores):
+            if score >= threshold:
+                x1, y1, x2, y2 = box
+                rect = plt.Rectangle(
+                    (x1, y1), x2 - x1, y2 - y1, fill=False, color="red", linewidth=2
+                )
+                ax.add_patch(rect)
+                ax.text(x1, y1 - 10, f"{label}: {score:.2f}", color="red", fontsize=12)
+
+        plt.axis("off")
+        plt.title(title)
+        plt.show()
+
+    draw_boxes(image, ref[0]["boxes"].cpu().numpy(), ref[0]["labels"].cpu().numpy(), labels, ref[0]["scores"].cpu().numpy(), threshold=0.5, title="Torch Detections")
+    draw_boxes(image, res[0]["boxes"].cpu().numpy(), res[0]["labels"].cpu().numpy(), labels, res[0]["scores"].cpu().numpy(), threshold=0.5, title="Q.ANT Detections")
+else:
+    print("\nSkipping visualization in CI environment")

--- a/mlir/lib/Target/SDFG/TensorToSDFGTranslator.cpp
+++ b/mlir/lib/Target/SDFG/TensorToSDFGTranslator.cpp
@@ -246,6 +246,163 @@ LogicalResult translateTensorExtractOp(SDFGTranslator& translator, tensor::Extra
     auto& tasklet = builder.add_tasklet(block, ::sdfg::data_flow::TaskletCode::assign, "_out", {"_in"}, deb_info);
     builder.add_computational_memlet(block, tensor_access, tasklet, "_in", subset, *sdfg_tensor, deb_info);
     builder.add_computational_memlet(block, tasklet, "_out", result_access, {}, deb_info);
+}
+
+LogicalResult translateTensorInsertSliceOp(SDFGTranslator& translator, tensor::InsertSliceOp* insert_slice_op) {
+    Value source = insert_slice_op->getSource();
+    Value dest = insert_slice_op->getDest();
+    Value result = insert_slice_op->getResult();
+
+    auto source_tensor_type = llvm::dyn_cast<TensorType>(source.getType());
+    auto dest_tensor_type = llvm::dyn_cast<TensorType>(dest.getType());
+    auto result_tensor_type = llvm::dyn_cast<TensorType>(result.getType());
+
+    // Get offsets, sizes, and strides
+    SmallVector<OpFoldResult> mixed_offsets = insert_slice_op->getMixedOffsets();
+    SmallVector<OpFoldResult> mixed_sizes = insert_slice_op->getMixedSizes();
+    SmallVector<OpFoldResult> mixed_strides = insert_slice_op->getMixedStrides();
+
+    // Convert to symbolic expressions
+    std::vector<::sdfg::symbolic::Expression> offsets, sizes, strides;
+    offsets.reserve(mixed_offsets.size());
+    sizes.reserve(mixed_sizes.size());
+    strides.reserve(mixed_strides.size());
+
+    for (const auto& offset : mixed_offsets) {
+        if (offset.is<Attribute>()) {
+            auto attr = mlir::cast<IntegerAttr>(offset.get<Attribute>());
+            offsets.push_back(::sdfg::symbolic::integer(attr.getInt()));
+        } else {
+            Value offset_val = offset.get<Value>();
+            offsets.push_back(::sdfg::symbolic::symbol(translator.get_or_create_container(offset_val)));
+        }
+    }
+
+    for (const auto& size : mixed_sizes) {
+        if (size.is<Attribute>()) {
+            auto attr = mlir::cast<IntegerAttr>(size.get<Attribute>());
+            sizes.push_back(::sdfg::symbolic::integer(attr.getInt()));
+        } else {
+            Value size_val = size.get<Value>();
+            sizes.push_back(::sdfg::symbolic::symbol(translator.get_or_create_container(size_val)));
+        }
+    }
+
+    for (const auto& stride : mixed_strides) {
+        if (stride.is<Attribute>()) {
+            auto attr = mlir::cast<IntegerAttr>(stride.get<Attribute>());
+            strides.push_back(::sdfg::symbolic::integer(attr.getInt()));
+        } else {
+            Value stride_val = stride.get<Value>();
+            strides.push_back(::sdfg::symbolic::symbol(translator.get_or_create_container(stride_val)));
+        }
+    }
+
+    auto& builder = translator.builder();
+    auto source_container = translator.get_or_create_container(source);
+    auto dest_container = translator.get_or_create_container(dest);
+    auto result_container = translator.get_or_create_container(result);
+
+    auto& source_tensor_info = translator.get_or_create_tensor_info(source_container, source_tensor_type);
+    auto& dest_tensor_info = translator.get_or_create_tensor_info(dest_container, dest_tensor_type);
+    auto& result_tensor_info = translator.get_or_create_tensor_info(result_container, result_tensor_type);
+
+    auto source_element_type = translator.convertType(source_tensor_type.getElementType());
+    auto source_sdfg_tensor =
+        source_tensor_info.get_sdfg_tensor(static_cast<::sdfg::types::Scalar&>(*source_element_type));
+    auto dest_element_type = translator.convertType(dest_tensor_type.getElementType());
+    auto dest_sdfg_tensor = dest_tensor_info.get_sdfg_tensor(static_cast<::sdfg::types::Scalar&>(*dest_element_type));
+    auto result_element_type = translator.convertType(result_tensor_type.getElementType());
+    auto result_sdfg_tensor =
+        result_tensor_info.get_sdfg_tensor(static_cast<::sdfg::types::Scalar&>(*result_element_type));
+
+    // Allocate result tensor
+    uint64_t size = 1;
+    for (int64_t dim : result_tensor_info.shape()) {
+        size *= dim;
+    }
+    translator.handle_malloc(
+        result_container,
+        ::sdfg::symbolic::mul(::sdfg::symbolic::integer(size), ::sdfg::symbolic::size_of_type(*result_element_type))
+    );
+
+    // Step 1: Copy destination to result (full copy)
+    ::sdfg::structured_control_flow::Sequence* current_seq = &translator.insertion_point();
+    std::vector<std::string> dest_indvars;
+    ::sdfg::data_flow::Subset dest_subset;
+    for (size_t i = 0; i < dest_tensor_info.shape().size(); i++) {
+        int64_t dim = dest_tensor_info.shape().at(i);
+        auto indvar_container = builder.find_new_name("_i");
+        builder.add_container(indvar_container, ::sdfg::types::Scalar(sdfg_index_type));
+        dest_indvars.push_back(indvar_container);
+        auto indvar = ::sdfg::symbolic::symbol(indvar_container);
+        dest_subset.push_back(indvar);
+        auto bound = ::sdfg::symbolic::integer(dim);
+        auto condition = ::sdfg::symbolic::Lt(indvar, bound);
+        auto init = ::sdfg::symbolic::zero();
+        auto update = ::sdfg::symbolic::add(indvar, ::sdfg::symbolic::one());
+
+        auto& map = builder.add_map(
+            *current_seq,
+            indvar,
+            condition,
+            init,
+            update,
+            ::sdfg::structured_control_flow::ScheduleType_Sequential::create()
+        );
+        current_seq = &map.root();
+    }
+
+    auto& dest_block = builder.add_block(*current_seq);
+    auto& dest_access = builder.add_access(dest_block, dest_container);
+    auto& result_access_1 = builder.add_access(dest_block, result_container);
+    auto& dest_tasklet = builder.add_tasklet(dest_block, ::sdfg::data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(dest_block, dest_access, dest_tasklet, "_in", dest_subset, *dest_sdfg_tensor);
+    builder
+        .add_computational_memlet(dest_block, dest_tasklet, "_out", result_access_1, dest_subset, *result_sdfg_tensor);
+
+    // Step 2: Insert source at offset
+    current_seq = &translator.insertion_point();
+    std::vector<std::string> source_indvars;
+    ::sdfg::data_flow::Subset source_subset;
+    ::sdfg::data_flow::Subset result_offset_subset;
+    for (size_t i = 0; i < source_tensor_info.shape().size(); i++) {
+        int64_t dim = source_tensor_info.shape().at(i);
+        auto indvar_container = builder.find_new_name("_j");
+        builder.add_container(indvar_container, ::sdfg::types::Scalar(sdfg_index_type));
+        source_indvars.push_back(indvar_container);
+        auto indvar = ::sdfg::symbolic::symbol(indvar_container);
+        source_subset.push_back(indvar);
+
+        // Calculate offset index: result[indvar * stride + offset] = source[indvar]
+        auto offset_idx = ::sdfg::symbolic::add(::sdfg::symbolic::mul(indvar, strides[i]), offsets[i]);
+        result_offset_subset.push_back(offset_idx);
+
+        auto bound = ::sdfg::symbolic::integer(dim);
+        auto condition = ::sdfg::symbolic::Lt(indvar, bound);
+        auto init = ::sdfg::symbolic::zero();
+        auto update = ::sdfg::symbolic::add(indvar, ::sdfg::symbolic::one());
+
+        auto& map = builder.add_map(
+            *current_seq,
+            indvar,
+            condition,
+            init,
+            update,
+            ::sdfg::structured_control_flow::ScheduleType_Sequential::create()
+        );
+        current_seq = &map.root();
+    }
+
+    auto& source_block = builder.add_block(*current_seq);
+    auto& source_access = builder.add_access(source_block, source_container);
+    auto& result_access_2 = builder.add_access(source_block, result_container);
+    auto& source_tasklet = builder.add_tasklet(source_block, ::sdfg::data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder
+        .add_computational_memlet(source_block, source_access, source_tasklet, "_in", source_subset, *source_sdfg_tensor);
+    builder.add_computational_memlet(
+        source_block, source_tasklet, "_out", result_access_2, result_offset_subset, *result_sdfg_tensor
+    );
 
     return success();
 }
@@ -438,6 +595,9 @@ LogicalResult translateTensorOp(SDFGTranslator& translator, Operation* op) {
         })
         .Case<tensor::ExtractOp>([&](tensor::ExtractOp extract_op) {
             return translateTensorExtractOp(translator, &extract_op);
+        })
+        .Case<tensor::InsertSliceOp>([&](tensor::InsertSliceOp insert_slice_op) {
+            return translateTensorInsertSliceOp(translator, &insert_slice_op);
         })
         .Case<tensor::PadOp>([&](tensor::PadOp pad_op) { return translateTensorPadOp(translator, &pad_op); })
         .Default([&](Operation* op) {

--- a/mlir/lib/Target/SDFG/TensorToSDFGTranslator.cpp
+++ b/mlir/lib/Target/SDFG/TensorToSDFGTranslator.cpp
@@ -246,6 +246,8 @@ LogicalResult translateTensorExtractOp(SDFGTranslator& translator, tensor::Extra
     auto& tasklet = builder.add_tasklet(block, ::sdfg::data_flow::TaskletCode::assign, "_out", {"_in"}, deb_info);
     builder.add_computational_memlet(block, tensor_access, tasklet, "_in", subset, *sdfg_tensor, deb_info);
     builder.add_computational_memlet(block, tasklet, "_out", result_access, {}, deb_info);
+
+    return success();
 }
 
 LogicalResult translateTensorInsertSliceOp(SDFGTranslator& translator, tensor::InsertSliceOp* insert_slice_op) {

--- a/sdfg/src/data_flow/library_nodes/load_const_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/load_const_node.cpp
@@ -92,8 +92,6 @@ data_flow::LibraryNode& LoadConstNodeSerializer::deserialize(
         throw InvalidSDFGException("Invalid library node code");
     }
 
-    std::cout << "Loading const node" << std::endl;
-
     sdfg::serializer::JSONSerializer serializer;
     DebugInfo debug_info = serializer.json_to_debug_info(j.at("debug_info"));
     std::unique_ptr<types::IType> type = serializer.json_to_type(j.at("load_type"));


### PR DESCRIPTION
- Adds tensor.insert_slice() support to the mlir frontend
- Adds a fasterrcnn_resnet50 benchmark to the repository. Only the backbone can be lowered to torch-mlir. Therefore, no harness and benchmarking infrastructure is used for this benchmark.