### PR TITLE
Fuse paddings into convolutions

### DIFF
--- a/mlir/benchmarks/torch/model_zoo/resnet18.py
+++ b/mlir/benchmarks/torch/model_zoo/resnet18.py
@@ -1,17 +1,154 @@
 import torch
+import torch.nn as nn
 import torchvision.models as models
-import pytest
+from functools import partial
 
 import docc.torch
 
+class Resnet18BasicBlock(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, stride: int = 1):
+        super().__init__()
+        self.conv1 = nn.Conv2d(in_channels, out_channels, kernel_size=(3, 3), stride=stride, padding=(1, 1), bias=False)
+        self.bn1 = nn.BatchNorm2d(out_channels, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
+        self.relu = nn.ReLU()
+        self.conv2 = nn.Conv2d(out_channels, out_channels, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
+        self.bn2 = nn.BatchNorm2d(out_channels, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
+        if in_channels == out_channels:
+            self.downsample = nn.Sequential()
+        else:
+            self.downsample = nn.Sequential(
+                nn.Conv2d(in_channels, out_channels, kernel_size=(1, 1), stride=stride, bias=False),
+                nn.BatchNorm2d(out_channels, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
+            )
+    def forward(self, x: torch.Tensor):
+        y = self.conv1(x)
+        y = self.bn1(y)
+        y = self.relu(y)
+        y = self.conv2(y)
+        y = self.bn2(y)
+        y += self.downsample(x)
+        return y
+
+class Resnet18Layer(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, stride: int):
+        super().__init__()
+        self.layer = nn.Sequential(
+            Resnet18BasicBlock(in_channels, out_channels, stride),
+            Resnet18BasicBlock(out_channels, out_channels)
+        )
+    def forward(self, x: torch.Tensor):
+        y = self.layer(x)
+        return y
+
+class Resnet18Begin(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False)
+        self.bn1 = nn.BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
+        self.relu = nn.ReLU()
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1, dilation=1, ceil_mode=False)
+    def forward(self, x: torch.Tensor):
+        y = self.conv1(x)
+        y = self.bn1(y)
+        y = self.relu(y)
+        y = self.maxpool(y)
+        return y
+
+class Resnet18End(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.avgpool = nn.AdaptiveAvgPool2d(output_size=(1, 1))
+        self.fc = nn.Linear(in_features=512, out_features=1000, bias=True)
+    def forward(self, x: torch.Tensor):
+        y = self.avgpool(x)
+        y = y.view(y.size(0), -1)
+        y = self.fc(y)
+        return y
+
+class Resnet18(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.begin = Resnet18Begin()
+        self.layer1 = Resnet18Layer(64, 64, 1)
+        self.layer2 = Resnet18Layer(64, 128, 2)
+        self.layer3 = Resnet18Layer(128, 256, 2)
+        self.layer4 = Resnet18Layer(256, 512, 2)
+        self.end = Resnet18End()
+    def forward(self, x: torch.Tensor):
+        y = self.begin(x)
+        y = self.layer1(y)
+        y = self.layer2(y)
+        y = self.layer3(y)
+        y = self.layer4(y)
+        y = self.end(y)
+        return y
+
+def setup_basicblock(in_channels: int, out_channels: int, stride: int, h: int, w: int):
+    model = Resnet18BasicBlock(in_channels, out_channels, stride)
+    model.eval()
+    x = torch.randn(32, in_channels, h, w)
+    return model, x
+
+def setup_layer(in_channels: int, out_channels: int, stride: int, h: int, w: int):
+    model = Resnet18Layer(in_channels, out_channels, stride)
+    model.eval()
+    x = torch.randn(32, in_channels, h, w)
+    return model, x
+
+def setup_begin():
+    model = Resnet18Begin()
+    model.eval()
+    x = torch.randn(32, 3, 224, 224)
+    return model, x
+
+def setup_end():
+    model = Resnet18End()
+    model.eval()
+    x = torch.randn(32, 512, 7, 7)
+    return model, x
+
+def setup_all():
+    model = Resnet18()
+    model.eval()
+    x = torch.randn(32, 3, 224, 224)
+    return model, x
+
 def setup():
-    """Return (eval-mode model, example_input) for ResNet-18 with random weights."""
     model = models.resnet18(weights=None)
     model.eval()
     x = torch.randn(32, 3, 224, 224)
     return model, x
 
+BENCHMARKS = {
+    "default": setup,
+    "begin": setup_begin,
+    "layer1_begin": partial(setup_basicblock, 64, 64, 1, 58, 58),
+    "layer1_end": partial(setup_basicblock, 64, 64, 1, 58, 58),
+    "layer1": partial(setup_layer, 64, 64, 1, 58, 58),
+    "layer2_begin": partial(setup_basicblock, 64, 128, 2, 58, 58),
+    "layer2_end": partial(setup_basicblock, 128, 128, 1, 30, 30),
+    "layer2": partial(setup_layer, 64, 128, 2, 58, 58),
+    "layer3_begin": partial(setup_basicblock, 128, 256, 2, 30, 30),
+    "layer3_end": partial(setup_basicblock, 256, 256, 1, 16, 16),
+    "layer3": partial(setup_layer, 128, 256, 2, 30, 30),
+    "layer4_begin": partial(setup_basicblock, 256, 512, 2, 16, 16),
+    "layer4_end": partial(setup_basicblock, 512, 512, 1, 9, 9),
+    "layer4": partial(setup_layer, 256, 512, 2, 16, 16),
+    "end": setup_end,
+    "all": setup_all,
+}
+
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="resnet18 benchmark")
+    parser.add_argument("--variant", type=str, choices=list(BENCHMARKS.keys()), default="default")
+    args, remaining = parser.parse_known_args()
+
+    import sys
+
+    sys.argv = [sys.argv[0]] + remaining
+
     from benchmarks.harness import run_benchmark
 
-    run_benchmark(setup, "resnet18")
+    run_benchmark(BENCHMARKS[args.variant], f"resnet18 {args.variant}")

--- a/mlir/bindings/bindings.cpp
+++ b/mlir/bindings/bindings.cpp
@@ -77,6 +77,7 @@ public:
         mlir::PassManager pm(context_.get());
         pm.addPass(mlir::createLinalgCustomSpecializeGenericOpsPass());
         pm.addPass(mlir::createLinalgCustomRemoveRedundantOpsPass());
+        pm.addPass(mlir::createLinalgCustomFuseConvPaddingPass());
         if (mlir::failed(pm.run(*module_))) {
             throw std::runtime_error("Failed to convert MLIR module");
         }

--- a/mlir/include/mlir/Dialect/Linalg/CustomPasses.td
+++ b/mlir/include/mlir/Dialect/Linalg/CustomPasses.td
@@ -21,4 +21,14 @@ def LinalgCustomRemoveRedundantOpsPass : Pass<"linalg-custom-remove-redundant-op
     ];
 }
 
+def LinalgCustomFuseConvPaddingPass : Pass<"linalg-custom-fuse-conv-padding"> {
+    let summary = "Fuse tensor.pad operations into convolutions (custom DOCC MLIR pass)";
+    let dependentDialects = [
+        "arith::ArithDialect",
+        "linalg::LinalgDialect",
+        "linalg::custom::LinalgCustomDialect",
+        "tensor::TensorDialect"
+    ];
+}
+
 #endif // MLIR_DIALECT_LINALG_CUSTOM_PASSES

--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgCustomOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgCustomOps.td
@@ -1,6 +1,7 @@
 #ifndef LINALG_CUSTOM_OPS
 #define LINALG_CUSTOM_OPS
 
+include "mlir/IR/BuiltinAttributeInterfaces.td"
 include "mlir/IR/OpBase.td"
 
 def LinalgCustom_Dialect : Dialect {
@@ -67,6 +68,27 @@ def LinalgCustom_BatchNorm2DNchwOp : LinalgCustom_Op<"batchnorm_2d_nchw",
             `:`
             type($batch) `,` type($e) `,` type($var) `,` type($gamma) `,` type($beta) `,` type($eps)
         `)`
+        `outs` `(` $output `:` type($output) `)`
+        `->` type($result)
+    }];
+    let hasVerifier = 1;
+}
+
+def LinalgCustom_Conv2DNchwFchwOp : LinalgCustom_Op<"conv_2d_nchw_fchw",
+        [PredOpTrait<"element types must be the same", TCopVTEtAreSameAt<[0, 1, 2]>>]> {
+    let summary = "Performs 2-D convolution.";
+
+    let arguments = (ins TensorRankOf<[AnyType], [4]>:$input,
+                         TensorRankOf<[AnyType], [4]>:$weights,
+                         Optional<TensorRankOf<[AnyType], [1]>>:$bias,
+                         TensorRankOf<[AnyType], [4]>:$output,
+                         DenseI64ArrayAttr:$strides,
+                         DenseI64ArrayAttr:$dilations,
+                         DenseI64ArrayAttr:$paddings);
+    let results = (outs TensorRankOf<[AnyType], [4]>:$result);
+    let assemblyFormat = [{
+        attr-dict
+        `ins` `(` $input `,` $weights (`,` $bias^)? `:` type($input) `,` type($weights) (`,` type($bias)^)? `)`
         `outs` `(` $output `:` type($output) `)`
         `->` type($result)
     }];

--- a/mlir/include/mlir/Dialect/Linalg/Transforms/CustomTransforms.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/CustomTransforms.h
@@ -9,5 +9,7 @@ void populateLinalgCustomSpecializeGenericOpsPass(RewritePatternSet& patterns);
 
 void populateLinalgCustomRemoveRedundantOpsPass(RewritePatternSet& patterns);
 
+void populateLinalgCustomFuseConvPaddingPass(RewritePatternSet& patterns);
+
 } // namespace linalg
 } // namespace mlir

--- a/mlir/lib/Dialect/Linalg/IR/LinalgCustomOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgCustomOps.cpp
@@ -53,12 +53,12 @@ LogicalResult SigmoidOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult BatchNorm2DNchwOp::verify() {
-    RankedTensorType batchType = llvm::cast<RankedTensorType>(this->getBatch().getType());
-    RankedTensorType eType = llvm::cast<RankedTensorType>(this->getE().getType());
-    RankedTensorType varType = llvm::cast<RankedTensorType>(this->getVar().getType());
-    RankedTensorType gammaType = llvm::cast<RankedTensorType>(this->getGamma().getType());
-    RankedTensorType betaType = llvm::cast<RankedTensorType>(this->getBeta().getType());
-    RankedTensorType outputType = llvm::cast<RankedTensorType>(this->getOutput().getType());
+    RankedTensorType batchType = this->getBatch().getType();
+    RankedTensorType eType = this->getE().getType();
+    RankedTensorType varType = this->getVar().getType();
+    RankedTensorType gammaType = this->getGamma().getType();
+    RankedTensorType betaType = this->getBeta().getType();
+    RankedTensorType outputType = this->getOutput().getType();
 
     ArrayRef<int64_t> batchShape = batchType.getShape();
     ArrayRef<int64_t> eShape = eType.getShape();
@@ -83,6 +83,59 @@ LogicalResult BatchNorm2DNchwOp::verify() {
     }
     if (betaShape[0] != c) {
         return this->emitOpError("incompatible beta shape");
+    }
+
+    return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Conv2DNchwFchwOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult Conv2DNchwFchwOp::verify() {
+    RankedTensorType inputType = this->getInput().getType();
+    RankedTensorType weightsType = this->getWeights().getType();
+    RankedTensorType outputType = this->getOutput().getType();
+
+    if (inputType.getDimSize(0) != outputType.getDimSize(0)) {
+        return this->emitOpError("incompatible N shape");
+    }
+    if (inputType.getDimSize(1) != weightsType.getDimSize(1)) {
+        return this->emitOpError("incompatible C shape");
+    }
+    if (weightsType.getDimSize(0) != outputType.getDimSize(1)) {
+        return this->emitOpError("incompatible F shape");
+    }
+    if (this->getBias()) {
+        RankedTensorType biasType = this->getBias().getType();
+        if (weightsType.getDimSize(0) != biasType.getDimSize(0)) {
+            return this->emitOpError("incompatible F shape");
+        }
+    }
+
+    if (this->getStrides().size() != 2) {
+        return this->emitOpError("must have exactly two stride values");
+    }
+    if (this->getDilations().size() != 2) {
+        return this->emitOpError("must have exactly two dialtion values");
+    }
+    if (this->getPaddings().size() != 4) {
+        return this->emitOpError("must have exactly four padding values");
+    }
+
+    int64_t Ho = (inputType.getDimSize(2) + this->getPaddings()[0] + this->getPaddings()[2] -
+                  this->getDilations()[0] * (weightsType.getDimSize(2) - 1) - 1) /
+                     this->getStrides()[0] +
+                 1;
+    int64_t Wo = (inputType.getDimSize(3) + this->getPaddings()[1] + this->getPaddings()[3] -
+                  this->getDilations()[1] * (weightsType.getDimSize(3) - 1) - 1) /
+                     this->getStrides()[1] +
+                 1;
+    if (Ho != outputType.getDimSize(2)) {
+        return this->emitOpError("output height should be ") << Ho;
+    }
+    if (Wo != outputType.getDimSize(3)) {
+        return this->emitOpError("output width should be ") << Wo;
     }
 
     return success();

--- a/mlir/lib/Dialect/Linalg/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Linalg/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_dialect_library(MLIRLinalgCustomTransforms
+    CustomFuseConvPadding.cpp
     CustomRemoveRedundant.cpp
     CustomSpecialize.cpp
     CustomSpecializeBatchNorm.cpp

--- a/mlir/lib/Dialect/Linalg/Transforms/CustomFuseConvPadding.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/CustomFuseConvPadding.cpp
@@ -1,0 +1,148 @@
+#include <cstdint>
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgCustomOps.h"
+#include "mlir/Dialect/Linalg/Transforms/CustomTransforms.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+#define GEN_PASS_DEF_LINALGCUSTOMFUSECONVPADDINGPASS
+#include "mlir/Dialect/Linalg/CustomPasses.h.inc"
+
+namespace linalg {
+
+struct FusePaddingIntoConv2DNchwFchw : OpRewritePattern<Conv2DNchwFchwOp> {
+    using OpRewritePattern<Conv2DNchwFchwOp>::OpRewritePattern;
+
+    bool broadcastOpIsConvBias(BroadcastOp broadcast_op) const {
+        auto dims = broadcast_op.getDimensions();
+        if (dims.size() != 3 || dims[0] != 0 || dims[1] != 2 || dims[2] != 3) {
+            return false;
+        }
+
+        auto biasShape = broadcast_op.getInput().getType().getShape();
+        auto outputShape = broadcast_op.getInit().getType().getShape();
+        if (biasShape.size() != 1 || outputShape.size() != 4 || biasShape[0] != outputShape[1]) {
+            return false;
+        }
+
+        return true;
+    }
+
+    LogicalResult matchAndRewrite(Conv2DNchwFchwOp conv_op, PatternRewriter& rewriter) const override {
+        // Check and get values
+        if (conv_op.getInputs().size() != 2) {
+            return failure();
+        }
+        if (conv_op.getOutputs().size() != 1) {
+            return failure();
+        }
+        if (conv_op.getResults().size() != 1) {
+            return failure();
+        }
+        Type resultType = conv_op.getResults()[0].getType();
+        Value input = conv_op.getInputs()[0];
+        Value weights = conv_op.getInputs()[1];
+        Value bias;
+        Value output = conv_op.getOutputs()[0];
+
+        // Check padding operation
+        auto pad_op = llvm::dyn_cast_or_null<tensor::PadOp>(input.getDefiningOp());
+        if (!pad_op || pad_op.getStaticLow().size() != 4 || pad_op.getStaticLow()[0] != 0 ||
+            pad_op.getStaticLow()[1] != 0 || pad_op.getStaticLow()[2] == INT64_MIN ||
+            pad_op.getStaticLow()[3] == INT64_MIN || pad_op.getStaticHigh().size() != 4 ||
+            pad_op.getStaticHigh()[0] != 0 || pad_op.getStaticHigh()[1] != 0 ||
+            pad_op.getStaticHigh()[2] == INT64_MIN || pad_op.getStaticHigh()[3] == INT64_MIN ||
+            pad_op.getRegion().getBlocks().size() != 1) {
+            return failure();
+        }
+        auto& block = pad_op.getRegion().getBlocks().front();
+        if (block.getOperations().size() != 1) {
+            return failure();
+        }
+        auto yield_op = llvm::dyn_cast_or_null<tensor::YieldOp>(block.getOperations().front());
+        if (!yield_op) {
+            return failure();
+        }
+
+        // Check that padding is performed with a zero
+        auto constant_op = llvm::dyn_cast_or_null<arith::ConstantOp>(yield_op.getValue().getDefiningOp());
+        if (!constant_op) {
+            return failure();
+        }
+        if (auto float_attr = llvm::dyn_cast<FloatAttr>(constant_op.getValue())) {
+            if (float_attr.getValueAsDouble() != 0.0) {
+                return failure();
+            }
+        } else if (auto integer_attr = llvm::dyn_cast<IntegerAttr>(constant_op.getValue())) {
+            if (integer_attr.getUInt() != 0) {
+                return failure();
+            }
+        } else {
+            return failure();
+        }
+
+        // Remap the input to the un-padded value
+        input = pad_op.getSource();
+
+        // Check if the output is a broadcasted value
+        if (auto broadcast_op = llvm::dyn_cast_or_null<BroadcastOp>(output.getDefiningOp())) {
+            if (this->broadcastOpIsConvBias(broadcast_op)) {
+                // Add bias & remap output
+                bias = broadcast_op.getInput();
+                output = broadcast_op.getInit();
+            }
+        }
+
+        // Copy the padding values
+        SmallVector<int64_t> paddings;
+        paddings.push_back(pad_op.getStaticLow()[2]);
+        paddings.push_back(pad_op.getStaticLow()[3]);
+        paddings.push_back(pad_op.getStaticHigh()[2]);
+        paddings.push_back(pad_op.getStaticHigh()[3]);
+
+        // Copy strides and dilations
+        SmallVector<int64_t> strides, dilations;
+        for (int64_t stride : conv_op.getStrides().getValues<int64_t>()) {
+            strides.push_back(stride);
+        }
+        for (int64_t dilation : conv_op.getDilations().getValues<int64_t>()) {
+            dilations.push_back(dilation);
+        }
+        auto strides_attr = DenseI64ArrayAttr::get(this->getContext(), strides);
+        auto dilations_attr = DenseI64ArrayAttr::get(this->getContext(), dilations);
+        auto paddings_attr = DenseI64ArrayAttr::get(this->getContext(), paddings);
+
+        // Create the custom convolution with paddings
+        rewriter.replaceOpWithNewOp<custom::Conv2DNchwFchwOp>(
+            conv_op, resultType, input, weights, bias, output, strides_attr, dilations_attr, paddings_attr
+        );
+
+        return success();
+    }
+};
+
+struct LinalgCustomFuseConvPaddingPass
+    : public impl::LinalgCustomFuseConvPaddingPassBase<LinalgCustomFuseConvPaddingPass> {
+    using LinalgCustomFuseConvPaddingPassBase::LinalgCustomFuseConvPaddingPassBase;
+
+    void runOnOperation() override {
+        mlir::RewritePatternSet patterns(&this->getContext());
+        populateLinalgCustomFuseConvPaddingPass(patterns);
+        if (failed(applyPatternsAndFoldGreedily(this->getOperation(), std::move(patterns)))) {
+            this->signalPassFailure();
+        }
+    }
+};
+
+void populateLinalgCustomFuseConvPaddingPass(RewritePatternSet& patterns) {
+    patterns.add<FusePaddingIntoConv2DNchwFchw>(patterns.getContext());
+}
+
+} // namespace linalg
+} // namespace mlir

--- a/mlir/lib/Target/SDFG/LinalgToSDFGTranslator.cpp
+++ b/mlir/lib/Target/SDFG/LinalgToSDFGTranslator.cpp
@@ -560,6 +560,85 @@ translateLinalgCustomBatchNorm2DNchw(SDFGTranslator& translator, linalg::custom:
     return success();
 }
 
+LogicalResult translateLinalgCustomConv2DNchwFchwOp(SDFGTranslator& translator, linalg::custom::Conv2DNchwFchwOp* conv_op) {
+    auto input = conv_op->getInput();
+    auto weights = conv_op->getWeights();
+    auto bias = conv_op->getBias();
+    auto output = conv_op->getOutput();
+    auto result = conv_op->getResult();
+    auto deb_info = translator.get_debug_info(conv_op->getOperationName(), conv_op->getLoc());
+
+    auto& builder = translator.builder();
+    auto input_container = translator.get_or_create_container(input);
+    auto weights_container = translator.get_or_create_container(weights);
+    auto output_container = translator.get_or_copy_output_container(output, deb_info);
+    auto result_container = translator.get_or_create_container(result);
+
+    auto input_tensor_info = translator.get_or_create_tensor_info(input_container, input.getType());
+    auto input_element_type = translator.convertType(input.getType().getElementType());
+    auto input_sdfg_tensor = input_tensor_info.get_sdfg_tensor(static_cast<::sdfg::types::Scalar&>(*input_element_type)
+    );
+
+    auto weights_tensor_info = translator.get_or_create_tensor_info(weights_container, weights.getType());
+    auto weights_element_type = translator.convertType(weights.getType().getElementType());
+    auto weights_sdfg_tensor =
+        weights_tensor_info.get_sdfg_tensor(static_cast<::sdfg::types::Scalar&>(*weights_element_type));
+
+    auto result_tensor_info = translator.get_or_create_tensor_info(result_container, result.getType());
+    auto result_element_type = translator.convertType(result.getType().getElementType());
+    auto result_sdfg_tensor =
+        result_tensor_info.get_sdfg_tensor(static_cast<::sdfg::types::Scalar&>(*result_element_type));
+
+    translator.add_reference(output_container, result_container, deb_info);
+
+    ::sdfg::symbolic::MultiExpression shape;
+    for (int64_t dim : input.getType().getShape()) {
+        shape.push_back(::sdfg::symbolic::integer(dim));
+    }
+    ::sdfg::symbolic::MultiExpression kernel_shape;
+    kernel_shape.push_back(::sdfg::symbolic::integer(weights.getType().getShape()[2]));
+    kernel_shape.push_back(::sdfg::symbolic::integer(weights.getType().getShape()[3]));
+    ::sdfg::symbolic::MultiExpression strides;
+    for (int64_t stride : conv_op->getStrides()) {
+        strides.push_back(::sdfg::symbolic::integer(stride));
+    }
+    ::sdfg::symbolic::MultiExpression pads;
+    for (int64_t padding : conv_op->getPaddings()) {
+        pads.push_back(::sdfg::symbolic::integer(padding));
+    }
+    ::sdfg::symbolic::MultiExpression dilations;
+    for (int64_t dilation : conv_op->getDilations()) {
+        dilations.push_back(::sdfg::symbolic::integer(dilation));
+    }
+    ::sdfg::symbolic::Expression output_channels = ::sdfg::symbolic::integer(weights.getType().getShape()[0]);
+    ::sdfg::symbolic::Expression group = ::sdfg::symbolic::one();
+
+    auto& block = builder.add_block(translator.insertion_point(), {}, deb_info);
+    auto& input_access = builder.add_access(block, input_container, deb_info);
+    auto& weights_access = builder.add_access(block, weights_container, deb_info);
+    auto& result_access = builder.add_access(block, result_container, deb_info);
+    auto& libnode = builder.add_library_node<::sdfg::math::tensor::ConvNode>(
+        block, deb_info, shape, kernel_shape, strides, pads, dilations, output_channels, group
+    );
+    builder.add_computational_memlet(block, input_access, libnode, "X", {}, *input_sdfg_tensor, deb_info);
+    builder.add_computational_memlet(block, weights_access, libnode, "W", {}, *weights_sdfg_tensor, deb_info);
+    builder.add_computational_memlet(block, libnode, "Y", result_access, {}, *result_sdfg_tensor, deb_info);
+
+    if (bias) {
+        auto bias_container = translator.get_or_create_container(bias);
+
+        auto bias_tensor_info = translator.get_or_create_tensor_info(bias_container, bias.getType());
+        auto bias_element_type = translator.convertType(bias.getType().getElementType());
+        auto bias_sdfg_tensor = bias_tensor_info.get_sdfg_tensor(static_cast<::sdfg::types::Scalar&>(*bias_element_type)
+        );
+
+        auto& bias_access = builder.add_access(block, bias_container, deb_info);
+        builder.add_computational_memlet(block, bias_access, libnode, "B", {}, *bias_sdfg_tensor, deb_info);
+    }
+
+    return success();
+}
+
 template<typename PoolOp>
 LogicalResult translateLinalgPoolingNchwOp(SDFGTranslator& translator, PoolOp* op, ::sdfg::math::tensor::PoolingMode mode);
 
@@ -685,6 +764,9 @@ LogicalResult translateLinalgOp(SDFGTranslator& translator, Operation* op) {
         })
         .Case<linalg::custom::BatchNorm2DNchwOp>([&](linalg::custom::BatchNorm2DNchwOp batch_norm_op) {
             return translateLinalgCustomBatchNorm2DNchw(translator, &batch_norm_op);
+        })
+        .Case<linalg::custom::Conv2DNchwFchwOp>([&](linalg::custom::Conv2DNchwFchwOp conv_op) {
+            return translateLinalgCustomConv2DNchwFchwOp(translator, &conv_op);
         })
         .Default([&](Operation* op) {
             return op->emitError("Unknown operation from linalg dialect encountered: ") << op->getName();

--- a/sdfg/src/data_flow/library_nodes/math/tensor/conv_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/conv_node.cpp
@@ -248,21 +248,6 @@ bool ConvNode::expand(builder::StructuredSDFGBuilder& builder, analysis::Analysi
             );
         }
 
-        // Memset patches to zero
-        auto& patches_memset_block = builder.add_block(new_sequence, {}, block->debug_info());
-        {
-            auto& patches_access = builder.add_access(patches_memset_block, patches_container, this->debug_info());
-            auto& libnode = builder.add_library_node<stdlib::MemsetNode>(
-                patches_memset_block,
-                this->debug_info(),
-                symbolic::zero(),
-                symbolic::mul(patches_size, symbolic::size_of_type(base_type))
-            );
-            builder.add_computational_memlet(
-                patches_memset_block, libnode, "_ptr", patches_access, {}, patches_type, this->debug_info()
-            );
-        }
-
         // Add malloc for temporary GEMM output
         symbolic::Expression tmp_Y_size = symbolic::mul(this->output_channels_, this->shape_[0]);
         for (size_t i = 0; i < dims; i++) {
@@ -341,21 +326,15 @@ bool ConvNode::expand(builder::StructuredSDFGBuilder& builder, analysis::Analysi
         // Add loops over kernel shape
         symbolic::SymbolVec ks;
         ks.reserve(dims);
-        symbolic::MultiExpression is;
-        is.reserve(dims);
         for (size_t i = 0; i < dims; i++) {
             auto k_container = builder.find_new_name("_k");
             builder.add_container(k_container, indvar_type);
             auto k = symbolic::symbol(k_container);
             ks.push_back(k);
-            auto i_expr = symbolic::
-                add(symbolic::sub(symbolic::mul(os[i], this->strides_[i]), this->pads_[i]),
-                    symbolic::mul(k, this->dilations_[i]));
-            is.push_back(i_expr);
             auto& loop_k = builder.add_map(
                 *current_seq,
                 k,
-                symbolic::And(symbolic::Lt(k, this->kernel_shape_[i]), symbolic::Lt(i_expr, this->shape_[i + 2])),
+                symbolic::Lt(k, this->kernel_shape_[i]),
                 symbolic::zero(),
                 symbolic::add(k, symbolic::one()),
                 ScheduleType_Sequential::create(),
@@ -364,6 +343,27 @@ bool ConvNode::expand(builder::StructuredSDFGBuilder& builder, analysis::Analysi
             );
             current_seq = &loop_k.root();
         }
+
+        // Add if/else to stay in bounds for copying
+        symbolic::MultiExpression is;
+        is.reserve(dims);
+        symbolic::Condition copy_condition = symbolic::__true__();
+        symbolic::Condition zero_condition = symbolic::__false__();
+        for (size_t i = 0; i < dims; i++) {
+            auto i_expr = symbolic::
+                add(symbolic::sub(symbolic::mul(os[i], this->strides_[i]), this->pads_[i]),
+                    symbolic::mul(ks[i], this->dilations_[i]));
+            is.push_back(i_expr);
+            copy_condition = symbolic::
+                And(copy_condition,
+                    symbolic::And(symbolic::Lt(i_expr, this->shape_[i + 2]), symbolic::Ge(i_expr, symbolic::zero())));
+            zero_condition = symbolic::
+                Or(zero_condition,
+                   symbolic::Or(symbolic::Ge(i_expr, this->shape_[i + 2]), symbolic::Lt(i_expr, symbolic::zero())));
+        }
+        auto& branch = builder.add_if_else(*current_seq, {}, block->debug_info());
+        auto& copy_case = builder.add_case(branch, copy_condition, block->debug_info());
+        auto& zero_case = builder.add_case(branch, zero_condition, block->debug_info());
 
         // Determine patches subset & tensor type
         data_flow::Subset patches_subset;
@@ -385,17 +385,31 @@ bool ConvNode::expand(builder::StructuredSDFGBuilder& builder, analysis::Analysi
         subset_X.insert(subset_X.end(), is.begin(), is.end());
 
         // Add copy from X to patches
-        auto& true_block = builder.add_block(*current_seq, {}, block->debug_info());
+        auto& copy_block = builder.add_block(copy_case, {}, block->debug_info());
         {
-            auto& X_access = builder.add_access(true_block, access_X->data(), access_X->debug_info());
-            auto& patches_access = builder.add_access(true_block, patches_container, this->debug_info());
+            auto& X_access = builder.add_access(copy_block, access_X->data(), access_X->debug_info());
+            auto& patches_access = builder.add_access(copy_block, patches_container, this->debug_info());
             auto& tasklet =
-                builder.add_tasklet(true_block, data_flow::TaskletCode::assign, "_out", {"_in"}, this->debug_info());
+                builder.add_tasklet(copy_block, data_flow::TaskletCode::assign, "_out", {"_in"}, this->debug_info());
             builder.add_computational_memlet(
-                true_block, X_access, tasklet, "_in", subset_X, iedge_X->base_type(), iedge_X->debug_info()
+                copy_block, X_access, tasklet, "_in", subset_X, iedge_X->base_type(), iedge_X->debug_info()
             );
             builder.add_computational_memlet(
-                true_block, tasklet, "_out", patches_access, patches_subset, patches_tensor_type, this->debug_info()
+                copy_block, tasklet, "_out", patches_access, patches_subset, patches_tensor_type, this->debug_info()
+            );
+        }
+
+        // Add zero assignment to patches
+        auto& zero_block = builder.add_block(zero_case, {}, block->debug_info());
+        {
+            auto& constant_zero = builder.add_constant(zero_block, "0.0", base_type, this->debug_info());
+            auto& patches_access = builder.add_access(zero_block, patches_container, this->debug_info());
+            auto& tasklet =
+                builder.add_tasklet(zero_block, data_flow::TaskletCode::assign, "_out", {"_in"}, this->debug_info());
+            builder
+                .add_computational_memlet(zero_block, constant_zero, tasklet, "_in", {}, base_type, this->debug_info());
+            builder.add_computational_memlet(
+                zero_block, tasklet, "_out", patches_access, patches_subset, patches_tensor_type, this->debug_info()
             );
         }
 
@@ -630,21 +644,6 @@ bool ConvNode::expand(builder::StructuredSDFGBuilder& builder, analysis::Analysi
             );
         }
 
-        // Memset patches to zero
-        auto& patches_memset_block = builder.add_block(loop_g.root(), {}, block->debug_info());
-        {
-            auto& patches_access = builder.add_access(patches_memset_block, patches_container, this->debug_info());
-            auto& libnode = builder.add_library_node<stdlib::MemsetNode>(
-                patches_memset_block,
-                this->debug_info(),
-                symbolic::zero(),
-                symbolic::mul(patches_size, symbolic::size_of_type(base_type))
-            );
-            builder.add_computational_memlet(
-                patches_memset_block, libnode, "_ptr", patches_access, {}, patches_type, this->debug_info()
-            );
-        }
-
         // Add loops over output dimensions
         structured_control_flow::Sequence* current_seq = &loop_g.root();
         symbolic::SymbolVec os;
@@ -686,21 +685,15 @@ bool ConvNode::expand(builder::StructuredSDFGBuilder& builder, analysis::Analysi
         // Add loops over kernel shape
         symbolic::SymbolVec ks;
         ks.reserve(dims);
-        symbolic::MultiExpression is;
-        is.reserve(dims);
         for (size_t i = 0; i < dims; i++) {
             auto k_container = builder.find_new_name("_k");
             builder.add_container(k_container, indvar_type);
             auto k = symbolic::symbol(k_container);
             ks.push_back(k);
-            auto i_expr = symbolic::
-                add(symbolic::sub(symbolic::mul(os[i], this->strides_[i]), this->pads_[i]),
-                    symbolic::mul(k, this->dilations_[i]));
-            is.push_back(i_expr);
             auto& loop_k = builder.add_map(
                 *current_seq,
                 k,
-                symbolic::And(symbolic::Lt(k, this->kernel_shape_[i]), symbolic::Lt(i_expr, this->shape_[i + 2])),
+                symbolic::Lt(k, this->kernel_shape_[i]),
                 symbolic::zero(),
                 symbolic::add(k, symbolic::one()),
                 ScheduleType_Sequential::create(),
@@ -709,6 +702,27 @@ bool ConvNode::expand(builder::StructuredSDFGBuilder& builder, analysis::Analysi
             );
             current_seq = &loop_k.root();
         }
+
+        // Add if/else to stay in bounds for copying
+        symbolic::MultiExpression is;
+        is.reserve(dims);
+        symbolic::Condition copy_condition = symbolic::__true__();
+        symbolic::Condition zero_condition = symbolic::__false__();
+        for (size_t i = 0; i < dims; i++) {
+            auto i_expr = symbolic::
+                add(symbolic::sub(symbolic::mul(os[i], this->strides_[i]), this->pads_[i]),
+                    symbolic::mul(ks[i], this->dilations_[i]));
+            is.push_back(i_expr);
+            copy_condition = symbolic::
+                And(copy_condition,
+                    symbolic::And(symbolic::Lt(i_expr, this->shape_[i + 2]), symbolic::Ge(i_expr, symbolic::zero())));
+            zero_condition = symbolic::
+                Or(zero_condition,
+                   symbolic::Or(symbolic::Ge(i_expr, this->shape_[i + 2]), symbolic::Lt(i_expr, symbolic::zero())));
+        }
+        auto& branch = builder.add_if_else(*current_seq, {}, block->debug_info());
+        auto& copy_case = builder.add_case(branch, copy_condition, block->debug_info());
+        auto& zero_case = builder.add_case(branch, zero_condition, block->debug_info());
 
         // Determine patches subset & tensor type
         data_flow::Subset patches_subset;
@@ -728,17 +742,31 @@ bool ConvNode::expand(builder::StructuredSDFGBuilder& builder, analysis::Analysi
         subset_X.insert(subset_X.end(), is.begin(), is.end());
 
         // Add copy from X to patches
-        auto& true_block = builder.add_block(*current_seq, {}, block->debug_info());
+        auto& copy_block = builder.add_block(copy_case, {}, block->debug_info());
         {
-            auto& X_access = builder.add_access(true_block, access_X->data(), access_X->debug_info());
-            auto& patches_access = builder.add_access(true_block, patches_container, this->debug_info());
+            auto& X_access = builder.add_access(copy_block, access_X->data(), access_X->debug_info());
+            auto& patches_access = builder.add_access(copy_block, patches_container, this->debug_info());
             auto& tasklet =
-                builder.add_tasklet(true_block, data_flow::TaskletCode::assign, "_out", {"_in"}, this->debug_info());
+                builder.add_tasklet(copy_block, data_flow::TaskletCode::assign, "_out", {"_in"}, this->debug_info());
             builder.add_computational_memlet(
-                true_block, X_access, tasklet, "_in", subset_X, iedge_X->base_type(), iedge_X->debug_info()
+                copy_block, X_access, tasklet, "_in", subset_X, iedge_X->base_type(), iedge_X->debug_info()
             );
             builder.add_computational_memlet(
-                true_block, tasklet, "_out", patches_access, patches_subset, patches_tensor_type, this->debug_info()
+                copy_block, tasklet, "_out", patches_access, patches_subset, patches_tensor_type, this->debug_info()
+            );
+        }
+
+        // Add zero assignment to patches
+        auto& zero_block = builder.add_block(zero_case, {}, block->debug_info());
+        {
+            auto& constant_zero = builder.add_constant(zero_block, "0.0", base_type, this->debug_info());
+            auto& patches_access = builder.add_access(zero_block, patches_container, this->debug_info());
+            auto& tasklet =
+                builder.add_tasklet(zero_block, data_flow::TaskletCode::assign, "_out", {"_in"}, this->debug_info());
+            builder
+                .add_computational_memlet(zero_block, constant_zero, tasklet, "_in", {}, base_type, this->debug_info());
+            builder.add_computational_memlet(
+                zero_block, tasklet, "_out", patches_access, patches_subset, patches_tensor_type, this->debug_info()
             );
         }
 


### PR DESCRIPTION
- Added new convolution node that has a padding attribute
- Added a MLIR pass that fuses a padding node into a convolution by creating the new convolution node and setting the padding attribute
- Fixed the expand method of the SDFG convolution node to correctly support padding
- Added partial resnet18 nets to the resnet18 benchmark