### PR TITLE
Data flow transfer elimination

### DIFF
--- a/opt/CMakeLists.txt
+++ b/opt/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(ISL REQUIRED IMPORTED_TARGET isl)
 
 set(SOURCE_FILES
+    src/analysis/data_transfer_elimination_analysis.cpp
     src/passes/einsum.cpp
     src/passes/normalization/loop_normal_form.cpp
     src/passes/normalization/perfect_loop_distribution.cpp

--- a/opt/include/sdfg/analysis/data_transfer_elimination_analysis.h
+++ b/opt/include/sdfg/analysis/data_transfer_elimination_analysis.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include "sdfg/analysis/base_user_visitor.h"
+#include "sdfg/analysis/pointer_analyzers.h"
+#include "sdfg/analysis/structured_data_flow_analysis.h"
+#include "sdfg/data_flow/library_node.h"
+#include "sdfg/targets/offloading/data_offloading_node.h"
+
+namespace sdfg::analysis {
+
+class ForwardingEscapePolicy {
+protected:
+
+public:
+    virtual void on_escape(const std::string& container, const ControlFlowNode* node, const Element* user) = 0;
+    virtual void on_write_via(const std::string& container, const ControlFlowNode* node, const data_flow::Memlet* user) = 0;
+    virtual void on_read_via(const std::string& container, const ControlFlowNode* node, const data_flow::Memlet* user) = 0;
+};
+
+struct OffloadHolder {
+    offloading::DataOffloadingNode* node;
+    const data_flow::AccessNode* host_data;
+    const data_flow::Memlet* host_access;
+    const data_flow::AccessNode* dev_data;
+};
+
+struct ExposedOffload {
+    OffloadHolder* offload;
+    int read_count = 0;
+};
+
+class DataTransferEliminationCandidateCollector {
+protected:
+    std::vector<std::pair<ExposedOffload, OffloadHolder>> candidates_;
+
+public:
+    void found_candidate_pair(const ExposedOffload& src, const OffloadHolder& dst) {
+        candidates_.emplace_back(src, dst);
+    }
+
+    const std::vector<std::pair<ExposedOffload, OffloadHolder>>& candidates() const { return candidates_; }
+};
+
+struct OffloadState : public ElementIdMapDataFlowState<ExposedOffload, OffloadHolder> {
+protected:
+    /**
+     * These containers are used in a way that makes us lose track of their contents (pointer-leaks & aliasing
+     * situations) or accesses it on the host, such that data on device would become out of sync
+     * Needs to not include the accesses of offloading nodes, as we want to handle them more intelligently
+     */
+    std::unordered_set<std::string> kills_containers_;
+    /**
+     * All offload nodes that H2D. They kill whatever they could alias with.
+     * If its a direct match (the inverse of an open D2H node), then its a candidate for removal
+     */
+    std::unordered_map<size_t, OffloadHolder> kernel_entry_nodes_;
+    std::unordered_map<std::string, std::vector<const data_flow::Memlet*>> reads_;
+    bool full_kill_ = false;
+    DataTransferEliminationCandidateCollector& collector_;
+
+public:
+    OffloadState(DataTransferEliminationCandidateCollector& collector);
+    void apply_kills_and_changes(ExposedType& exposed) const override;
+
+    void found_escape(const std::string& container);
+    void found_full_barrier(ControlFlowNode& node);
+    void found_offload_node(Block& block, offloading::DataOffloadingNode& offload);
+    void found_ptr_read(const std::string& container, const data_flow::Memlet* memlet);
+    void found_ptr_write(const std::string& container, const data_flow::Memlet* memlet);
+
+    void add_h2d_entry(const OffloadHolder& entry);
+
+    ExposedOffload expose(OffloadHolder& holder) override;
+
+    std::pair<bool, const OffloadHolder*> find_killing_entry_node(const OffloadHolder& exit_node) const;
+};
+
+class DataTransferEliminationAnalysis : public BaseUserVisitor,
+                                        public ForwardStructuredDataFlowAnalysis<OffloadState>,
+                                        PointerEscapeAnalyzer<ForwardingEscapePolicy>,
+                                        PointerUsedAnalyzer<ForwardingEscapePolicy>,
+                                        ForwardingEscapePolicy,
+                                        public DataTransferEliminationCandidateCollector {
+private:
+    StructuredSDFG& sdfg_;
+    AnalysisManager& ana_;
+
+public:
+    DataTransferEliminationAnalysis(StructuredSDFG& sdfg, AnalysisManager& ana)
+        : sdfg_(sdfg), ana_(ana), PointerEscapeAnalyzer(sdfg, *this), PointerUsedAnalyzer(sdfg, *this) {}
+
+    void handle_lib_node(Block& block, data_flow::LibraryNode& node) override;
+
+    void handle_structured_loop_before_body(StructuredLoop& loop) override;
+
+    void on_escape(const std::string& container, const ControlFlowNode* node, const Element* user) override;
+    void on_write_via(const std::string& container, const ControlFlowNode* node, const data_flow::Memlet* user) override;
+    void on_read_via(const std::string& container, const ControlFlowNode* node, const data_flow::Memlet* user) override;
+
+    void use_as_return_src(const std::string& container, const Return& ret) override {
+        PointerEscapeAnalyzer::use_as_return_src(container, ret);
+        PointerUsedAnalyzer::use_as_return_src(container, ret);
+    }
+    void use_as_symbol_read(
+        const std::string& container,
+        const ControlFlowNode* node,
+        const Element* user,
+        SymbolReadLocation loc,
+        int loc_index,
+        symbolic::Expression expr
+    ) override {
+        PointerEscapeAnalyzer::use_as_symbol_read(container, node, user, loc, loc_index, expr);
+        PointerUsedAnalyzer::use_as_symbol_read(container, node, user, loc, loc_index, expr);
+    }
+    void use_as_src_node(
+        const std::string& container,
+        const data_flow::AccessNode& node,
+        const data_flow::Memlet& edge,
+        const Block& block
+    ) override {
+        PointerEscapeAnalyzer::use_as_src_node(container, node, edge, block);
+        PointerUsedAnalyzer::use_as_src_node(container, node, edge, block);
+    }
+    void use_as_dst_node(
+        const std::string& container,
+        const data_flow::AccessNode& node,
+        const data_flow::Memlet& edge,
+        const Block& block
+    ) override {
+        PointerEscapeAnalyzer::use_as_dst_node(container, node, edge, block);
+        PointerUsedAnalyzer::use_as_dst_node(container, node, edge, block);
+    }
+    void use_as_symbol_write(
+        const symbolic::Symbol& container, const ControlFlowNode* node, const Element* user, SymbolWriteLocation loc
+    ) override {
+        PointerEscapeAnalyzer::use_as_symbol_write(container, node, user, loc);
+        PointerUsedAnalyzer::use_as_symbol_write(container, node, user, loc);
+    }
+
+    std::unique_ptr<OffloadState> create_initial_state(const structured_control_flow::ControlFlowNode& node) override;
+
+    void run();
+};
+
+} // namespace sdfg::analysis

--- a/opt/include/sdfg/analysis/structured_data_flow_analysis.h
+++ b/opt/include/sdfg/analysis/structured_data_flow_analysis.h
@@ -16,6 +16,11 @@
 namespace sdfg {
 namespace analysis {
 
+enum class MergeMode {
+    CUMULATIVE,
+    BRANCHES,
+};
+
 template<typename T>
 struct DataFlowState {
     using ExposedType = T;
@@ -29,13 +34,16 @@ struct DataFlowState {
     virtual bool update_forward_exposed(const T& forward_exposed) = 0;
 };
 
-template<typename T>
-struct SetDataFlowState : public DataFlowState<std::unordered_set<T>> {
-    using ExposedType = std::unordered_set<T>;
+typedef size_t ElementId;
+
+template<typename T, typename I>
+struct ElementIdMapDataFlowState : public DataFlowState<std::unordered_map<ElementId, T>> {
+    using ExposedType = DataFlowState<std::unordered_map<ElementId, T>>::ExposedType;
+    using InternalType = std::unordered_map<ElementId, std::unique_ptr<I>>;
 
 protected:
     ExposedType incoming_;
-    ExposedType generated_;
+    InternalType generated_;
     ExposedType forward_exposed_;
     bool ran_ = false;
 
@@ -43,20 +51,22 @@ public:
     bool ran_at_least_once() const override { return ran_; }
 
     bool update(const ExposedType& incoming) override {
-        bool incoming_changed = update_incoming(incoming);
+        bool needs_update = update_incoming(incoming);
 
-        if (!incoming_changed) {
+        if (!needs_update) {
             return false;
         }
 
         ExposedType exposed = incoming_;
-        apply_kills(exposed);
-        for (auto& gen : generated_) {
-            exposed.insert(gen);
+        apply_kills_and_changes(exposed);
+        for (auto& [id, gen] : generated_) {
+            exposed.insert({id, expose(*gen)});
         }
 
         return update_forward_exposed(exposed);
     }
+
+    virtual T expose(I& internal) = 0;
 
     bool update_incoming(const ExposedType& incoming) override {
         bool any_changes = false;
@@ -85,11 +95,22 @@ public:
 
     static ExposedType empty_in() { return ExposedType(); }
 
-    static void merge(ExposedType& merge_into, const ExposedType& other) {
-        merge_into.insert(other.begin(), other.end());
+    static void merge(ExposedType& merge_into, const ExposedType& other, MergeMode mode = MergeMode::CUMULATIVE) {
+        if (mode == MergeMode::BRANCHES) {
+            for (auto it = merge_into.begin(); it != merge_into.end();) {
+                auto key = it->first;
+                if (!other.contains(key)) {
+                    it = merge_into.erase(it);
+                    continue;
+                }
+                ++it;
+            }
+        } else {
+            merge_into.insert(other.begin(), other.end());
+        }
     }
 
-    virtual void apply_kills(ExposedType& exposed) const = 0;
+    virtual void apply_kills_and_changes(ExposedType& exposed) const = 0;
 };
 
 /**
@@ -225,17 +246,14 @@ private:
 
     std::pair<bool, const ExposedType&> solve(structured_control_flow::Sequence& seq, const ExposedType& in) {
         auto& seq_state = get_or_create_state(seq);
-        bool must_run = !seq_state.ran_at_least_once();
-        if (!seq_state.update_incoming(in) && !must_run) {
-            return {false, seq_state.forward_exposed()};
-        }
+        seq_state.update_incoming(in);
 
         const ExposedType* current = &in;
         bool updating = true;
         for (size_t i = 0; i < seq.size() && updating; ++i) {
             auto [child, transition] = seq.at(i);
             auto [changed, output] = solve(child, *current);
-            updating = changed || must_run;
+            updating = changed;
             current = &output;
         }
 
@@ -251,23 +269,23 @@ private:
 
     std::pair<bool, const ExposedType&> solve(structured_control_flow::IfElse& if_else, const ExposedType& in) {
         auto& state = get_or_create_state(if_else);
-        if (!state.update_incoming(in) && state.ran_at_least_once()) {
-            return {false, state.forward_exposed()};
-        }
+        state.update_incoming(in);
 
         ExposedType merged = State::empty_in();
+        bool first = true;
         bool changed = true;
         for (size_t i = 0; i < if_else.size(); ++i) {
             auto [branch_seq, cond] = if_else.at(i);
             auto [branch_changed, branch_out] = solve(branch_seq, in);
             changed |= branch_changed;
-            State::merge(merged, branch_out);
+            State::merge(merged, branch_out, first ? MergeMode::CUMULATIVE : MergeMode::BRANCHES);
+            first = false;
         }
 
         // If the IfElse is not complete (no else-branch covering all cases)
         // the input can also flow through unchanged.
         if (!if_else.is_complete()) {
-            State::merge(merged, in);
+            State::merge(merged, in, MergeMode::BRANCHES);
         }
 
         if (changed) {
@@ -292,9 +310,7 @@ private:
         const ExposedType& in,
         std::function<void(ExposedType&)> apply_after_body
     ) {
-        if (!state.update_incoming(in) && state.ran_at_least_once()) {
-            return {false, state.forward_exposed()};
-        }
+        state.update_incoming(in);
 
         ExposedType current = in;
         bool changing = false;
@@ -305,7 +321,7 @@ private:
             changed |= body_changed;
 
             if (body_changed) {
-                State::merge(current, body_out);
+                State::merge(current, body_out, MergeMode::BRANCHES);
             }
 
             if (apply_after_body) {

--- a/opt/include/sdfg/analysis/structured_data_flow_analysis.h
+++ b/opt/include/sdfg/analysis/structured_data_flow_analysis.h
@@ -1,0 +1,331 @@
+#pragma once
+
+#include <unordered_set>
+
+#include "sdfg/data_flow/library_nodes/math/blas/blas_node.h"
+#include "sdfg/structured_control_flow/block.h"
+#include "sdfg/structured_control_flow/control_flow_node.h"
+#include "sdfg/structured_control_flow/for.h"
+#include "sdfg/structured_control_flow/if_else.h"
+#include "sdfg/structured_control_flow/map.h"
+#include "sdfg/structured_control_flow/return.h"
+#include "sdfg/structured_control_flow/sequence.h"
+#include "sdfg/structured_control_flow/structured_loop.h"
+#include "sdfg/structured_control_flow/while.h"
+
+namespace sdfg {
+namespace analysis {
+
+template<typename T>
+struct DataFlowState {
+    using ExposedType = T;
+
+    virtual ~DataFlowState() = default;
+
+    virtual bool ran_at_least_once() const = 0;
+    virtual bool update(const T& incoming) = 0;
+    virtual const T& forward_exposed() const = 0;
+    virtual bool update_incoming(const T& incoming) = 0;
+    virtual bool update_forward_exposed(const T& forward_exposed) = 0;
+};
+
+template<typename T>
+struct SetDataFlowState : public DataFlowState<std::unordered_set<T>> {
+    using ExposedType = std::unordered_set<T>;
+
+protected:
+    ExposedType incoming_;
+    ExposedType generated_;
+    ExposedType forward_exposed_;
+    bool ran_ = false;
+
+public:
+    bool ran_at_least_once() const override { return ran_; }
+
+    bool update(const ExposedType& incoming) override {
+        bool incoming_changed = update_incoming(incoming);
+
+        if (!incoming_changed) {
+            return false;
+        }
+
+        ExposedType exposed = incoming_;
+        apply_kills(exposed);
+        for (auto& gen : generated_) {
+            exposed.insert(gen);
+        }
+
+        return update_forward_exposed(exposed);
+    }
+
+    bool update_incoming(const ExposedType& incoming) override {
+        bool any_changes = false;
+        for (auto it = incoming.begin(); it != incoming.end(); ++it) {
+            auto [placed, changed] = incoming_.insert(*it);
+            any_changes |= changed;
+        }
+        return any_changes || !ran_;
+    }
+
+    bool update_forward_exposed(const ExposedType& forward_exposed) override {
+        bool any_changes = false;
+        for (auto it = forward_exposed.begin(); it != forward_exposed.end(); ++it) {
+            auto [placed, changed] = forward_exposed_.insert(*it);
+            any_changes |= changed;
+        }
+        if (!ran_) {
+            ran_ = true;
+            return true;
+        } else {
+            return any_changes;
+        }
+    }
+
+    const ExposedType& forward_exposed() const override { return forward_exposed_; }
+
+    static ExposedType empty_in() { return ExposedType(); }
+
+    static void merge(ExposedType& merge_into, const ExposedType& other) {
+        merge_into.insert(other.begin(), other.end());
+    }
+
+    virtual void apply_kills(ExposedType& exposed) const = 0;
+};
+
+/**
+ * @brief Base class for forward data-flow analysis over structured control flow.
+ *
+ * The analysis walks the structured CFG tree (Sequence, Block, IfElse,
+ * StructuredLoop, While, Return, Break, Continue) in forward order and
+ * propagates sets of instances of type `T` using the classic gen/kill
+ * framework:
+ *
+ *     out(n) = gen(n) ∪ (in(n) − kill(n))
+ *
+ * Merge at join points (after IfElse branches, loop back-edges) is
+ * performed by the virtual `merge` function which defaults to set union.
+ *
+ * **Usage:**
+ *
+ * 1. Derive from `ForwardDataFlowAnalysis<YourElementType>`.
+ * 2. Override `transfer` to provide the gen/kill sets for leaf nodes.
+ *    At a minimum you should handle `Block`; the other overloads have
+ *    sensible defaults (empty gen/kill).
+ * 3. Optionally override `merge` if you need intersection semantics
+ *    (must-analysis) instead of the default union (may-analysis).
+ * 4. Optionally override `boundary` to provide the initial set that
+ *    flows into the root of the tree.
+ * 5. Call `run(root_sequence)`.  Afterwards query `state(node)` for any
+ *    visited node.
+ *
+ * @tparam T Element type.  Must support `operator<` (used in std::set).
+ */
+template<typename State>
+class ForwardStructuredDataFlowAnalysis {
+public:
+    virtual ~ForwardStructuredDataFlowAnalysis() = default;
+
+    using ExposedType = typename State::ExposedType;
+
+    // -----------------------------------------------------------------
+    //  Main entry point
+    // -----------------------------------------------------------------
+
+    struct SolveProgress {
+        std::variant<
+            structured_control_flow::ControlFlowNode*,
+            structured_control_flow::StructuredLoop*,
+            structured_control_flow::While*,
+            structured_control_flow::IfElse*,
+            structured_control_flow::Sequence*>
+            node;
+        int index = 0;
+    };
+
+    /**
+     * @brief Run the analysis starting from the given root sequence.
+     * @param root Typically `sdfg.root()`.
+     */
+    void run_forward(structured_control_flow::Sequence& root) { solve(root, boundary()); }
+
+    // -----------------------------------------------------------------
+    //  Query results
+    // -----------------------------------------------------------------
+
+    /**
+     * @brief Retrieve the computed data-flow state for a node.
+     * @param node A node that was visited during `run`.
+     * @return Reference to its DataFlowState (in/out sets).
+     */
+    const State& state(const structured_control_flow::ControlFlowNode& node) const { return *states_.at(&node); }
+
+    bool has_state(const structured_control_flow::ControlFlowNode& node) const { return states_.contains(&node); }
+
+protected:
+    State& get_or_create_state(const structured_control_flow::ControlFlowNode& node) {
+        auto& ptr = states_[&node];
+        if (!ptr) {
+            ptr = create_initial_state(node);
+        }
+        return *ptr;
+    }
+
+    virtual std::unique_ptr<State> create_initial_state(const structured_control_flow::ControlFlowNode& node) = 0;
+    // -----------------------------------------------------------------
+    //  Merge at join points
+    // -----------------------------------------------------------------
+
+    /**
+     * @brief Provide the initial set flowing into the root.
+     *
+     * Override to seed the analysis with an initial set (e.g. function
+     * arguments that are live on entry).  Default: empty set.
+     */
+    virtual ExposedType boundary() { return State::empty_in(); }
+
+private:
+    std::unordered_map<const structured_control_flow::ControlFlowNode*, std::unique_ptr<State>> states_;
+
+    // -----------------------------------------------------------------
+    //  Recursive solvers for each node type
+    // -----------------------------------------------------------------
+
+    /**
+     * @brief Solve a generic ControlFlowNode by dispatching on its
+     *        dynamic type.
+     * @param node  The node to solve.
+     * @param in    The set flowing into this node.
+     * @return      The set flowing out of this node.
+     */
+    std::pair<bool, const ExposedType&> solve(structured_control_flow::ControlFlowNode& node, const ExposedType& in) {
+        // Dispatch to the concrete type
+        if (auto* seq = dynamic_cast<structured_control_flow::Sequence*>(&node)) {
+            return solve(*seq, in);
+        }
+        if (auto* if_else = dynamic_cast<structured_control_flow::IfElse*>(&node)) {
+            return solve(*if_else, in);
+        }
+        if (auto* for_loop = dynamic_cast<structured_control_flow::For*>(&node)) {
+            return solve_loop(*for_loop, in);
+        }
+        if (auto* map_loop = dynamic_cast<structured_control_flow::Map*>(&node)) {
+            return solve_loop(*map_loop, in);
+        }
+        if (auto* while_loop = dynamic_cast<structured_control_flow::While*>(&node)) {
+            return solve(*while_loop, in);
+        }
+
+        // Unknown node – treat as transparent
+        auto& s = get_or_create_state(node);
+        bool changed = s.update(in);
+        return {changed, s.forward_exposed()};
+    }
+
+    // -- Sequence: propagate through children left-to-right ---------------
+
+    std::pair<bool, const ExposedType&> solve(structured_control_flow::Sequence& seq, const ExposedType& in) {
+        auto& seq_state = get_or_create_state(seq);
+        bool must_run = !seq_state.ran_at_least_once();
+        if (!seq_state.update_incoming(in) && !must_run) {
+            return {false, seq_state.forward_exposed()};
+        }
+
+        const ExposedType* current = &in;
+        bool updating = true;
+        for (size_t i = 0; i < seq.size() && updating; ++i) {
+            auto [child, transition] = seq.at(i);
+            auto [changed, output] = solve(child, *current);
+            updating = changed || must_run;
+            current = &output;
+        }
+
+        if (updating) {
+            auto changed = seq_state.update_forward_exposed(*current);
+            return {changed, *current};
+        } else {
+            return {false, seq_state.forward_exposed()};
+        }
+    }
+
+    // -- IfElse: propagate into each branch, merge results ----------------
+
+    std::pair<bool, const ExposedType&> solve(structured_control_flow::IfElse& if_else, const ExposedType& in) {
+        auto& state = get_or_create_state(if_else);
+        if (!state.update_incoming(in) && state.ran_at_least_once()) {
+            return {false, state.forward_exposed()};
+        }
+
+        ExposedType merged = State::empty_in();
+        bool changed = true;
+        for (size_t i = 0; i < if_else.size(); ++i) {
+            auto [branch_seq, cond] = if_else.at(i);
+            auto [branch_changed, branch_out] = solve(branch_seq, in);
+            changed |= branch_changed;
+            State::merge(merged, branch_out);
+        }
+
+        // If the IfElse is not complete (no else-branch covering all cases)
+        // the input can also flow through unchanged.
+        if (!if_else.is_complete()) {
+            State::merge(merged, in);
+        }
+
+        if (changed) {
+            changed = state.update_forward_exposed(merged);
+        }
+        return {changed, state.forward_exposed()};
+    }
+
+    // -- StructuredLoop (For / Map): fixed-point iteration ----------------
+
+    std::pair<bool, const ExposedType&> solve_loop(structured_control_flow::StructuredLoop& loop, const ExposedType& in) {
+        // todo factor in loop header exposes
+
+        return solve_loop_body(get_or_create_state(loop), loop.root(), in, [&](ExposedType& after_body) {
+            // todo factor in loop update exposes
+        });
+    }
+
+    std::pair<bool, const ExposedType&> solve_loop_body(
+        State& state,
+        structured_control_flow::Sequence& body,
+        const ExposedType& in,
+        std::function<void(ExposedType&)> apply_after_body
+    ) {
+        if (!state.update_incoming(in) && state.ran_at_least_once()) {
+            return {false, state.forward_exposed()};
+        }
+
+        ExposedType current = in;
+        bool changing = false;
+        bool changed = false;
+        do {
+            auto [body_changed, body_out] = solve(body, current);
+            changing = body_changed;
+            changed |= body_changed;
+
+            if (body_changed) {
+                State::merge(current, body_out);
+            }
+
+            if (apply_after_body) {
+                apply_after_body(current);
+            }
+        } while (changing);
+
+        if (changed) {
+            changed = state.update_forward_exposed(current);
+        }
+
+        return {changed, state.forward_exposed()};
+    }
+
+    // -- While: same fixed-point strategy ---------------------------------
+
+    std::pair<bool, const ExposedType&> solve(structured_control_flow::While& loop, const ExposedType& in) {
+        return solve_loop_body(get_or_create_state(loop), loop.root(), in, nullptr);
+    }
+};
+
+} // namespace analysis
+} // namespace sdfg

--- a/opt/include/sdfg/passes/extended_data_transfer_minimization_pass.h
+++ b/opt/include/sdfg/passes/extended_data_transfer_minimization_pass.h
@@ -18,7 +18,7 @@
 namespace sdfg {
 namespace passes {
 
-class ExtendedDataTransferMinimization : public DataTransferMinimization {
+class ExtendedDataTransferMinimization : public DataTransferMinimizationLegacy {
 private:
     virtual std::pair<data_flow::AccessNode*, data_flow::AccessNode*>
     get_src_and_dst(data_flow::DataFlowGraph& dfg, offloading::DataOffloadingNode* offloading_node);

--- a/opt/include/sdfg/passes/offloading/data_transfer_minimization_pass.h
+++ b/opt/include/sdfg/passes/offloading/data_transfer_minimization_pass.h
@@ -4,6 +4,7 @@
 #include <utility>
 
 #include "sdfg/analysis/analysis.h"
+#include "sdfg/analysis/data_transfer_elimination_analysis.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
 #include "sdfg/data_flow/access_node.h"
 #include "sdfg/data_flow/code_node.h"
@@ -17,7 +18,26 @@
 namespace sdfg {
 namespace passes {
 
-class DataTransferMinimization : public visitor::NonStoppingStructuredSDFGVisitor {
+class DataTransferMinimizationPass : public Pass {
+public:
+    DataTransferMinimizationPass();
+
+    std::string name() override { return "DataTransferMinimization"; };
+
+    bool run_pass(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) override;
+
+    static bool available(analysis::AnalysisManager& AM) { return true; }
+
+protected:
+    bool eliminate_transfer(
+        builder::StructuredSDFGBuilder& builder,
+        const analysis::OffloadHolder& copy_out,
+        const analysis::OffloadHolder& copy_in,
+        bool remove_d2h = false
+    );
+};
+
+class DataTransferMinimizationLegacy : public visitor::NonStoppingStructuredSDFGVisitor {
 private:
     virtual std::pair<data_flow::AccessNode*, data_flow::AccessNode*>
     get_src_and_dst(data_flow::DataFlowGraph& dfg, offloading::DataOffloadingNode* offloading_node);
@@ -34,7 +54,7 @@ protected:
     );
 
 public:
-    DataTransferMinimization(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager);
+    DataTransferMinimizationLegacy(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager);
 
     static std::string name() { return "DataTransferMinimization"; }
 
@@ -43,7 +63,7 @@ public:
     virtual bool accept(structured_control_flow::Sequence& sequence) override;
 };
 
-typedef VisitorPass<DataTransferMinimization> DataTransferMinimizationPass;
+typedef VisitorPass<DataTransferMinimizationLegacy> DataTransferMinimizationLegacyPass;
 
 } // namespace passes
 } // namespace sdfg

--- a/opt/src/analysis/data_transfer_elimination_analysis.cpp
+++ b/opt/src/analysis/data_transfer_elimination_analysis.cpp
@@ -1,0 +1,193 @@
+#include "sdfg/analysis/data_transfer_elimination_analysis.h"
+
+
+#include "sdfg/targets/offloading/data_offloading_node.h"
+
+namespace sdfg::analysis {
+
+OffloadState::OffloadState(DataTransferEliminationCandidateCollector& collector) : collector_(collector) {}
+
+void OffloadState::found_escape(const std::string& container) { kills_containers_.insert(container); }
+
+void OffloadState::found_ptr_write(const std::string& container) { kills_containers_.insert(container); }
+
+void OffloadState::found_ptr_read(const std::string& container) { kills_containers_.insert(container); }
+
+void OffloadState::found_offloaded_kernel(data_flow::LibraryNode& libnode) {
+    generated_.clear(); // all generateds are from before and now wiped
+    full_kill_ = true;
+    // TODO more granularity: find the vars involved in the kernel and put them in kills_containers instead. But full
+    // kill should allow simpler testing
+    //  can be easier with transfers included in libnode, same as map if not
+}
+
+void OffloadState::found_offloaded_kernel(Map& map) {
+    generated_.clear(); // all generateds are from before and now wiped
+    full_kill_ = true;
+    // TODO more granularity: find the vars involved in the kernel and put them in kills_containers instead. But full
+    // kill should allow simpler testing
+}
+
+std::pair<bool, const OffloadHolder*> OffloadState::find_killing_entry_node(const OffloadHolder& exit_node) const {
+    auto& host_access_type = exit_node.host_access->base_type();
+    for (auto& entry_node : kernel_entry_nodes_) {
+        if (entry_node.host_data->data() == exit_node.host_data->data() &&
+            exit_node.node->redundant_with(*entry_node.node)) {
+            return {true, &entry_node};
+        } else if (host_access_type == entry_node.host_access->base_type()) { // aliases
+            // return &entry_node; // TODO left unhandled for now, because then most situations like a matmul could
+            // never be eliminated
+        }
+    }
+
+    return {false, nullptr};
+}
+
+void OffloadState::found_offload_node(Block& block, offloading::DataOffloadingNode& offload) {
+    auto& dflow = block.dataflow();
+
+    bool src_is_dev = false;
+    bool src_is_host = false;
+    bool dst_is_dev = false;
+    bool dst_is_host = false;
+
+    if (is_D2H(offload.transfer_direction())) {
+        src_is_dev = true;
+        dst_is_host = true;
+    } else if (is_H2D(offload.transfer_direction())) {
+        src_is_host = true;
+        dst_is_dev = true;
+    }
+
+    const data_flow::AccessNode* found_dev_access = nullptr;
+    const data_flow::AccessNode* found_host_access = nullptr;
+    const data_flow::Memlet* found_host_memlet = nullptr;
+
+    for (auto& conn : offload.inputs()) {
+        auto* memlet = dflow.in_edge_for_connector(offload, conn);
+        auto* access_node = dynamic_cast<const data_flow::AccessNode*>(&memlet->src());
+
+        if (src_is_host) {
+            found_host_access = access_node;
+            found_host_memlet = memlet;
+        }
+        if (src_is_dev) {
+            found_dev_access = access_node;
+        }
+    }
+
+    for (auto& conn : offload.outputs()) {
+        auto edges = dflow.out_edges_for_connector(offload, conn);
+        if (edges.size() > 1) {
+            throw std::runtime_error(
+                "Unsupported: offload node " + std::to_string(offload.element_id()) +
+                " with multiple outputs edges on " + conn
+            );
+        }
+        auto* memlet = edges.at(0);
+        auto* access_node = dynamic_cast<const data_flow::AccessNode*>(&memlet->dst());
+
+        if (dst_is_host) {
+            found_host_access = access_node;
+            found_host_memlet = memlet;
+        }
+        if (dst_is_dev) {
+            found_dev_access = access_node;
+        }
+    }
+
+    if (found_host_access && found_dev_access) {
+        if (dst_is_dev) {
+            generated_.emplace(OffloadHolder{&offload, found_host_access, found_host_memlet, found_dev_access});
+        } else {
+            kernel_entry_nodes_.emplace(OffloadHolder{&offload, found_host_access, found_host_memlet, found_dev_access}
+            );
+        }
+    }
+}
+
+void OffloadState::apply_kills(ExposedType& exposed) const {
+    if (full_kill_) {
+        exposed.clear();
+        return;
+    }
+    for (auto it = exposed.begin(); it != exposed.end(); ++it) {
+        auto& holder = *it;
+        auto* host = holder.host_data;
+        if (host && kills_containers_.contains(host->data())) {
+            it = exposed.erase(it);
+            continue;
+        }
+        auto [is_elim_candidate, killing_entry] = find_killing_entry_node(holder);
+        if (killing_entry) {
+            if (is_elim_candidate) {
+                collector_.found_candidate_pair(holder, *killing_entry);
+            }
+            it = exposed.erase(it);
+            continue;
+        }
+    }
+}
+
+
+void DataTransferEliminationAnalysis::handle_lib_node(Block& block, data_flow::LibraryNode& node) {
+    BaseUserVisitor::handle_lib_node(block, node);
+
+    if (auto* offload_node = dynamic_cast<offloading::DataOffloadingNode*>(&node)) {
+        get_or_create_state(block).found_offload_node(block, *offload_node);
+    }
+}
+
+void DataTransferEliminationAnalysis::handle_structured_loop_before_body(StructuredLoop& loop) {
+    BaseUserVisitor::handle_structured_loop_before_body(loop);
+
+    auto* map = dynamic_cast<sdfg::structured_control_flow::Map*>(&loop);
+
+    if (map && map->schedule_type().category() == ScheduleTypeCategory::Offloader) {
+        get_or_create_state(loop).found_offloaded_kernel(*map);
+    }
+}
+
+void DataTransferEliminationAnalysis::
+    on_escape(const std::string& container, const ControlFlowNode* node, const Element* user) {
+    get_or_create_state(*node).found_escape(container);
+}
+
+void DataTransferEliminationAnalysis::
+    on_read_via(const std::string& container, const ControlFlowNode* node, const data_flow::Memlet* user) {
+    if (!dynamic_cast<const offloading::DataOffloadingNode*>(&user->dst())) {
+        get_or_create_state(*node).found_ptr_read(container);
+    }
+}
+
+void DataTransferEliminationAnalysis::
+    on_write_via(const std::string& container, const ControlFlowNode* node, const data_flow::Memlet* user) {
+    if (!dynamic_cast<const offloading::DataOffloadingNode*>(&user->dst())) {
+        get_or_create_state(*node).found_ptr_write(container);
+    }
+}
+
+std::unique_ptr<OffloadState> DataTransferEliminationAnalysis::
+    create_initial_state(const structured_control_flow::ControlFlowNode& node) {
+    return std::make_unique<OffloadState>(*this);
+}
+
+void DataTransferEliminationAnalysis::run() {
+    dispatch(sdfg_.root());
+
+    run_forward(sdfg_.root());
+
+    for (auto& candidate : candidates_) {
+        auto& copy_out = candidate.first;
+        auto& copy_in = candidate.second;
+        DEBUG_PRINTLN(
+            "  Eliminating "
+            << "copy-out: #" << copy_out.node->element_id() << " " << copy_out.dev_data->data() << " -> "
+            << (copy_out.host_data ? copy_out.host_data->data() : "-") << " / copy-in: #" << copy_in.node->element_id()
+            << " " << (copy_in.host_data ? copy_in.host_data->data() : "-") << " -> " << copy_in.dev_data->data()
+        );
+    }
+    std::cerr << "Ran analysis" << std::endl;
+}
+
+} // namespace sdfg::analysis

--- a/opt/src/analysis/data_transfer_elimination_analysis.cpp
+++ b/opt/src/analysis/data_transfer_elimination_analysis.cpp
@@ -1,6 +1,7 @@
 #include "sdfg/analysis/data_transfer_elimination_analysis.h"
 
 
+#include "sdfg/targets/cuda/cuda.h"
 #include "sdfg/targets/offloading/data_offloading_node.h"
 
 namespace sdfg::analysis {
@@ -9,31 +10,29 @@ OffloadState::OffloadState(DataTransferEliminationCandidateCollector& collector)
 
 void OffloadState::found_escape(const std::string& container) { kills_containers_.insert(container); }
 
-void OffloadState::found_ptr_write(const std::string& container) { kills_containers_.insert(container); }
-
-void OffloadState::found_ptr_read(const std::string& container) { kills_containers_.insert(container); }
-
-void OffloadState::found_offloaded_kernel(data_flow::LibraryNode& libnode) {
-    generated_.clear(); // all generateds are from before and now wiped
-    full_kill_ = true;
-    // TODO more granularity: find the vars involved in the kernel and put them in kills_containers instead. But full
-    // kill should allow simpler testing
-    //  can be easier with transfers included in libnode, same as map if not
+void OffloadState::found_ptr_write(const std::string& container, const data_flow::Memlet* memlet) {
+    kills_containers_.insert(container);
 }
 
-void OffloadState::found_offloaded_kernel(Map& map) {
-    generated_.clear(); // all generateds are from before and now wiped
-    full_kill_ = true;
-    // TODO more granularity: find the vars involved in the kernel and put them in kills_containers instead. But full
-    // kill should allow simpler testing
+void OffloadState::found_ptr_read(const std::string& container, const data_flow::Memlet* memlet) {
+    // todo check with generated set if its ever possible for it to contain the transfer and a use
+    reads_[container].push_back(memlet);
 }
 
+void OffloadState::found_full_barrier(ControlFlowNode& node) {
+    generated_.clear(); // all generateds are from before and now wiped
+    full_kill_ = true;
+}
+
+/**
+ * @return { candidate_for_elimination, killing node }
+ */
 std::pair<bool, const OffloadHolder*> OffloadState::find_killing_entry_node(const OffloadHolder& exit_node) const {
     auto& host_access_type = exit_node.host_access->base_type();
-    for (auto& entry_node : kernel_entry_nodes_) {
-        if (entry_node.host_data->data() == exit_node.host_data->data() &&
-            exit_node.node->redundant_with(*entry_node.node)) {
-            return {true, &entry_node};
+    for (const auto& entry_node : kernel_entry_nodes_ | std::views::values) {
+        if (entry_node.host_data->data() == exit_node.host_data->data()) {
+            bool is_elim_candidate = exit_node.node->redundant_with(*entry_node.node);
+            return {is_elim_candidate, &entry_node};
         } else if (host_access_type == entry_node.host_access->base_type()) { // aliases
             // return &entry_node; // TODO left unhandled for now, because then most situations like a matmul could
             // never be eliminated
@@ -97,35 +96,53 @@ void OffloadState::found_offload_node(Block& block, offloading::DataOffloadingNo
     }
 
     if (found_host_access && found_dev_access) {
-        if (dst_is_dev) {
-            generated_.emplace(OffloadHolder{&offload, found_host_access, found_host_memlet, found_dev_access});
-        } else {
-            kernel_entry_nodes_.emplace(OffloadHolder{&offload, found_host_access, found_host_memlet, found_dev_access}
+        if (dst_is_host) {
+            generated_.emplace(
+                offload.element_id(),
+                std::make_unique<OffloadHolder>(&offload, found_host_access, found_host_memlet, found_dev_access)
             );
+        } else {
+            add_h2d_entry(OffloadHolder{&offload, found_host_access, found_host_memlet, found_dev_access});
         }
     }
 }
 
-void OffloadState::apply_kills(ExposedType& exposed) const {
+void OffloadState::add_h2d_entry(const OffloadHolder& entry) {
+    kernel_entry_nodes_.emplace(entry.node->element_id(), entry);
+    // todo also need to remove generated ones killed by this. But right now
+}
+
+ExposedOffload OffloadState::expose(OffloadHolder& holder) { return ExposedOffload{&holder, 0}; }
+
+void OffloadState::apply_kills_and_changes(ExposedType& exposed) const {
     if (full_kill_) {
         exposed.clear();
         return;
     }
-    for (auto it = exposed.begin(); it != exposed.end(); ++it) {
-        auto& holder = *it;
-        auto* host = holder.host_data;
-        if (host && kills_containers_.contains(host->data())) {
+    for (auto it = exposed.begin(); it != exposed.end();) {
+        auto& [id, exposedOffload] = *it;
+        auto* host = exposedOffload.offload->host_data;
+        auto& host_container = host->data();
+
+        auto host_reads = reads_.find(host_container);
+        if (host_reads != reads_.end() && host_reads->second.size() > 0) {
+            ++exposedOffload.read_count;
+        }
+
+        if (host && kills_containers_.contains(host_container)) {
             it = exposed.erase(it);
             continue;
         }
-        auto [is_elim_candidate, killing_entry] = find_killing_entry_node(holder);
+
+        auto [is_elim_candidate, killing_entry] = find_killing_entry_node(*exposedOffload.offload);
         if (killing_entry) {
             if (is_elim_candidate) {
-                collector_.found_candidate_pair(holder, *killing_entry);
+                collector_.found_candidate_pair(exposedOffload, *killing_entry);
             }
             it = exposed.erase(it);
             continue;
         }
+        ++it;
     }
 }
 
@@ -141,29 +158,38 @@ void DataTransferEliminationAnalysis::handle_lib_node(Block& block, data_flow::L
 void DataTransferEliminationAnalysis::handle_structured_loop_before_body(StructuredLoop& loop) {
     BaseUserVisitor::handle_structured_loop_before_body(loop);
 
-    auto* map = dynamic_cast<sdfg::structured_control_flow::Map*>(&loop);
+    // auto* map = dynamic_cast<sdfg::structured_control_flow::Map*>(&loop);
 
-    if (map && map->schedule_type().category() == ScheduleTypeCategory::Offloader) {
-        get_or_create_state(loop).found_offloaded_kernel(*map);
-    }
+    // if (map && map->schedule_type().category() == ScheduleTypeCategory::Offloader) {
+    //     get_or_create_state(loop).found_offloaded_kernel(*map);
+    // }
 }
 
 void DataTransferEliminationAnalysis::
     on_escape(const std::string& container, const ControlFlowNode* node, const Element* user) {
+    if (dynamic_cast<const Block*>(node)) {
+        if (auto* memlet = dynamic_cast<const data_flow::Memlet*>(user)) {
+            if (auto* offload = dynamic_cast<const offloading::DataOffloadingNode*>(&memlet->dst())) {
+                // accesses of offloading nodes are handled more intelligently in found_offload_node, so ignore them
+                // here
+                return;
+            }
+        }
+    }
     get_or_create_state(*node).found_escape(container);
 }
 
 void DataTransferEliminationAnalysis::
     on_read_via(const std::string& container, const ControlFlowNode* node, const data_flow::Memlet* user) {
     if (!dynamic_cast<const offloading::DataOffloadingNode*>(&user->dst())) {
-        get_or_create_state(*node).found_ptr_read(container);
+        get_or_create_state(*node).found_ptr_read(container, user);
     }
 }
 
 void DataTransferEliminationAnalysis::
     on_write_via(const std::string& container, const ControlFlowNode* node, const data_flow::Memlet* user) {
     if (!dynamic_cast<const offloading::DataOffloadingNode*>(&user->dst())) {
-        get_or_create_state(*node).found_ptr_write(container);
+        get_or_create_state(*node).found_ptr_write(container, user);
     }
 }
 
@@ -176,18 +202,6 @@ void DataTransferEliminationAnalysis::run() {
     dispatch(sdfg_.root());
 
     run_forward(sdfg_.root());
-
-    for (auto& candidate : candidates_) {
-        auto& copy_out = candidate.first;
-        auto& copy_in = candidate.second;
-        DEBUG_PRINTLN(
-            "  Eliminating "
-            << "copy-out: #" << copy_out.node->element_id() << " " << copy_out.dev_data->data() << " -> "
-            << (copy_out.host_data ? copy_out.host_data->data() : "-") << " / copy-in: #" << copy_in.node->element_id()
-            << " " << (copy_in.host_data ? copy_in.host_data->data() : "-") << " -> " << copy_in.dev_data->data()
-        );
-    }
-    std::cerr << "Ran analysis" << std::endl;
 }
 
 } // namespace sdfg::analysis

--- a/opt/src/passes/extended_data_transfer_minimization_pass.cpp
+++ b/opt/src/passes/extended_data_transfer_minimization_pass.cpp
@@ -25,7 +25,7 @@ namespace passes {
 ExtendedDataTransferMinimization::ExtendedDataTransferMinimization(
     builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager
 )
-    : sdfg::passes::DataTransferMinimization(builder, analysis_manager) {}
+    : sdfg::passes::DataTransferMinimizationLegacy(builder, analysis_manager) {}
 
 std::pair<data_flow::AccessNode*, data_flow::AccessNode*> ExtendedDataTransferMinimization::
     get_src_and_dst(data_flow::DataFlowGraph& dfg, offloading::DataOffloadingNode* offloading_node) {

--- a/opt/src/passes/offloading/data_transfer_minimization_pass.cpp
+++ b/opt/src/passes/offloading/data_transfer_minimization_pass.cpp
@@ -57,8 +57,8 @@ bool DataTransferMinimizationPass::eliminate_transfer(
 
     // Maps the device pointers if necessary
     if (copy_out_device_container != copy_in_device_container) {
-        types::Pointer void_pointer;
-        types::Pointer void_pointer_pointer(*void_pointer.clone());
+        auto& container_type = builder.subject().type(copy_out_device_container);
+        auto ref_type = container_type.clone();
         auto& in_access = builder.add_access(*copy_in_block, copy_out_device_container, copy_out_src_debinfo);
         auto& out_access = builder.add_access(*copy_in_block, copy_in_device_container, copy_in_dst_debinfo);
         builder.add_reference_memlet(
@@ -66,7 +66,7 @@ bool DataTransferMinimizationPass::eliminate_transfer(
             in_access,
             out_access,
             {symbolic::zero()},
-            void_pointer_pointer,
+            *ref_type,
             DebugInfo::merge(copy_out.node->debug_info(), copy_in.node->debug_info())
         );
     }

--- a/opt/src/passes/offloading/data_transfer_minimization_pass.cpp
+++ b/opt/src/passes/offloading/data_transfer_minimization_pass.cpp
@@ -141,9 +141,10 @@ bool DataTransferMinimization::accept(structured_control_flow::Sequence& sequenc
 
             // Debug output
             DEBUG_PRINTLN(
-                "  Eliminating " << (read_after ? "(" : "") << "copy-out: " << copy_out_src->data() << " -> "
-                                 << copy_out_dst->data() << (read_after ? ")" : "")
-                                 << " / copy-in: " << copy_in_src->data() << " -> " << copy_in_dst->data()
+                "  Eliminating " << (read_after ? "(" : "") << "copy-out: #" << copy_out->element_id() << " "
+                                 << copy_out_src->data() << " -> " << copy_out_dst->data() << (read_after ? ")" : "")
+                                 << " / copy-in: #" << copy_in->element_id() << " " << copy_in_src->data() << " -> "
+                                 << copy_in_dst->data()
             );
 
             // Get all relevant information

--- a/opt/src/passes/offloading/data_transfer_minimization_pass.cpp
+++ b/opt/src/passes/offloading/data_transfer_minimization_pass.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "sdfg/analysis/analysis.h"
+#include "sdfg/analysis/data_transfer_elimination_analysis.h"
 #include "sdfg/analysis/scope_analysis.h"
 #include "sdfg/analysis/users.h"
 #include "sdfg/data_flow/access_node.h"
@@ -30,16 +31,112 @@
 namespace sdfg {
 namespace passes {
 
-DataTransferMinimization::
-    DataTransferMinimization(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager)
+DataTransferMinimizationPass::DataTransferMinimizationPass() {}
+
+bool DataTransferMinimizationPass::eliminate_transfer(
+    builder::StructuredSDFGBuilder& builder,
+    const analysis::OffloadHolder& copy_out,
+    const analysis::OffloadHolder& copy_in,
+    bool remove_d2h
+) {
+    // Get all relevant information
+    std::string copy_out_device_container = copy_out.dev_data->data();
+    std::string copy_in_device_container = copy_in.dev_data->data();
+    DebugInfo copy_out_src_debinfo = copy_out.dev_data->debug_info();
+    DebugInfo copy_in_dst_debinfo = copy_in.dev_data->debug_info();
+
+    // Remove what you can remove
+    if (!remove_d2h && copy_out.node->is_free()) {
+        copy_out.node->remove_free();
+    } else if (remove_d2h) {
+        auto* copy_out_block = dynamic_cast<structured_control_flow::Block*>(copy_out.node->get_parent().get_parent());
+        builder.clear_code_node_legacy(*copy_out_block, *copy_out.node);
+    }
+    auto* copy_in_block = dynamic_cast<structured_control_flow::Block*>(copy_in.node->get_parent().get_parent());
+    builder.clear_code_node_legacy(*copy_in_block, *copy_in.node);
+
+    // Maps the device pointers if necessary
+    if (copy_out_device_container != copy_in_device_container) {
+        types::Pointer void_pointer;
+        types::Pointer void_pointer_pointer(*void_pointer.clone());
+        auto& in_access = builder.add_access(*copy_in_block, copy_out_device_container, copy_out_src_debinfo);
+        auto& out_access = builder.add_access(*copy_in_block, copy_in_device_container, copy_in_dst_debinfo);
+        builder.add_reference_memlet(
+            *copy_in_block,
+            in_access,
+            out_access,
+            {symbolic::zero()},
+            void_pointer_pointer,
+            DebugInfo::merge(copy_out.node->debug_info(), copy_in.node->debug_info())
+        );
+    }
+
+    return true;
+}
+
+bool DataTransferMinimizationPass::
+    run_pass(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {
+    analysis::DataTransferEliminationAnalysis transfer_analysis(builder.subject(), analysis_manager);
+    transfer_analysis.run();
+    auto& candidates = transfer_analysis.candidates();
+
+    auto& users = analysis_manager.get<analysis::Users>();
+
+    int removed = 0;
+
+    for (auto& candidate : candidates) {
+        auto reads = candidate.first.read_count;
+        auto& copy_out = *candidate.first.offload;
+        auto& copy_in = candidate.second;
+        auto& copy_in_container = copy_in.host_data->data();
+
+        // copy from legacy version as hack: checking for users after the copy_in container (because current analysis
+        // stops looking at that point)
+        // TODO unsafe: this does not cover all ways that still need the data on host. Safe is: only manage device-side
+        // things here and let dead-data find the unused host stuff
+        auto* read = users.get_user(
+            copy_in.host_data->data(), const_cast<data_flow::AccessNode*>(copy_in.host_data), analysis::Use::READ
+        );
+
+        for (auto* after_use : users.all_uses_after(*read)) {
+            if (after_use->container() == copy_in_container && after_use->use() == analysis::Use::READ &&
+                after_use != read) {
+                ++reads;
+            }
+        }
+
+#ifndef NDEBUG
+        std::cerr << "  Elim candidate "
+                  << "copy-out: #" << copy_out.node->element_id() << " " << copy_out.dev_data->data() << " -> "
+                  << (copy_out.host_data ? copy_out.host_data->data() : "-") << " / ";
+        if (reads) {
+            std::cerr << reads << " reads / ";
+        }
+        std::cerr << "copy-in: #" << copy_in.node->element_id() << " "
+                  << (copy_in.host_data ? copy_in.host_data->data() : "-") << " -> " << copy_in.dev_data->data()
+                  << std::endl;
+#endif
+
+        bool success = eliminate_transfer(builder, copy_out, copy_in, reads == 0);
+
+        if (success) {
+            ++removed;
+        }
+    }
+
+    return removed > 0;
+}
+
+DataTransferMinimizationLegacy::
+    DataTransferMinimizationLegacy(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager)
     : visitor::NonStoppingStructuredSDFGVisitor(builder, analysis_manager) {}
 
-bool DataTransferMinimization::visit() {
+bool DataTransferMinimizationLegacy::visit() {
     DEBUG_PRINTLN("Running DataTransferMinimizationPass on " << this->builder_.subject().name());
     return visitor::NonStoppingStructuredSDFGVisitor::visit();
 }
 
-bool DataTransferMinimization::accept(structured_control_flow::Sequence& sequence) {
+bool DataTransferMinimizationLegacy::accept(structured_control_flow::Sequence& sequence) {
     bool applied = false;
     offloading::DataOffloadingNode* copy_out = nullptr;
     structured_control_flow::Block* copy_out_block = nullptr;
@@ -194,7 +291,7 @@ bool DataTransferMinimization::accept(structured_control_flow::Sequence& sequenc
     return applied;
 }
 
-std::pair<data_flow::AccessNode*, data_flow::AccessNode*> DataTransferMinimization::
+std::pair<data_flow::AccessNode*, data_flow::AccessNode*> DataTransferMinimizationLegacy::
     get_src_and_dst(data_flow::DataFlowGraph& dfg, offloading::DataOffloadingNode* offloading_node) {
     if (!offloading_node->has_transfer()) {
         throw InvalidSDFGException(
@@ -216,7 +313,8 @@ std::pair<data_flow::AccessNode*, data_flow::AccessNode*> DataTransferMinimizati
     return {src, dst};
 }
 
-data_flow::AccessNode* DataTransferMinimization::get_in_access(data_flow::CodeNode* node, const std::string& dst_conn) {
+data_flow::AccessNode* DataTransferMinimizationLegacy::
+    get_in_access(data_flow::CodeNode* node, const std::string& dst_conn) {
     auto& dfg = node->get_parent();
     for (auto& iedge : dfg.in_edges(*node)) {
         if (iedge.dst_conn() == dst_conn) {
@@ -226,7 +324,8 @@ data_flow::AccessNode* DataTransferMinimization::get_in_access(data_flow::CodeNo
     return nullptr;
 }
 
-data_flow::AccessNode* DataTransferMinimization::get_out_access(data_flow::CodeNode* node, const std::string& src_conn) {
+data_flow::AccessNode* DataTransferMinimizationLegacy::
+    get_out_access(data_flow::CodeNode* node, const std::string& src_conn) {
     auto& dfg = node->get_parent();
     for (auto& oedge : dfg.out_edges(*node)) {
         if (oedge.src_conn() == src_conn) {
@@ -236,7 +335,7 @@ data_flow::AccessNode* DataTransferMinimization::get_out_access(data_flow::CodeN
     return nullptr;
 }
 
-bool DataTransferMinimization::check_container_dependency(
+bool DataTransferMinimizationLegacy::check_container_dependency(
     structured_control_flow::Block* copy_out_block,
     const std::string& copy_out_container,
     structured_control_flow::Block* copy_in_block,

--- a/opt/src/passes/scheduler/loop_scheduling_pass.cpp
+++ b/opt/src/passes/scheduler/loop_scheduling_pass.cpp
@@ -1,5 +1,6 @@
 #include "sdfg/passes/scheduler/loop_scheduling_pass.h"
 
+#include "sdfg/analysis/data_transfer_elimination_analysis.h"
 #include "sdfg/passes/offloading/data_transfer_minimization_pass.h"
 #include "sdfg/passes/scheduler/loop_scheduler.h"
 #include "sdfg/passes/scheduler/scheduler_registry.h"
@@ -149,11 +150,6 @@ bool LoopSchedulingPass::run_pass(builder::StructuredSDFGBuilder& builder, analy
     for (const auto& target : targets_) {
         bool target_applied = run_pass_target(builder, analysis_manager, target);
         applied = applied || target_applied;
-    }
-
-    if (applied) {
-        DataTransferMinimizationPass dtm_pass;
-        dtm_pass.run(builder, analysis_manager);
     }
 
     return applied;

--- a/opt/tests/passes/offloading/data_transfer_minimization_pass_test.cpp
+++ b/opt/tests/passes/offloading/data_transfer_minimization_pass_test.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include "../../../../sdfg/tests/sdfg_debug_dump.h"
 #include "sdfg/analysis/analysis.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
 #include "sdfg/element.h"
@@ -99,8 +100,12 @@ TEST(DataTransferMinimizationPassTest, MultiMapTest) {
     auto& out_type2 = builder.subject().type("A");
     builder.add_computational_memlet(block2, memcpy_node2, "_dst", access_node_out2, {}, out_type2);
 
+    dump_sdfg(builder.subject(), "0-before");
+
     passes::DataTransferMinimizationPass pass;
     EXPECT_TRUE(pass.run(builder, analysis_manager));
+
+    dump_sdfg(builder.subject(), "1-after");
 
     EXPECT_EQ(block.dataflow().nodes().size(), 0);
     EXPECT_EQ(block2.dataflow().nodes().size(), 0);
@@ -166,8 +171,12 @@ TEST(DataTransferMinimizationPassTest, MultiMapWithLatterUseTest) {
     builder.add_computational_memlet(block3, C3, tasklet3, "_in", {symbolic::zero()});
     builder.add_computational_memlet(block3, tasklet3, "_out", B, {symbolic::zero()});
 
+    dump_sdfg(builder.subject(), "0-before");
+
     passes::DataTransferMinimizationPass pass;
     EXPECT_TRUE(pass.run(builder, analysis_manager));
+
+    dump_sdfg(builder.subject(), "1-after");
 
     // Check that there is exactly two H2D and one D2H transfer for C
     int h2d_count = 0;

--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -55,6 +55,7 @@
 #include "docc/util/docc_paths.h"
 #include "sdfg/passes/offloading/code_motion/block_hoisting.h"
 #include "sdfg/passes/offloading/code_motion/block_sorting.h"
+#include "sdfg/passes/offloading/data_transfer_minimization_pass.h"
 #include "sdfg/passes/rpc/daisytuner_rpc_context.h"
 #include "sdfg/passes/rpc/rpc_context.h"
 #include "sdfg/passes/rpc/rpc_scheduler.h"
@@ -392,7 +393,11 @@ void PyStructuredSDFG::schedule(const std::string& target, const std::string& ca
         std::cerr << "[WARNING] Target '" << target << "' is not supported, ignoring!" << std::endl;
     }
     sdfg::passes::scheduler::LoopSchedulingPass loop_scheduling_pass(schedulers, nullptr);
-    loop_scheduling_pass.run(builder, analysis_manager);
+    bool loop_scheduling_changes = loop_scheduling_pass.run(builder, analysis_manager);
+    if (loop_scheduling_changes) {
+        sdfg::passes::DataTransferMinimizationPass data_transfer_minimization_pass;
+        data_transfer_minimization_pass.run(builder, analysis_manager);
+    }
 }
 
 struct SnippetMetadata {

--- a/sdfg/include/sdfg/analysis/base_user_visitor.h
+++ b/sdfg/include/sdfg/analysis/base_user_visitor.h
@@ -4,10 +4,7 @@
 
 namespace sdfg::analysis {
 
-/**
- * Finds uses of containers
- */
-class BaseUserVisitor : public visitor::ActualStructuredSDFGVisitor {
+class BaseUserAnalyzer {
 public:
     constexpr static int LOC_LOOP_READ_INIT = 0;
     constexpr static int LOC_LOOP_READ_CONDITION = 1;
@@ -27,14 +24,19 @@ public:
                    // call!
     };
 
+    virtual ~BaseUserAnalyzer() = default;
+
     virtual void use_as_symbol_read(
         const std::string& container,
+        const ControlFlowNode* node,
         const Element* user,
         SymbolReadLocation loc,
         int loc_index,
         symbolic::Expression expr
     ) = 0;
-    virtual void use_as_symbol_write(const symbolic::Symbol& container, const Element* user, SymbolWriteLocation loc) = 0;
+    virtual void use_as_symbol_write(
+        const symbolic::Symbol& container, const ControlFlowNode* node, const Element* user, SymbolWriteLocation loc
+    ) = 0;
     virtual void use_as_src_node(
         const std::string& container,
         const data_flow::AccessNode& node,
@@ -48,6 +50,17 @@ public:
         const Block& block
     ) = 0;
     virtual void use_as_return_src(const std::string& container, const Return& ret) = 0;
+};
+
+/**
+ * Finds uses of containers
+ */
+class BaseUserVisitor : public visitor::ActualStructuredSDFGVisitor, public virtual BaseUserAnalyzer {
+public:
+    virtual void handle_lib_node(Block&, data_flow::LibraryNode& libnode);
+
+    virtual void handle_structured_loop_before_body(StructuredLoop& loop);
+    virtual void handle_structured_loop_after_body(StructuredLoop& loop);
 
     bool visit(sdfg::structured_control_flow::Block& node) override;
     bool visit(sdfg::structured_control_flow::Sequence& node) override;

--- a/sdfg/include/sdfg/analysis/pointer_analyzers.h
+++ b/sdfg/include/sdfg/analysis/pointer_analyzers.h
@@ -1,0 +1,201 @@
+#pragma once
+
+#include <concepts>
+#include <string>
+#include <unordered_map>
+
+#include "sdfg/analysis/base_user_visitor.h"
+#include "sdfg/function.h"
+
+namespace sdfg::analysis {
+/**
+ * Concept for policies that handle pointer escape and overwrite events.
+ *
+ * An EscapePolicy receives notifications when a pointer-typed container
+ * is observed to escape (its value becomes visible outside the current scope)
+ * or to be overwritten (a new value is assigned to the pointer variable itself).
+ */
+template<typename P>
+concept EscapePolicy = requires(P& p, const std::string& container, const ControlFlowNode* node, const Element* user) {
+    p.on_escape(container, node, user);
+};
+
+/**
+ * Reusable BaseUserAnalyzer that detects pointer escapes and overwrites.
+ *
+ * For each of the 5 BaseUserAnalyzer callbacks, it checks whether the access
+ * involves a pointer-typed container and whether the operation constitutes
+ * an escape (value leaks out of our control) or an overwrite (the pointer
+ * variable itself is reassigned).  Detected events are forwarded to the
+ * policy object via static dispatch.
+ *
+ * Does NOT walk the SDFG itself — must be driven by a BaseUserVisitor
+ * (or future CompositeUserVisitor) that calls the callbacks.
+ */
+template<EscapePolicy Policy>
+class PointerEscapeAnalyzer : public virtual BaseUserAnalyzer {
+    const StructuredSDFG& sdfg_;
+    Policy& policy_;
+
+public:
+    PointerEscapeAnalyzer(const StructuredSDFG& sdfg, Policy& policy) : sdfg_(sdfg), policy_(policy) {}
+
+    void use_as_return_src(const std::string& container, const Return& ret) override {
+        if (sdfg_.type(container).type_id() == types::TypeID::Pointer) {
+            policy_.on_escape(container, &ret, &ret);
+        }
+    }
+
+    void use_as_symbol_read(
+        const std::string& container,
+        const ControlFlowNode* node,
+        const Element* user,
+        SymbolReadLocation loc,
+        int loc_index,
+        symbolic::Expression expr
+    ) override {
+        auto& type = sdfg_.type(container);
+        if (type.type_id() == types::TypeID::Pointer) {
+            policy_.on_escape(container, node, user);
+        }
+    }
+
+    void use_as_src_node(
+        const std::string& container,
+        const data_flow::AccessNode& node,
+        const data_flow::Memlet& edge,
+        const Block& block
+    ) override {
+        auto& type = sdfg_.type(container);
+        if (edge.is_src_pointed_to_address_leak(type) || edge.is_src_address_leak()) {
+            // pulls a reference to the owned memory area or can alias the entire pointer
+
+            policy_.on_escape(container, &block, &edge);
+            // it may not be, but this is the safest
+            // assumption. other passes can forward the original container and fold it into accesses
+        }
+    }
+
+    void use_as_dst_node(
+        const std::string& container,
+        const data_flow::AccessNode& node,
+        const data_flow::Memlet& edge,
+        const Block& block
+    ) override {}
+    void use_as_symbol_write(
+        const symbolic::Symbol& container, const ControlFlowNode* node, const Element* user, SymbolWriteLocation loc
+    ) override {}
+};
+
+template<typename P>
+concept OverwritePolicy =
+    requires(P& p, const std::string& container, const ControlFlowNode* node, const Element* user) {
+        p.on_overwrite(container, node, user);
+    };
+
+template<OverwritePolicy Policy>
+class PointerOverwriteAnalyzer : public BaseUserAnalyzer {
+    const StructuredSDFG& sdfg_;
+    Policy& policy_;
+
+public:
+    PointerOverwriteAnalyzer(const StructuredSDFG& sdfg, Policy& policy) : sdfg_(sdfg), policy_(policy) {}
+
+    void use_as_dst_node(
+        const std::string& container,
+        const data_flow::AccessNode& node,
+        const data_flow::Memlet& edge,
+        const Block& block
+    ) override {
+        if (edge.is_dst_write()) { // writes to the ptr
+            auto& type = sdfg_.type(container);
+            if (type.type_id() == types::TypeID::Pointer) {
+                policy_.on_overwrite(container, &block, &edge);
+            }
+        }
+    }
+
+    void use_as_symbol_write(
+        const symbolic::Symbol& container, const ControlFlowNode* node, const Element* user, SymbolWriteLocation loc
+    ) override {
+        auto name = container->get_name();
+        if (sdfg_.type(name).type_id() == types::TypeID::Pointer) {
+            policy_.on_overwrite(name, node, user);
+        }
+    }
+
+    void use_as_return_src(const std::string& container, const Return& ret) override {}
+    void use_as_src_node(
+        const std::string& container,
+        const data_flow::AccessNode& node,
+        const data_flow::Memlet& edge,
+        const Block& block
+    ) override {}
+    void use_as_symbol_read(
+        const std::string& container,
+        const ControlFlowNode* node,
+        const Element* user,
+        SymbolReadLocation loc,
+        int loc_index,
+        symbolic::Expression expr
+    ) override {}
+};
+
+template<typename P>
+concept PointerUsedPolicy =
+    requires(P& p, const std::string& container, const ControlFlowNode* node, const data_flow::Memlet* user) {
+        p.on_write_via(container, node, user);
+        p.on_read_via(container, node, user);
+    };
+
+/**
+ * Indirect access via pointer happened
+ **/
+template<PointerUsedPolicy Policy>
+class PointerUsedAnalyzer : public BaseUserAnalyzer {
+    const StructuredSDFG& sdfg_;
+    Policy& policy_;
+
+public:
+    PointerUsedAnalyzer(const StructuredSDFG& sdfg, Policy& policy) : sdfg_(sdfg), policy_(policy) {}
+
+    void use_as_src_node(
+        const std::string& container,
+        const data_flow::AccessNode& node,
+        const data_flow::Memlet& edge,
+        const Block& block
+    ) override {
+        if (edge.is_src_pointed_to_read()) {
+            policy_.on_read_via(container, &block, &edge);
+        }
+    }
+
+    void use_as_dst_node(
+        const std::string& container,
+        const data_flow::AccessNode& node,
+        const data_flow::Memlet& edge,
+        const Block& block
+    ) override {
+        if (edge.is_dst_pointed_to_write()) {
+            policy_.on_write_via(container, &block, &edge);
+        }
+    }
+
+    void use_as_symbol_write(
+        const symbolic::Symbol& container, const ControlFlowNode* node, const Element* user, SymbolWriteLocation loc
+    ) override {}
+
+    void use_as_return_src(const std::string& container, const Return& ret) override {}
+
+    void use_as_symbol_read(
+        const std::string& container,
+        const ControlFlowNode* node,
+        const Element* user,
+        SymbolReadLocation loc,
+        int loc_index,
+        symbolic::Expression expr
+    ) override {}
+};
+
+
+} // namespace sdfg::analysis

--- a/sdfg/include/sdfg/structured_control_flow/map.h
+++ b/sdfg/include/sdfg/structured_control_flow/map.h
@@ -74,6 +74,7 @@ public:
         for (const auto& entry : rhs.properties_) {
             properties_.insert(entry);
         }
+        category_ = rhs.category_;
     }
 };
 

--- a/sdfg/include/sdfg/visualizer/dot_visualizer.h
+++ b/sdfg/include/sdfg/visualizer/dot_visualizer.h
@@ -18,6 +18,7 @@ class DotVisualizer : public Visualizer {
 private:
     std::string last_comp_name_;
     std::string last_comp_name_cluster_;
+    bool show_block_ids = false;
 
     virtual void visualizeBlock(const StructuredSDFG& sdfg, const structured_control_flow::Block& block) override;
     virtual void visualizeSequence(const StructuredSDFG& sdfg, const structured_control_flow::Sequence& sequence)

--- a/sdfg/src/analysis/base_user_visitor.cpp
+++ b/sdfg/src/analysis/base_user_visitor.cpp
@@ -2,6 +2,14 @@
 
 namespace sdfg::analysis {
 
+void BaseUserVisitor::handle_lib_node(Block& block, data_flow::LibraryNode& libnode) {
+    for (auto atom : libnode.symbols()) {
+        if (!symbolic::is_nullptr(atom)) {
+            use_as_symbol_read(atom->get_name(), &block, &libnode, SymbolReadLocation::LibraryNode, -1, SymEngine::null);
+        }
+    }
+}
+
 bool BaseUserVisitor::visit(sdfg::structured_control_flow::Block& node) {
     auto& dflow = node.dataflow();
     for (auto dnode : dflow.topological_sort()) {
@@ -9,11 +17,7 @@ bool BaseUserVisitor::visit(sdfg::structured_control_flow::Block& node) {
         std::string maybe_container;
 
         if (auto libnode = dynamic_cast<data_flow::LibraryNode*>(dnode)) {
-            for (auto atom : libnode->symbols()) {
-                if (!symbolic::is_nullptr(atom)) {
-                    use_as_symbol_read(atom->get_name(), libnode, SymbolReadLocation::LibraryNode, -1, SymEngine::null);
-                }
-            }
+            handle_lib_node(node, *libnode);
         } else if (auto access_node = dynamic_cast<data_flow::AccessNode*>(dnode)) {
             if (dynamic_cast<data_flow::ConstantNode*>(dnode) == nullptr) {
                 maybe_container = access_node->data();
@@ -32,7 +36,9 @@ bool BaseUserVisitor::visit(sdfg::structured_control_flow::Block& node) {
                 auto& subset_part = edge.subset().at(i);
                 for (auto& atom : symbolic::atoms(subset_part)) {
                     if (!symbolic::is_nullptr(atom)) {
-                        use_as_symbol_read(atom->get_name(), &edge, SymbolReadLocation::MemletSubset, i, subset_part);
+                        use_as_symbol_read(
+                            atom->get_name(), &node, &edge, SymbolReadLocation::MemletSubset, i, subset_part
+                        );
                     }
                 }
             }
@@ -67,7 +73,9 @@ bool BaseUserVisitor::visit(sdfg::structured_control_flow::Sequence& node) {
         for (auto& entry : transition.assignments()) {
             for (auto& atom : symbolic::atoms(entry.second)) {
                 if (!symbolic::is_nullptr(atom)) {
-                    use_as_symbol_read(atom->get_name(), &transition, SymbolReadLocation::Assignment, i, entry.second);
+                    use_as_symbol_read(
+                        atom->get_name(), &node, &transition, SymbolReadLocation::Assignment, i, entry.second
+                    );
                 }
             }
         }
@@ -80,7 +88,7 @@ bool BaseUserVisitor::visit(sdfg::structured_control_flow::IfElse& node) {
         auto [seq, condition] = node.at(i);
         for (auto& atom : symbolic::atoms(condition)) {
             if (!symbolic::is_nullptr(atom)) {
-                use_as_symbol_read(atom->get_name(), &node, SymbolReadLocation::IfHeader, i, condition);
+                use_as_symbol_read(atom->get_name(), &node, &node, SymbolReadLocation::IfHeader, i, condition);
             }
         }
         dispatch(seq);
@@ -88,29 +96,41 @@ bool BaseUserVisitor::visit(sdfg::structured_control_flow::IfElse& node) {
     return true;
 }
 
-bool BaseUserVisitor::handleStructuredLoop(StructuredLoop& loop) {
-    use_as_symbol_write(loop.indvar(), &loop, SymbolWriteLocation::LoopHeader); // for both init and update
+void BaseUserVisitor::handle_structured_loop_before_body(StructuredLoop& loop) {
+    use_as_symbol_write(loop.indvar(), &loop, &loop, SymbolWriteLocation::LoopHeader); // for both init and update
 
     for (auto& atom : symbolic::atoms(loop.init())) {
         if (!symbolic::is_nullptr(atom)) {
-            use_as_symbol_read(atom->get_name(), &loop, SymbolReadLocation::LoopHeader, LOC_LOOP_READ_INIT, loop.init());
+            use_as_symbol_read(
+                atom->get_name(), &loop, &loop, SymbolReadLocation::LoopHeader, LOC_LOOP_READ_INIT, loop.init()
+            );
         }
     }
     for (auto& atom : symbolic::atoms(loop.condition())) {
         if (!symbolic::is_nullptr(atom)) {
             use_as_symbol_read(
-                atom->get_name(), &loop, SymbolReadLocation::LoopHeader, LOC_LOOP_READ_CONDITION, loop.init()
+                atom->get_name(), &loop, &loop, SymbolReadLocation::LoopHeader, LOC_LOOP_READ_CONDITION, loop.init()
             );
         }
     }
+}
+
+void BaseUserVisitor::handle_structured_loop_after_body(StructuredLoop& loop) {
+    for (auto& atom : symbolic::atoms(loop.update())) {
+        if (!symbolic::is_nullptr(atom)) {
+            use_as_symbol_read(
+                atom->get_name(), &loop, &loop, SymbolReadLocation::LoopHeader, LOC_LOOP_READ_UPDATE, loop.init()
+            );
+        }
+    }
+}
+
+bool BaseUserVisitor::handleStructuredLoop(StructuredLoop& loop) {
+    handle_structured_loop_before_body(loop);
 
     ActualStructuredSDFGVisitor::handleStructuredLoop(loop); // descend further
 
-    for (auto& atom : symbolic::atoms(loop.update())) {
-        if (!symbolic::is_nullptr(atom)) {
-            use_as_symbol_read(atom->get_name(), &loop, SymbolReadLocation::LoopHeader, LOC_LOOP_READ_UPDATE, loop.init());
-        }
-    }
+    handle_structured_loop_after_body(loop);
 
     return true;
 }

--- a/sdfg/src/offloading/data_offloading_node.cpp
+++ b/sdfg/src/offloading/data_offloading_node.cpp
@@ -14,6 +14,8 @@
 namespace sdfg {
 namespace offloading {
 
+constexpr bool dump_offload_node_ids = false;
+
 DataOffloadingNode::DataOffloadingNode(
     size_t element_id,
     const DebugInfo& debug_info,
@@ -77,7 +79,12 @@ std::string DataOffloadingNode::toStr() const {
             lifecycle = " NO_CHANGE";
             break;
     }
-    return std::string(this->code_.value()) + direction + lifecycle;
+    std::string res = std::string(this->code_.value());
+    if (dump_offload_node_ids) {
+        res += " #" + std::to_string(element_id_);
+    }
+    res += direction + lifecycle;
+    return res;
 }
 
 symbolic::Expression DataOffloadingNode::flop() const { return symbolic::zero(); }

--- a/sdfg/src/passes/dataflow/dead_data_elimination.cpp
+++ b/sdfg/src/passes/dataflow/dead_data_elimination.cpp
@@ -2,6 +2,7 @@
 
 #include "sdfg/analysis/base_user_visitor.h"
 #include "sdfg/analysis/data_dependency_analysis.h"
+#include "sdfg/analysis/pointer_analyzers.h"
 #include "sdfg/data_flow/library_nodes/stdlib/free.h"
 #include "sdfg/data_flow/library_nodes/stdlib/malloc.h"
 #include "sdfg/visitor/structured_sdfg_visitor.h"
@@ -17,13 +18,37 @@ DeadDataElimination::DeadDataElimination(bool permissive) : Pass(), permissive_(
 std::string DeadDataElimination::name() { return "DeadDataElimination"; };
 
 /**
+ * Simple escape policy that collects all escape and overwrite events
+ * into a map of container -> {element -> type} entries.
+ */
+class BlockerListPolicy {
+public:
+    enum class BlockerType { Escape, Overwrite };
+
+    using BlockerMap = std::unordered_map<std::string, std::unordered_map<const Element*, BlockerType>>;
+
+protected:
+    BlockerMap blockers_;
+
+public:
+    void on_escape(const std::string& container, const ControlFlowNode* node, const Element* user) {
+        blockers_[container].emplace(user, BlockerType::Escape);
+    }
+
+    void on_overwrite(const std::string& container, const ControlFlowNode* node, const Element* user) {
+        blockers_[container].emplace(user, BlockerType::Overwrite);
+    }
+};
+
+/**
  * Finds memory areas (heap for now) that are wholly owned by the surrounding function. Owned memory can be removed if
  * its no longer used, writes to it can be ellided if the data is never read. This is not true for memory writes in
  * general, as you must prove no reference to that data ever escapes our control
  */
-class MemoryOwnershipAnalysis : public analysis::BaseUserVisitor {
-    enum class BlockerType { Escape, Overwrite };
-
+class MemoryOwnershipAnalysis : public analysis::BaseUserVisitor,
+                                analysis::PointerEscapeAnalyzer<BlockerListPolicy>,
+                                analysis::PointerOverwriteAnalyzer<BlockerListPolicy>,
+                                BlockerListPolicy {
     struct FreeCluster {
         const Block* block;
         const data_flow::Memlet* in;
@@ -49,7 +74,6 @@ private:
     StructuredSDFG& sdfg_;
     // memory that is allocated by us and therefore 'owned' until it escapes
     std::unordered_map<std::string, OwnedArea> originally_owned_data_;
-    std::unordered_map<std::string, std::unordered_map<const Element*, BlockerType>> blockers_;
     std::unordered_set<std::string> fully_owned_; // never escaped
 
 public:
@@ -59,27 +83,45 @@ public:
 
     bool visit(sdfg::structured_control_flow::Block& node) override;
 
-    void use_as_symbol_write(const symbolic::Symbol& container, const Element* user, SymbolWriteLocation loc) override;
+    void use_as_symbol_write(
+        const symbolic::Symbol& container, const ControlFlowNode* node, const Element* user, SymbolWriteLocation loc
+    ) override {
+        PointerEscapeAnalyzer::use_as_symbol_write(container, node, user, loc);
+        PointerOverwriteAnalyzer::use_as_symbol_write(container, node, user, loc);
+    }
     void use_as_symbol_read(
         const std::string& container,
+        const ControlFlowNode* node,
         const Element* user,
         SymbolReadLocation loc,
         int loc_index,
         symbolic::Expression expr
-    ) override;
+    ) override {
+        PointerEscapeAnalyzer::use_as_symbol_read(container, node, user, loc, loc_index, std::move(expr));
+        PointerOverwriteAnalyzer::use_as_symbol_read(container, node, user, loc, loc_index, std::move(expr));
+    }
     void use_as_src_node(
         const std::string& container,
         const data_flow::AccessNode& node,
         const data_flow::Memlet& edge,
         const Block& block
-    ) override;
+    ) override {
+        PointerEscapeAnalyzer::use_as_src_node(container, node, edge, block);
+        PointerOverwriteAnalyzer::use_as_src_node(container, node, edge, block);
+    }
     void use_as_dst_node(
         const std::string& container,
         const data_flow::AccessNode& node,
         const data_flow::Memlet& edge,
         const Block& block
-    ) override;
-    void use_as_return_src(const std::string& container, const Return& ret) override;
+    ) override {
+        PointerEscapeAnalyzer::use_as_dst_node(container, node, edge, block);
+        PointerOverwriteAnalyzer::use_as_dst_node(container, node, edge, block);
+    }
+    void use_as_return_src(const std::string& container, const Return& ret) override {
+        PointerEscapeAnalyzer::use_as_return_src(container, ret);
+        PointerOverwriteAnalyzer::use_as_return_src(container, ret);
+    }
 
     const std::unordered_set<std::string>& fully_owned_areas() const { return fully_owned_; }
 
@@ -107,7 +149,8 @@ void MemoryOwnershipAnalysis::OwnedArea::remove_from(builder::StructuredSDFGBuil
     }
 }
 
-MemoryOwnershipAnalysis::MemoryOwnershipAnalysis(StructuredSDFG& sdfg) : sdfg_(sdfg) {}
+MemoryOwnershipAnalysis::MemoryOwnershipAnalysis(StructuredSDFG& sdfg)
+    : sdfg_(sdfg), PointerEscapeAnalyzer(sdfg, *this), PointerOverwriteAnalyzer(sdfg, *this) {}
 
 bool MemoryOwnershipAnalysis::excusedEscape(const Element* element, const OwnedArea& area) {
     // An escape is excused if it matches the input edge of one of the free_clusters.
@@ -224,53 +267,6 @@ bool MemoryOwnershipAnalysis::visit(sdfg::structured_control_flow::Block& node) 
     return BaseUserVisitor::visit(node);
 }
 
-
-void MemoryOwnershipAnalysis::use_as_return_src(const std::string& container, const Return& ret) {
-    if (sdfg_.type(container).type_id() == types::TypeID::Pointer) {
-        blockers_[container].emplace(&ret, BlockerType::Escape);
-    }
-}
-
-void MemoryOwnershipAnalysis::
-    use_as_symbol_write(const symbolic::Symbol& container, const Element* user, SymbolWriteLocation loc) {
-    auto name = container->get_name();
-    if (sdfg_.type(name).type_id() == types::TypeID::Pointer) {
-        blockers_[name].emplace(user, BlockerType::Overwrite);
-    }
-}
-
-void MemoryOwnershipAnalysis::use_as_symbol_read(
-    const std::string& container, const Element* user, SymbolReadLocation loc, int loc_index, symbolic::Expression expr
-) {
-    auto& type = sdfg_.type(container);
-    if (type.type_id() == types::TypeID::Pointer) {
-        blockers_[container].emplace(user, BlockerType::Escape);
-    }
-}
-
-void MemoryOwnershipAnalysis::use_as_src_node(
-    const std::string& container, const data_flow::AccessNode& node, const data_flow::Memlet& edge, const Block& block
-) {
-    auto& type = sdfg_.type(container);
-    if (edge.is_src_pointed_to_address_leak(type) || edge.is_src_address_leak()) {
-        // pulls a reference to the owned memory area or can alias the entire pointer
-
-        blockers_[container].emplace(&edge, BlockerType::Escape); // it may not be, but this is the safest
-        // assumption. other passes can forward the original container and fold it into accesses
-    }
-}
-
-void MemoryOwnershipAnalysis::use_as_dst_node(
-    const std::string& container, const data_flow::AccessNode& node, const data_flow::Memlet& edge, const Block& block
-) {
-    if (edge.is_dst_write()) { // writes to the ptr
-        auto& type = sdfg_.type(container);
-        if (type.type_id() == types::TypeID::Pointer) {
-            blockers_[container].emplace(&edge, BlockerType::Overwrite);
-        }
-    }
-}
-
 /**
  * Does not care about other types of accesses.
  * Presumes, that the data cannot alias and there is only one SSA-like instance of backing data.
@@ -278,7 +274,8 @@ void MemoryOwnershipAnalysis::use_as_dst_node(
  * Any read of the pointer or getting of an address is considered an escape for which aliasing cannot be excluded,
  * in which case you must not rely on this analysis
  */
-class IndirectMemoryAccessFinder : public analysis::BaseUserVisitor {
+class IndirectMemoryAccessFinder : public analysis::BaseUserVisitor { // TODO update to use the PointerUsedAnalyzer and
+                                                                      // a policy that filters the containstarg
 private:
     std::unordered_map<std::string, std::unordered_set<const data_flow::Memlet*>> indirect_reads_;
     std::unordered_map<std::string, std::unordered_map<const data_flow::Memlet*, const Block*>> writes_to_remove_;
@@ -296,13 +293,15 @@ public:
 
     void use_as_symbol_read(
         const std::string& container,
+        const ControlFlowNode* node,
         const Element* user,
         SymbolReadLocation loc,
         int loc_index,
         symbolic::Expression expr
     ) override {}
-    void use_as_symbol_write(const symbolic::Symbol& container, const Element* user, SymbolWriteLocation loc) override {
-    }
+    void use_as_symbol_write(
+        const symbolic::Symbol& container, const ControlFlowNode* node, const Element* user, SymbolWriteLocation loc
+    ) override {}
     void use_as_src_node(
         const std::string& container,
         const data_flow::AccessNode& node,

--- a/sdfg/src/visualizer/dot_visualizer.cpp
+++ b/sdfg/src/visualizer/dot_visualizer.cpp
@@ -26,7 +26,11 @@ void DotVisualizer::visualizeBlock(const StructuredSDFG& sdfg, const structured_
     auto id = escapeDotId(block.element_id(), "block_");
     this->stream_ << "subgraph cluster_" << id << " {" << std::endl;
     this->stream_.setIndent(this->stream_.indent() + 4);
-    this->stream_ << "style=filled;shape=box;fillcolor=white;color=black;label=\"\";" << std::endl;
+    this->stream_ << "style=filled;shape=box;fillcolor=white;color=black;label=\"";
+    if (show_block_ids) {
+        this->stream_ << "#" << block.element_id() << " ";
+    }
+    this->stream_ << "\";" << std::endl;
     this->last_comp_name_cluster_ = "cluster_" + id;
     if (block.dataflow().nodes().empty()) {
         this->stream_ << id << " [shape=point,style=invis,label=\"\"];" << std::endl;
@@ -187,8 +191,11 @@ void DotVisualizer::visualizeIfElse(const StructuredSDFG& sdfg, const structured
     auto id = escapeDotId(if_else.element_id(), "if_");
     this->stream_ << "subgraph cluster_" << id << " {" << std::endl;
     this->stream_.setIndent(this->stream_.indent() + 4);
-    this->stream_ << "style=filled;shape=box;fillcolor=white;color=black;label=\"if:\";" << std::endl
-                  << id << " [shape=point,style=invis,label=\"\"];" << std::endl;
+    this->stream_ << "style=filled;shape=box;fillcolor=white;color=black;label=\"";
+    if (show_block_ids) {
+        this->stream_ << "#" << if_else.element_id() << " ";
+    }
+    this->stream_ << "if:\";" << std::endl << id << " [shape=point,style=invis,label=\"\"];" << std::endl;
     for (size_t i = 0; i < if_else.size(); ++i) {
         this->stream_ << "subgraph cluster_" << id << "_" << std::to_string(i) << " {" << std::endl;
         this->stream_.setIndent(this->stream_.indent() + 4);
@@ -208,8 +215,11 @@ void DotVisualizer::visualizeWhile(const StructuredSDFG& sdfg, const structured_
     auto id = escapeDotId(while_loop.element_id(), "while_");
     this->stream_ << "subgraph cluster_" << id << " {" << std::endl;
     this->stream_.setIndent(this->stream_.indent() + 4);
-    this->stream_ << "style=filled;shape=box;fillcolor=white;color=black;label=\"while:\";" << std::endl
-                  << id << " [shape=point,style=invis,label=\"\"];" << std::endl;
+    this->stream_ << "style=filled;shape=box;fillcolor=white;color=black;label=\"";
+    if (show_block_ids) {
+        this->stream_ << "#" << while_loop.element_id() << " ";
+    }
+    this->stream_ << "while:\";" << std::endl << id << " [shape=point,style=invis,label=\"\"];" << std::endl;
     this->visualizeSequence(sdfg, while_loop.root());
     this->stream_.setIndent(this->stream_.indent() - 4);
     this->stream_ << "}" << std::endl;
@@ -221,7 +231,11 @@ void DotVisualizer::visualizeFor(const StructuredSDFG& sdfg, const structured_co
     auto id = escapeDotId(loop.element_id(), "for_");
     this->stream_ << "subgraph cluster_" << id << " {" << std::endl;
     this->stream_.setIndent(this->stream_.indent() + 4);
-    this->stream_ << "style=filled;shape=box;fillcolor=white;color=black;label=\"for: ";
+    this->stream_ << "style=filled;shape=box;fillcolor=white;color=black;label=\"";
+    if (show_block_ids) {
+        this->stream_ << "#" << loop.element_id() << " ";
+    }
+    this->stream_ << "for: ";
     this->visualizeForBounds(loop.indvar(), loop.init(), loop.condition(), loop.update());
     this->stream_ << "\";" << std::endl << id << " [shape=point,style=invis,label=\"\"];" << std::endl;
     this->visualizeSequence(sdfg, loop.root());
@@ -255,8 +269,13 @@ void DotVisualizer::visualizeMap(const StructuredSDFG& sdfg, const structured_co
     auto id = escapeDotId(map_node.element_id(), "map_");
     this->stream_ << "subgraph cluster_" << id << " {" << std::endl;
     this->stream_.setIndent(this->stream_.indent() + 4);
-    this->stream_ << "style=filled;shape=box;fillcolor=white;color=black;label=\"map: ";
+    this->stream_ << "style=filled;shape=box;fillcolor=white;color=black;label=\"";
+    if (show_block_ids) {
+        this->stream_ << "#" << map_node.element_id() << " ";
+    }
+    this->stream_ << "map: ";
     this->visualizeForBounds(map_node.indvar(), map_node.init(), map_node.condition(), map_node.update());
+
     this->stream_ << "\";" << std::endl << id << " [shape=point,style=invis,label=\"\"];" << std::endl;
     this->visualizeSequence(sdfg, map_node.root());
     this->stream_.setIndent(this->stream_.indent() - 4);


### PR DESCRIPTION
Redone following dataflow in execution order to support finding all hazards in between the offloading nodes to modify.

Built in top of new BaseUseVisitor and StructuredDataflowAnalysis.

The Dataflow Analysis is expected to support updating its propagation on changes in the future. Currently, it does not consider transitive changes (changes in dataflow due to removal / change of the SDFG)