### PR TITLE
Add support for DDE to remove mallocs and frees as dead-code when DataOffloadingNodes operate on them

### DIFF
--- a/opt/include/sdfg/transformations/offloading/offload_transform.h
+++ b/opt/include/sdfg/transformations/offloading/offload_transform.h
@@ -13,6 +13,7 @@ class OffloadTransform : public transformations::Transformation {
 protected:
     structured_control_flow::Map& map_;
     bool allow_dynamic_sizes_ = false;
+    bool skip_unneeded_d2h_ = true;
 
 public:
     explicit OffloadTransform(structured_control_flow::Map& map, bool allow_dynamic_sizes = false);

--- a/opt/src/transformations/offloading/offload_transform.cpp
+++ b/opt/src/transformations/offloading/offload_transform.cpp
@@ -160,7 +160,7 @@ void OffloadTransform::apply(builder::StructuredSDFGBuilder& builder, analysis::
         auto argument_device = container_prefix + argument;
         auto& new_block = builder.add_block_after(*parent_scope, this->map_, {}, this->map_.debug_info());
         auto& size = argument_sizes.at(argument);
-        if (meta.is_output) {
+        if (!skip_unneeded_d2h_ || meta.is_output) {
             copy_from_device_with_free(builder, new_block, argument, argument_device, size, SymEngine::null);
         } else {
             deallocate_device_arg(builder, new_block, argument_device, size, SymEngine::null);

--- a/python/benchmarks/npbench/polybench/test_fdtd_2d.py
+++ b/python/benchmarks/npbench/polybench/test_fdtd_2d.py
@@ -61,7 +61,7 @@ def test_fdtd_2d(target):
                 "MAP": 25,
                 "CUDAOffloading": 42,
                 "FOR": 26,
-                "Malloc": 9,
+                "Malloc": 0,
             }
         )
     else:  # rocm
@@ -71,7 +71,7 @@ def test_fdtd_2d(target):
                 "MAP": 25,
                 "ROCMOffloading": 42,
                 "FOR": 26,
-                "Malloc": 9,
+                "Malloc": 0,
             }
         )
     run_pytest(initialize, kernel, PARAMETERS, target, verifier=verifier)

--- a/python/benchmarks/npbench/polybench/test_floyd_warshall.py
+++ b/python/benchmarks/npbench/polybench/test_floyd_warshall.py
@@ -52,7 +52,7 @@ def test_floyd_warshall(target):
                 "MAP": 4,
                 "CUDAOffloading": 6,
                 "FOR": 5,
-                "Malloc": 1,
+                "Malloc": 0,
             }
         )
     else:  # rocm

--- a/python/benchmarks/npbench/polybench/test_gemver.py
+++ b/python/benchmarks/npbench/polybench/test_gemver.py
@@ -60,7 +60,7 @@ def test_gemver(target):
                 "FOR": 3,
                 "MAP": 3,
                 "CUDAOffloading": 14,
-                "Malloc": 3,
+                "Malloc": 2,
                 "GEMM": 4,
             }
         )
@@ -71,7 +71,7 @@ def test_gemver(target):
                 "FOR": 3,
                 "MAP": 3,
                 "ROCMOffloading": 14,
-                "Malloc": 3,
+                "Malloc": 2,
                 "GEMM": 4,
             }
         )

--- a/python/benchmarks/npbench/polybench/test_heat_3d.py
+++ b/python/benchmarks/npbench/polybench/test_heat_3d.py
@@ -73,7 +73,7 @@ def test_heat_3d(target):
                 "MAP": 62,
                 "SEQUENTIAL": 42,
                 "FOR": 67,
-                "Malloc": 30,
+                "Malloc": 22,
             }
         )
     else:  # rocm
@@ -84,7 +84,7 @@ def test_heat_3d(target):
                 "MAP": 62,
                 "SEQUENTIAL": 42,
                 "FOR": 67,
-                "Malloc": 30,
+                "Malloc": 22,
             }
         )
     run_pytest(initialize, kernel, PARAMETERS, target, verifier=verifier)

--- a/python/benchmarks/npbench/polybench/test_jacobi_2d.py
+++ b/python/benchmarks/npbench/polybench/test_jacobi_2d.py
@@ -62,7 +62,7 @@ def test_jacobi_2d(target):
                 "MAP": 24,
                 "CUDAOffloading": 40,
                 "FOR": 25,
-                "Malloc": 10,
+                "Malloc": 0,
             }
         )
     else:  # rocm
@@ -72,7 +72,7 @@ def test_jacobi_2d(target):
                 "MAP": 24,
                 "ROCMOffloading": 40,
                 "FOR": 25,
-                "Malloc": 10,
+                "Malloc": 0,
             }
         )
     run_pytest(initialize, kernel, PARAMETERS, target, verifier=verifier)

--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -401,6 +401,10 @@ void PyStructuredSDFG::schedule(const std::string& target, const std::string& ca
     if (loop_scheduling_changes) {
         sdfg::passes::DataTransferMinimizationPass data_transfer_minimization_pass;
         data_transfer_minimization_pass.run(builder, analysis_manager);
+        sdfg::passes::DeadDataElimination dde(false);
+        dde.run(builder, analysis_manager);
+        sdfg::passes::DeadCFGElimination dead_cfg_elimination;
+        dead_cfg_elimination.run(builder, analysis_manager);
     }
 }
 
@@ -599,7 +603,7 @@ std::string PyStructuredSDFG::compile(
 #endif
         }
         cmd << " " << source_path.string();
-        cmd << " -o " << (build_path / (sdfg_->name() + ".o")).string();
+        cmd << " -g -o " << (build_path / (sdfg_->name() + ".o")).string();
         DEBUG_PRINTLN("Compile: " << cmd.str());
         int ret = std::system(cmd.str().c_str());
         if (ret != 0) {
@@ -644,7 +648,7 @@ std::string PyStructuredSDFG::compile(
 #else
     cmd << " -lblas";
 #endif
-    cmd << " -lm";
+    cmd << " -lm -g";
     cmd << " -lstdc++";
     if (target == "cuda") {
         cmd << " /usr/local/cuda/lib64/libcudart.so";

--- a/sdfg/include/sdfg/data_flow/access_node.h
+++ b/sdfg/include/sdfg/data_flow/access_node.h
@@ -157,7 +157,7 @@ public:
      */
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
-    bool require_out_edge(const DataFlowGraph& graph, const Memlet* memlet) const override;
+    EdgeRemoveOption can_remove_out_edge(const DataFlowGraph& graph, const Memlet* memlet) const override;
 };
 
 /**

--- a/sdfg/include/sdfg/data_flow/data_flow_node.h
+++ b/sdfg/include/sdfg/data_flow/data_flow_node.h
@@ -68,6 +68,24 @@ class StructuredSDFGBuilder;
 
 namespace data_flow {
 
+enum class EdgeRemoveOption {
+    /** You must not remove this edge unless you can guarantee the entire node will be removed **/
+    NotRemovable,
+    /**
+     * You may remove the edge without further action
+     **/
+    Trivially,
+    /**
+     * It can be removed, but the node requires a call to update itself to match the removed edge
+     **/
+    RequiresUpdate,
+    /**
+     * This is the only relevant edge of this node. If it will be removed, the entire node must be removed as well,
+     * ignoring any potential side-effect flags of the node
+     **/
+    RemoveNodeAfter
+};
+
 class DataFlowGraph;
 class Memlet;
 
@@ -153,9 +171,21 @@ public:
     /**
      * Is the edge in question removable, or will this make the node its an output on invalid?
      * Currently, some nodes may require every out connector to have at least 1 connection attached
-     * @return true, if required
+     * @return NotRemovable, NoDependencies, CustomRemove
+     *
+     * [NotRemovable] means only if the entire node can be removed, can the edge be removed
+     * [NoDependencies] means, the edge can be removed trivially, the node will work without for the remaining functions
+     * [CustomRemove] means, a call to [remove_out_edge] can have the node remove the edge itself and make necessary
      */
-    virtual bool require_out_edge(const data_flow::DataFlowGraph& graph, const Memlet* memlet) const = 0;
+    virtual EdgeRemoveOption can_remove_out_edge(const data_flow::DataFlowGraph& graph, const Memlet* memlet) const = 0;
+
+    /**
+     *
+     * @param out_conn a output connector, whose edge was just removed after approval via [can_remove_out_edge] ==
+     * EdgeRemoveOption::RequiresUpdate
+     * @return edge removal is completed, node is valid without edge
+     */
+    virtual bool update_edge_removed(const std::string& out_conn) { return false; }
 };
 } // namespace data_flow
 } // namespace sdfg

--- a/sdfg/include/sdfg/data_flow/library_node.h
+++ b/sdfg/include/sdfg/data_flow/library_node.h
@@ -48,6 +48,7 @@
 #include <vector>
 
 #include "sdfg/data_flow/code_node.h"
+#include "sdfg/data_flow/pointer_metadata.h"
 #include "sdfg/graph/graph.h"
 #include "sdfg/symbolic/symbolic.h"
 
@@ -177,7 +178,14 @@ public:
      */
     virtual symbolic::Expression flop() const;
 
-    bool require_out_edge(const data_flow::DataFlowGraph& graph, const Memlet* memlet) const override;
+    /**
+     * Describes what a pointer is used for
+     * @param input_idx index of input that is a pointer.
+     * @return Invalid if not asked about a pointer input
+     */
+    virtual PointerAccessType pointer_access_type(int input_idx) const { return PointerUnknownAccess(); }
+
+    EdgeRemoveOption can_remove_out_edge(const data_flow::DataFlowGraph& graph, const Memlet* memlet) const override;
 };
 
 } // namespace data_flow

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/cmath/cmath_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/cmath/cmath_node.h
@@ -415,7 +415,8 @@ public:
 
     std::string toStr() const override;
 
-    virtual bool require_out_edge(const data_flow::DataFlowGraph& graph, const data_flow::Memlet* memlet) const override;
+    data_flow::EdgeRemoveOption can_remove_out_edge(const data_flow::DataFlowGraph& graph, const data_flow::Memlet* memlet)
+        const override;
 };
 
 class CMathNodeSerializer : public serializer::LibraryNodeSerializer {

--- a/sdfg/include/sdfg/data_flow/pointer_metadata.h
+++ b/sdfg/include/sdfg/data_flow/pointer_metadata.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <optional>
+#include "sdfg/symbolic/symbolic.h"
+
+namespace sdfg::data_flow {
+
+class MemoryAccessPattern {
+public:
+    virtual ~MemoryAccessPattern() = default;
+};
+
+class ConvexAccessPattern : public MemoryAccessPattern {
+private:
+    symbolic::Expression size_;
+
+public:
+    ConvexAccessPattern(symbolic::Expression size) : size_(size) {}
+
+    symbolic::Expression size() const { return size_; }
+};
+
+class PointerAccessMeta {
+protected:
+    PointerAccessMeta() = default;
+
+public:
+    virtual ~PointerAccessMeta() = default;
+};
+
+/**
+ * The pointer is only used for reading. Like const* in Cpp.
+ * Data pointed to will not change due to this.
+ */
+class PointerReadOnly : public PointerAccessMeta {
+private:
+    symbolic::Expression size_;
+    bool no_ptr_escape_;
+
+public:
+    PointerReadOnly(symbolic::Expression size, bool no_ptr_escape = false)
+        : size_(size), no_ptr_escape_(no_ptr_escape) {}
+
+    /**
+     * Despite this being a leak of the pointer,
+     * the user will only use it for blocking accesses to the underlying data and not keep a reference to the data in
+     * any way Like a Rust temporary borrow for the duration for the LibNode and no more.
+     */
+    bool no_ptr_escape() const { return no_ptr_escape_; }
+
+    /**
+     * Describes which elements are accessed (for example a function may only access the range of [ptr, ptr+8] bytes and
+     * touch or care about what comes after) Pointer access metadata only applies to the elements that are part of the
+     * pattern.
+     */
+    std::optional<MemoryAccessPattern> access_pattern() const {
+        if (size_.is_null()) {
+            return std::nullopt;
+        } else {
+            return ConvexAccessPattern(size_);
+        }
+    }
+};
+
+/**
+ * The pointer is used to overwrite all of the data. No data within the area survives
+ * The result could potentially be written to a new memory area
+ */
+class PointerFullWrite : public PointerAccessMeta {
+    /**
+     * Describes which elements are accessed (for example a function may only access the range of [ptr, ptr+8] bytes and
+     * touch or care about what comes after) Pointer access metadata only applies to the elements that are part of the
+     * pattern.
+     */
+    std::optional<MemoryAccessPattern> access_pattern() const { return std::nullopt; }
+};
+
+/**
+ * It is unknown what is done with this pointer or it is a mix of reads and writes.
+ * This could overwrite some parts of the area pointed to, but leave others as is.
+ * Assume the worst: data is made dirty by a black box. You know nothing about the contents after this
+ */
+class PointerUnknownAccess : public PointerAccessMeta {};
+
+typedef std::variant<PointerUnknownAccess, PointerReadOnly, PointerFullWrite> PointerAccessType;
+
+} // namespace sdfg::data_flow

--- a/sdfg/include/sdfg/data_flow/tasklet.h
+++ b/sdfg/include/sdfg/data_flow/tasklet.h
@@ -498,7 +498,7 @@ public:
      */
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
-    bool require_out_edge(const data_flow::DataFlowGraph& graph, const Memlet* memlet) const override;
+    EdgeRemoveOption can_remove_out_edge(const data_flow::DataFlowGraph& graph, const Memlet* memlet) const override;
 };
 } // namespace data_flow
 } // namespace sdfg

--- a/sdfg/include/sdfg/passes/dataflow/dead_data_elimination.h
+++ b/sdfg/include/sdfg/passes/dataflow/dead_data_elimination.h
@@ -7,12 +7,12 @@ namespace passes {
 
 class DeadDataElimination : public Pass {
 private:
-    bool permissive_;
+    bool legacy_removals_;
 
 public:
     DeadDataElimination();
 
-    DeadDataElimination(bool permissive);
+    DeadDataElimination(bool legacy_removals);
 
     virtual std::string name() override;
 

--- a/sdfg/include/sdfg/targets/offloading/data_offloading_node.h
+++ b/sdfg/include/sdfg/targets/offloading/data_offloading_node.h
@@ -97,6 +97,13 @@ public:
     void remove_free();
 
     void remove_h2d();
+
+    data_flow::PointerAccessType pointer_access_type(int input_idx) const override;
+
+    data_flow::EdgeRemoveOption can_remove_out_edge(const data_flow::DataFlowGraph& graph, const data_flow::Memlet* memlet)
+        const override;
+
+    bool update_edge_removed(const std::string& out_conn) override;
 };
 
 } // namespace offloading

--- a/sdfg/src/builder/structured_sdfg_builder.cpp
+++ b/sdfg/src/builder/structured_sdfg_builder.cpp
@@ -1585,6 +1585,7 @@ int StructuredSDFGBuilder::clear_node(
     std::list<const data_flow::Memlet*> tmp;
     std::list<const data_flow::DataFlowNode*> queue = {&node};
     std::unordered_set<const data_flow::DataFlowNode*> remove_once_set;
+    std::unordered_set<const data_flow::DataFlowNode*> force_remove_set;
     int removed_nodes = 0;
 
     do {
@@ -1597,9 +1598,11 @@ int StructuredSDFGBuilder::clear_node(
             auto* access_node = dynamic_cast<const data_flow::AccessNode*>(current);
 
             bool ignore_side_effects_on_current = ignore_side_effects.contains(current);
-            // we can remove nodes without out-edges & side effects
+            bool force_remove = force_remove_set.contains(current);
+
+            // we can remove nodes without out-edges & side effects.
             if ((no_more_consumers && !current->side_effect()) ||
-                (ignore_side_effects_on_current && (no_more_consumers || access_node))) {
+                ((ignore_side_effects_on_current || force_remove) && (no_more_consumers || access_node))) {
                 // Or for access-nodes on the ignore list, we can remove the write side (will not remove the node, only
                 // inputs) For any other node on the ignore list, we can ignore if it has side effects or not
                 tmp.clear();
@@ -1610,11 +1613,18 @@ int StructuredSDFGBuilder::clear_node(
                 for (auto iedge : tmp) {
                     auto& src = iedge->src();
 
-                    if (!src.require_out_edge(graph, iedge)) {
+                    auto edge_rem = src.can_remove_out_edge(graph, iedge);
+                    if (edge_rem != data_flow::EdgeRemoveOption::NotRemovable) {
+                        auto src_conn = iedge->src_conn();
                         queue.push_back(&src);
                         auto edge = iedge->edge();
                         graph.edges_.erase(edge);
                         boost::remove_edge(edge, graph.graph_);
+                        if (edge_rem == data_flow::EdgeRemoveOption::RequiresUpdate) {
+                            const_cast<data_flow::DataFlowNode&>(src).update_edge_removed(src_conn);
+                        } else if (edge_rem == data_flow::EdgeRemoveOption::RemoveNodeAfter) {
+                            force_remove_set.insert(&src);
+                        }
                     } else {
                         no_in_edges = false;
                     }
@@ -1626,6 +1636,11 @@ int StructuredSDFGBuilder::clear_node(
                     graph.nodes_.erase(vertex);
                     boost::remove_vertex(vertex, graph.graph_);
                     ++removed_nodes;
+                } else if (!no_more_consumers && force_remove) {
+                    throw std::runtime_error(
+                        "Not yet supported: RemoveNodeAfter with more than 1 edge: #" +
+                        std::to_string(current->element_id())
+                    );
                 }
             }
         }

--- a/sdfg/src/data_flow/access_node.cpp
+++ b/sdfg/src/data_flow/access_node.cpp
@@ -68,7 +68,9 @@ void AccessNode::replace(const symbolic::Expression old_expression, const symbol
 /**
  * Every read can be removed
  */
-bool AccessNode::require_out_edge(const data_flow::DataFlowGraph& graph, const Memlet* memlet) const { return false; };
+EdgeRemoveOption AccessNode::can_remove_out_edge(const data_flow::DataFlowGraph& graph, const Memlet* memlet) const {
+    return EdgeRemoveOption::Trivially;
+}
 
 namespace {
 bool is_special_constant(const std::string& data) {

--- a/sdfg/src/data_flow/library_node.cpp
+++ b/sdfg/src/data_flow/library_node.cpp
@@ -34,9 +34,15 @@ std::string LibraryNode::toStr() const { return std::string(this->code_.value())
 
 symbolic::Expression LibraryNode::flop() const { return SymEngine::null; }
 
-bool LibraryNode::require_out_edge(const data_flow::DataFlowGraph& graph, const Memlet* memlet) const {
-    return graph.out_edges_for_connector(*this, memlet->src_conn()).size() <= 1; // cannot remove the last edge per
-                                                                                 // connector in general
+EdgeRemoveOption LibraryNode::can_remove_out_edge(const data_flow::DataFlowGraph& graph, const Memlet* memlet) const {
+    if (graph.out_edges_for_connector(*this, memlet->src_conn()).size() > 1) {
+        return EdgeRemoveOption::Trivially;
+    } else if (!side_effect_ && outputs_.size() == 1) {
+        return EdgeRemoveOption::RemoveNodeAfter;
+    } else {
+        // cannot remove the last edge per connector in general
+        return EdgeRemoveOption::NotRemovable;
+    }
 }
 
 } // namespace data_flow

--- a/sdfg/src/data_flow/library_nodes/math/cmath/cmath_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/cmath/cmath_node.cpp
@@ -317,9 +317,15 @@ std::string CMathNode::toStr() const {
     return LibraryNode::toStr() + "(" + get_cmath_intrinsic_name(this->function_, this->primitive_type_) + ")";
 }
 
-bool CMathNode::require_out_edge(const data_flow::DataFlowGraph& graph, const data_flow::Memlet* memlet) const {
-    // CMathNode always requires its output memlet to be present, as it represents a computation that produces a result.
-    return false;
+data_flow::EdgeRemoveOption CMathNode::
+    can_remove_out_edge(const data_flow::DataFlowGraph& graph, const data_flow::Memlet* memlet) const {
+    if (graph.out_edges_for_connector(*this, memlet->src_conn()).size() > 1) {
+        return data_flow::EdgeRemoveOption::Trivially;
+    } else {
+        // trick to allow removal of Tasklets, without having general mark-and-sweep logic to checkl tha that all
+        // outputs are
+        return data_flow::EdgeRemoveOption::RemoveNodeAfter;
+    }
 }
 
 nlohmann::json CMathNodeSerializer::serialize(const data_flow::LibraryNode& library_node) {

--- a/sdfg/src/data_flow/tasklet.cpp
+++ b/sdfg/src/data_flow/tasklet.cpp
@@ -284,7 +284,15 @@ std::unique_ptr<DataFlowNode> Tasklet::clone(size_t element_id, const graph::Ver
 
 void Tasklet::replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {}
 
-bool Tasklet::require_out_edge(const data_flow::DataFlowGraph& graph, const Memlet* memlet) const { return false; }
+EdgeRemoveOption Tasklet::can_remove_out_edge(const data_flow::DataFlowGraph& graph, const Memlet* memlet) const {
+    if (graph.out_edges_for_connector(*this, memlet->src_conn()).size() > 1) {
+        return EdgeRemoveOption::Trivially;
+    } else {
+        // trick to allow removal of Tasklets, without having general mark-and-sweep logic to checkl tha that all
+        // outputs are
+        return EdgeRemoveOption::RemoveNodeAfter;
+    }
+}
 
 } // namespace data_flow
 } // namespace sdfg

--- a/sdfg/src/offloading/data_offloading_node.cpp
+++ b/sdfg/src/offloading/data_offloading_node.cpp
@@ -145,6 +145,14 @@ void DataOffloadingNode::remove_h2d() {
     }
 }
 
+data_flow::PointerAccessType DataOffloadingNode::pointer_access_type(int input_idx) const {
+    if (is_h2d() && input_idx == 0) {
+        return data_flow::PointerReadOnly(size_, true);
+    } else {
+        return LibraryNode::pointer_access_type(input_idx);
+    }
+}
+
 void DataOffloadingNode::remove_free() {
     if (this->is_free()) {
         if (!this->has_transfer()) {
@@ -152,6 +160,35 @@ void DataOffloadingNode::remove_free() {
             );
         }
         this->buffer_lifecycle_ = BufferLifecycle::NO_CHANGE;
+    }
+}
+
+data_flow::EdgeRemoveOption DataOffloadingNode::
+    can_remove_out_edge(const data_flow::DataFlowGraph& graph, const data_flow::Memlet* memlet) const {
+    if (graph.out_edges_for_connector(*this, memlet->src_conn()).size() > 1) {
+        return data_flow::EdgeRemoveOption::Trivially;
+    } else if (transfer_direction_ != DataTransferDirection::NONE && outputs_.size() == 1 &&
+               memlet->src_conn() == outputs_.at(0)) {
+        // the node represents a transfer, whose output is dead.
+        if (buffer_lifecycle_ != BufferLifecycle::NO_CHANGE) {
+            // the node still has remaining purpose without the transfer
+            return data_flow::EdgeRemoveOption::RequiresUpdate;
+        } else {
+            // the node in its entirety is dead if it the transfer is not needed
+            return data_flow::EdgeRemoveOption::RemoveNodeAfter;
+        }
+    } else {
+        return data_flow::EdgeRemoveOption::NotRemovable;
+    }
+}
+
+bool DataOffloadingNode::update_edge_removed(const std::string& out_conn) {
+    if (transfer_direction_ != DataTransferDirection::NONE && outputs_.size() == 1 && out_conn == outputs_.at(0)) {
+        transfer_direction_ = DataTransferDirection::NONE;
+        outputs_.erase(outputs_.begin());
+        return true;
+    } else {
+        return false;
     }
 }
 

--- a/sdfg/src/passes/dataflow/dead_data_elimination.cpp
+++ b/sdfg/src/passes/dataflow/dead_data_elimination.cpp
@@ -5,15 +5,16 @@
 #include "sdfg/analysis/pointer_analyzers.h"
 #include "sdfg/data_flow/library_nodes/stdlib/free.h"
 #include "sdfg/data_flow/library_nodes/stdlib/malloc.h"
+#include "sdfg/targets/offloading/data_offloading_node.h"
 #include "sdfg/visitor/structured_sdfg_visitor.h"
 #include "sdfg/visualizer/dot_visualizer.h"
 
 namespace sdfg {
 namespace passes {
 
-DeadDataElimination::DeadDataElimination() : Pass(), permissive_(false) {};
+DeadDataElimination::DeadDataElimination() : Pass(), legacy_removals_(true) {};
 
-DeadDataElimination::DeadDataElimination(bool permissive) : Pass(), permissive_(permissive) {};
+DeadDataElimination::DeadDataElimination(bool legacy_removals) : Pass(), legacy_removals_(legacy_removals) {};
 
 std::string DeadDataElimination::name() { return "DeadDataElimination"; };
 
@@ -164,10 +165,24 @@ bool MemoryOwnershipAnalysis::excusedEscape(const Element* element, const OwnedA
 }
 
 bool MemoryOwnershipAnalysis::excusedOverwrite(const Element* element, const OwnedArea& area) {
+    auto* memlet = dynamic_cast<const data_flow::Memlet*>(element);
+
+    if (!memlet) {
+        return false;
+    }
+
     // The producer (malloc output edge) is an excused overwrite — it's the initial assignment.
     if (element == area.producer) {
         return true;
     }
+    // DataOffloadNodes currently have a fake-output edge instead of a pointer input.
+    // But they can only write to memory, never generate/overwrite the pointer
+    if (auto* offload = dynamic_cast<const offloading::DataOffloadingNode*>(&memlet->src())) {
+        if (offload->transfer_direction() != offloading::DataTransferDirection::NONE) {
+            return true;
+        }
+    }
+
     // The output edge of a free cluster is an excused overwrite — free sets the pointer
     // to NULL (a fake overwrite that doesn't represent a meaningful reassignment).
     for (const auto& cluster : area.free_clusters) {
@@ -327,6 +342,20 @@ void IndirectMemoryAccessFinder::use_as_src_node(
         if (edge.is_src_pointed_to_read()) {
             indirect_reads_[container].insert(&edge);
         }
+        // Library nodes may get a pointer as input. But some of them we know enough about,
+        // to know they are only borrowing the pointer for read access during their execution, not representing an
+        // actual leak these we can instead cound as indirect readse
+        if (edge.is_src_read()) {
+            if (auto* libNode = dynamic_cast<const data_flow::LibraryNode*>(&edge.dst())) {
+                auto conns = libNode->inputs();
+                auto idx = std::find(conns.begin(), conns.end(), edge.dst_conn()) - conns.begin();
+                auto access_type = libNode->pointer_access_type(idx);
+                auto maybe_rd_only = std::get_if<data_flow::PointerReadOnly>(&access_type);
+                if (maybe_rd_only && maybe_rd_only->no_ptr_escape()) {
+                    indirect_reads_[container].insert(&edge);
+                }
+            }
+        }
     }
 }
 
@@ -336,6 +365,17 @@ void IndirectMemoryAccessFinder::use_as_dst_node(
     if (target_containers_.contains(container)) {
         if (edge.is_dst_pointed_to_write()) {
             writes_to_remove_[container][&edge] = &block;
+        }
+        // hack to classify Offload nodes with D2H correctly. For historic reasons they use a direct output edge
+        // to the host ptr, even though they will never write the pointer, but only write the memory the pointer points
+        // to as that edge is destructive to many optimizations and scheduled to be removed, cuhere custom handleing per
+        // node
+        if (edge.is_dst_write()) {
+            if (auto* offload = dynamic_cast<const offloading::DataOffloadingNode*>(&edge.src())) {
+                if (offload->transfer_direction() != offloading::DataTransferDirection::NONE) {
+                    writes_to_remove_[container][&edge] = &block;
+                }
+            }
         }
     }
 }
@@ -388,75 +428,80 @@ bool DeadDataElimination::run_pass(builder::StructuredSDFGBuilder& builder, anal
                     auto& area = ownership_analysis.owned_area(owned_area_id);
                     area.remove_from(builder);
                     applied = true;
+                    dead_containers.insert(owned_area_id);
                 }
             }
         }
     }
-    if (applied) { // if changes were made, any cached analysis will be out of date.
-        analysis_manager.invalidate_all();
-    }
 
-    // slightly expensive, because for fully_owned_areas we already looked for uses. But classified differently and did
-    // not look at, whether the entire container can be removed
-    auto& users = analysis_manager.get<analysis::Users>();
-    auto& data_dependency_analysis = analysis_manager.get<analysis::DataDependencyAnalysis>();
-
-    for (auto& name : sdfg.containers()) {
-        if (!sdfg.is_transient(name)) {
-            continue;
-        }
-        if (users.num_views(name) > 0 || users.num_moves(name) > 0) {
-            continue;
-        }
-        auto num_reads = users.num_reads(name);
-        if (!num_reads && users.num_writes(name) == 0) { // no reference of [name] anywhere
-            dead_containers.insert(name);
-            applied = true;
-            continue;
+    if (legacy_removals_) {
+        if (applied) { // if changes were made, any cached analysis will be out of date.
+            analysis_manager.invalidate_all();
         }
 
-        if (sdfg.type(name).type_id() == types::TypeID::Pointer) {
-            continue;
-            // use analysis does not return actual reads and writes for pointers. So if [name] is a pointer,
-            // num reads/writes, does not actually mean no reads exist and any removal is problematic
-            // more complex cases have been removed above already
-        }
+        // slightly expensive, because for fully_owned_areas we already looked for uses. But classified differently and
+        // did not look at, whether the entire container can be removed
+        auto& users = analysis_manager.get<analysis::Users>();
+        auto& data_dependency_analysis = analysis_manager.get<analysis::DataDependencyAnalysis>();
 
-        bool completely_unused = !num_reads; // if there are reads left, we can never remove the container, but maybe
-                                             // some writes
-        auto raws = data_dependency_analysis.definitions(name);
-        for (auto set : raws) {
-            bool no_reads = false;
-            if (set.second.size() == 0) {
-                no_reads = true;
+        for (auto& name : sdfg.containers()) {
+            if (!sdfg.is_transient(name)) {
+                continue;
             }
-            if (data_dependency_analysis.is_undefined_user(*set.first)) {
+            if (users.num_views(name) > 0 || users.num_moves(name) > 0) {
+                continue;
+            }
+            auto num_reads = users.num_reads(name);
+            if (!num_reads && users.num_writes(name) == 0) { // no reference of [name] anywhere
+                dead_containers.insert(name);
+                applied = true;
                 continue;
             }
 
-            if (no_reads) {
-                bool could_eliminate_write = false;
-                auto write = set.first;
-                if (auto transition = dynamic_cast<structured_control_flow::Transition*>(write->element())) {
-                    transition->assignments().erase(symbolic::symbol(name));
-                    applied = true;
-                    could_eliminate_write = true;
-                } else if (auto access_node = dynamic_cast<data_flow::AccessNode*>(write->element())) {
-                    auto& graph = access_node->get_parent();
-                    auto& block = dynamic_cast<structured_control_flow::Block&>(*graph.get_parent());
+            if (sdfg.type(name).type_id() == types::TypeID::Pointer) {
+                continue;
+                // use analysis does not return actual reads and writes for pointers. So if [name] is a pointer,
+                // num reads/writes, does not actually mean no reads exist and any removal is problematic
+                // more complex cases have been removed above already
+            }
 
-                    if (builder.clear_node(block, *access_node)) {
-                        applied = true;
-                        could_eliminate_write = true;
-                    }
+            bool completely_unused = !num_reads; // if there are reads left, we can never remove the container, but
+                                                 // maybe
+            // some writes
+            auto raws = data_dependency_analysis.definitions(name);
+            for (auto set : raws) {
+                bool no_reads = false;
+                if (set.second.size() == 0) {
+                    no_reads = true;
+                }
+                if (data_dependency_analysis.is_undefined_user(*set.first)) {
+                    continue;
                 }
 
-                completely_unused &= could_eliminate_write;
-            }
-        }
+                if (no_reads) {
+                    bool could_eliminate_write = false;
+                    auto write = set.first;
+                    if (auto transition = dynamic_cast<structured_control_flow::Transition*>(write->element())) {
+                        transition->assignments().erase(symbolic::symbol(name));
+                        applied = true;
+                        could_eliminate_write = true;
+                    } else if (auto access_node = dynamic_cast<data_flow::AccessNode*>(write->element())) {
+                        auto& graph = access_node->get_parent();
+                        auto& block = dynamic_cast<structured_control_flow::Block&>(*graph.get_parent());
 
-        if (completely_unused) { // no reads, and all remaining writes could be removed
-            dead_containers.insert(name);
+                        if (builder.clear_node(block, *access_node)) {
+                            applied = true;
+                            could_eliminate_write = true;
+                        }
+                    }
+
+                    completely_unused &= could_eliminate_write;
+                }
+            }
+
+            if (completely_unused) { // no reads, and all remaining writes could be removed
+                dead_containers.insert(name);
+            }
         }
     }
 


### PR DESCRIPTION
 + generic modeling for libNodes to declare that an input pointer does not actually escape through them
 + draft of generic modeling of input-pointer access ranges and access types (read-only, full overwrite etc.)
 + DDE: Offload-Transfer-specific handling to reinterpret their fake output edges instead as only indirect writes vie the target pointer
 + DDE: option to disable all the legacy code that requires full UserAnalysis and DataDependencyAnalysis.
 * the new malloc/heap removal in DDE can now remove containers by itself, not relying on DataDependencyAnalysis for that
 * improved builder.clear_node, node can report how to deal with a dead edge, including calling an update method on the node to make it validate again after edge removal.
 + Used for OffloadTransfer nodes to support removing the output edge via dead-code and drop the transfer and maybe the entire node if it does nothing anymore.