### PR TITLE
Single GPU BLAS Handle Instantiation

### DIFF
--- a/opt/include/sdfg/targets/cuda/blas/utils.h
+++ b/opt/include/sdfg/targets/cuda/blas/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "sdfg/codegen/code_snippet_factory.h"
 #include "sdfg/codegen/language_extension.h"
 #include "sdfg/codegen/utils.h"
 namespace sdfg {
@@ -9,6 +10,8 @@ namespace blas {
 void create_blas_handle(codegen::PrettyPrinter& stream, const codegen::LanguageExtension& language_extension);
 
 void destroy_blas_handle(codegen::PrettyPrinter& stream, const codegen::LanguageExtension& language_extension);
+
+void setup_blas_handle(codegen::CodeSnippetFactory& factory, const codegen::LanguageExtension& language_extension);
 
 void cublas_error_checking(
     codegen::PrettyPrinter& stream,

--- a/opt/include/sdfg/targets/rocm/blas/utils.h
+++ b/opt/include/sdfg/targets/rocm/blas/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "sdfg/codegen/code_snippet_factory.h"
 #include "sdfg/codegen/language_extension.h"
 #include "sdfg/codegen/utils.h"
 namespace sdfg {
@@ -9,6 +10,8 @@ namespace blas {
 void create_blas_handle(codegen::PrettyPrinter& stream, const codegen::LanguageExtension& language_extension);
 
 void destroy_blas_handle(codegen::PrettyPrinter& stream, const codegen::LanguageExtension& language_extension);
+
+void setup_blas_handle(codegen::CodeSnippetFactory& factory, const codegen::LanguageExtension& language_extension);
 
 void rocmblas_error_checking(
     codegen::PrettyPrinter& stream,

--- a/opt/src/targets/cuda/blas/dot.cpp
+++ b/opt/src/targets/cuda/blas/dot.cpp
@@ -62,7 +62,7 @@ void DotNodeDispatcher_CUBLASWithTransfers::dispatch_code(
     stream << "err_cuda = cudaMemcpy(dy, __y, " << y_size << ", cudaMemcpyHostToDevice);" << std::endl;
     cuda_error_checking(stream, this->language_extension_, "err_cuda");
 
-    create_blas_handle(stream, this->language_extension_);
+    setup_blas_handle(library_snippet_factory, this->language_extension_);
     stream << "cublasStatus_t err;" << std::endl;
 
     stream << "err = cublas" << type2 << "dot(handle, " << this->language_extension_.expression(dot_node.n())
@@ -70,8 +70,6 @@ void DotNodeDispatcher_CUBLASWithTransfers::dispatch_code(
            << this->language_extension_.expression(dot_node.incy()) << ", &__out);" << std::endl;
     cublas_error_checking(stream, this->language_extension_, "err");
     check_cuda_kernel_launch_errors(stream, this->language_extension_, false);
-
-    destroy_blas_handle(stream, this->language_extension_);
 
     stream << "err_cuda = cudaFree(dx);" << std::endl;
     cuda_error_checking(stream, this->language_extension_, "err_cuda");
@@ -96,10 +94,10 @@ void DotNodeDispatcher_CUBLASWithoutTransfers::dispatch_code(
     globals_stream << "#include <cuda.h>" << std::endl;
     globals_stream << "#include <cublas_v2.h>" << std::endl;
 
+    setup_blas_handle(library_snippet_factory, this->language_extension_);
+
     stream << "cudaError_t err_cuda;" << std::endl;
     stream << "cublasStatus_t err;" << std::endl;
-
-    create_blas_handle(stream, this->language_extension_);
 
     stream << "err = cublas";
     switch (dot_node.precision()) {
@@ -118,8 +116,6 @@ void DotNodeDispatcher_CUBLASWithoutTransfers::dispatch_code(
 
     cublas_error_checking(stream, this->language_extension_, "err");
     check_cuda_kernel_launch_errors(stream, this->language_extension_, false);
-
-    destroy_blas_handle(stream, this->language_extension_);
 }
 
 } // namespace sdfg::cuda::blas

--- a/opt/src/targets/cuda/blas/dot.cpp
+++ b/opt/src/targets/cuda/blas/dot.cpp
@@ -22,8 +22,8 @@ void DotNodeDispatcher_CUBLASWithTransfers::dispatch_code(
 ) {
     auto& dot_node = static_cast<const math::blas::DotNode&>(this->node_);
 
-    globals_stream << "#include <cuda.h>" << std::endl;
-    globals_stream << "#include <cublas_v2.h>" << std::endl;
+    library_snippet_factory.add_global("#include <cuda.h>");
+    library_snippet_factory.add_global("#include <cublas_v2.h>");
 
     std::string type, type2;
     switch (dot_node.precision()) {
@@ -91,8 +91,8 @@ void DotNodeDispatcher_CUBLASWithoutTransfers::dispatch_code(
     codegen::CodeSnippetFactory& library_snippet_factory
 ) {
     auto& dot_node = static_cast<const math::blas::DotNode&>(this->node_);
-    globals_stream << "#include <cuda.h>" << std::endl;
-    globals_stream << "#include <cublas_v2.h>" << std::endl;
+    library_snippet_factory.add_global("#include <cuda.h>");
+    library_snippet_factory.add_global("#include <cublas_v2.h>");
 
     setup_blas_handle(library_snippet_factory, this->language_extension_);
 

--- a/opt/src/targets/cuda/blas/gemm.cpp
+++ b/opt/src/targets/cuda/blas/gemm.cpp
@@ -81,7 +81,7 @@ void GEMMNodeDispatcher_CUBLASWithTransfers::dispatch_code(
     stream << "err_cuda = cudaMemcpy(dC, __C, " << size_C << ", cudaMemcpyHostToDevice);" << std::endl;
     cuda_error_checking(stream, this->language_extension_, "err_cuda");
 
-    create_blas_handle(stream, this->language_extension_);
+    setup_blas_handle(library_snippet_factory, this->language_extension_);
 
     generate_kernel_gemm(stream, this->language_extension_, gemm_node);
 
@@ -94,8 +94,6 @@ void GEMMNodeDispatcher_CUBLASWithTransfers::dispatch_code(
     cuda_error_checking(stream, this->language_extension_, "err_cuda");
     stream << "err_cuda = cudaFree(dC);" << std::endl;
     cuda_error_checking(stream, this->language_extension_, "err_cuda");
-
-    destroy_blas_handle(stream, this->language_extension_);
 
     remove_guard_clause(stream);
 }
@@ -120,11 +118,10 @@ void GEMMNodeDispatcher_CUBLASWithoutTransfers::dispatch_code(
 
     add_guard_clause(stream, this->language_extension_, gemm_node);
 
-    create_blas_handle(stream, this->language_extension_);
+    setup_blas_handle(library_snippet_factory, this->language_extension_);
 
     generate_kernel_gemm(stream, this->language_extension_, gemm_node);
 
-    destroy_blas_handle(stream, this->language_extension_);
     remove_guard_clause(stream);
 }
 

--- a/opt/src/targets/cuda/blas/gemm.cpp
+++ b/opt/src/targets/cuda/blas/gemm.cpp
@@ -37,8 +37,8 @@ void GEMMNodeDispatcher_CUBLASWithTransfers::dispatch_code(
 ) {
     auto& gemm_node = static_cast<const math::blas::GEMMNode&>(this->node_);
 
-    globals_stream << "#include <cuda.h>" << std::endl;
-    globals_stream << "#include <cublas_v2.h>" << std::endl;
+    library_snippet_factory.add_global("#include <cuda.h>");
+    library_snippet_factory.add_global("#include <cublas_v2.h>");
 
     std::string type, type2;
     switch (gemm_node.precision()) {
@@ -113,8 +113,8 @@ void GEMMNodeDispatcher_CUBLASWithoutTransfers::dispatch_code(
 ) {
     auto& gemm_node = static_cast<const math::blas::GEMMNode&>(this->node_);
 
-    globals_stream << "#include <cuda.h>" << std::endl;
-    globals_stream << "#include <cublas_v2.h>" << std::endl;
+    library_snippet_factory.add_global("#include <cuda.h>");
+    library_snippet_factory.add_global("#include <cublas_v2.h>");
 
     add_guard_clause(stream, this->language_extension_, gemm_node);
 

--- a/opt/src/targets/cuda/blas/utils.cpp
+++ b/opt/src/targets/cuda/blas/utils.cpp
@@ -1,5 +1,6 @@
 #include "sdfg/targets/cuda/blas/utils.h"
 
+#include "sdfg/codegen/code_snippet_factory.h"
 #include "sdfg/codegen/language_extension.h"
 #include "sdfg/codegen/utils.h"
 #include "sdfg/targets/cuda/cuda.h"
@@ -9,13 +10,34 @@ namespace blas {
 
 void create_blas_handle(codegen::PrettyPrinter& stream, const codegen::LanguageExtension& language_extension) {
     stream << "cublasHandle_t handle;" << std::endl;
+    stream << "{" << std::endl;
+    stream.setIndent(stream.indent() + 4);
     stream << "cublasStatus_t status_create = cublasCreate(&handle);" << std::endl;
     cublas_error_checking(stream, language_extension, "status_create");
+    stream.setIndent(stream.indent() - 4);
+    stream << "}" << std::endl;
 }
 
 void destroy_blas_handle(codegen::PrettyPrinter& stream, const codegen::LanguageExtension& language_extension) {
+    stream << "{" << std::endl;
+    stream.setIndent(stream.indent() + 4);
     stream << "cublasStatus_t status_destroy = cublasDestroy(handle);" << std::endl;
     cublas_error_checking(stream, language_extension, "status_destroy");
+    stream.setIndent(stream.indent() - 4);
+    stream << "}" << std::endl;
+}
+
+void setup_blas_handle(codegen::CodeSnippetFactory& factory, const codegen::LanguageExtension& language_extension) {
+    {
+        codegen::PrettyPrinter setup_stream;
+        create_blas_handle(setup_stream, language_extension);
+        factory.add_setup(setup_stream.str());
+    }
+    {
+        codegen::PrettyPrinter teardown_stream;
+        destroy_blas_handle(teardown_stream, language_extension);
+        factory.add_teardown(teardown_stream.str());
+    }
 }
 
 void cublas_error_checking(

--- a/opt/src/targets/cuda/cuda_map_dispatcher.cpp
+++ b/opt/src/targets/cuda/cuda_map_dispatcher.cpp
@@ -144,7 +144,7 @@ void CUDAMapDispatcher::dispatch_node(
             arguments_device
         );
 
-        globals_stream << "#include <cstdio>" << std::endl;
+        library_snippet_factory.add_global("#include <cstdio>");
         // Kernel Declaration
         this->dispatch_header(globals_stream, kernel_name, arguments_declaration);
         globals_stream << ";" << std::endl;

--- a/opt/src/targets/cuda/stdlib/memset.cpp
+++ b/opt/src/targets/cuda/stdlib/memset.cpp
@@ -18,7 +18,7 @@ void MemsetNodeDispatcher_CUDAWithTransfers::dispatch_code(
 ) {
     auto& node = static_cast<const sdfg::stdlib::MemsetNode&>(node_);
 
-    globals_stream << "#include <cuda.h>" << std::endl;
+    library_snippet_factory.add_global("#include <cuda.h>");
 
     stream << "cudaError_t err_cuda;" << std::endl;
 
@@ -55,7 +55,7 @@ void MemsetNodeDispatcher_CUDAWithoutTransfers::dispatch_code(
 ) {
     auto& node = static_cast<const sdfg::stdlib::MemsetNode&>(node_);
 
-    globals_stream << "#include <cuda.h>" << std::endl;
+    library_snippet_factory.add_global("#include <cuda.h>");
 
     stream << "cudaError_t err_cuda;" << std::endl;
     stream << "err_cuda = cudaMemset(" << node.outputs().at(0) << ", " << language_extension_.expression(node.value())

--- a/opt/src/targets/rocm/blas/dot.cpp
+++ b/opt/src/targets/rocm/blas/dot.cpp
@@ -22,8 +22,8 @@ void DotNodeDispatcher_ROCMBLASWithTransfers::dispatch_code(
 ) {
     auto& dot_node = static_cast<const math::blas::DotNode&>(this->node_);
 
-    globals_stream << "#include <hip/hip_runtime.h>" << std::endl;
-    globals_stream << "#include <hipblas/hipblas.h>" << std::endl;
+    library_snippet_factory.add_global("#include <hip/hip_runtime.h>");
+    library_snippet_factory.add_global("#include <hipblas/hipblas.h>");
 
     std::string type, type2;
     switch (dot_node.precision()) {
@@ -91,8 +91,8 @@ void DotNodeDispatcher_ROCMBLASWithoutTransfers::dispatch_code(
     codegen::CodeSnippetFactory& library_snippet_factory
 ) {
     auto& dot_node = static_cast<const math::blas::DotNode&>(this->node_);
-    globals_stream << "#include <hip/hip_runtime.h>" << std::endl;
-    globals_stream << "#include <hipblas/hipblas.h>" << std::endl;
+    library_snippet_factory.add_global("#include <hip/hip_runtime.h>");
+    library_snippet_factory.add_global("#include <hipblas/hipblas.h>");
 
     setup_blas_handle(library_snippet_factory, this->language_extension_);
 

--- a/opt/src/targets/rocm/blas/dot.cpp
+++ b/opt/src/targets/rocm/blas/dot.cpp
@@ -62,7 +62,7 @@ void DotNodeDispatcher_ROCMBLASWithTransfers::dispatch_code(
     stream << "err_hip = hipMemcpy(dy, __y, " << y_size << ", hipMemcpyHostToDevice);" << std::endl;
     rocm_error_checking(stream, this->language_extension_, "err_hip");
 
-    create_blas_handle(stream, this->language_extension_);
+    setup_blas_handle(library_snippet_factory, this->language_extension_);
     stream << "hipblasStatus_t err;" << std::endl;
 
     stream << "err = hipblas" << type2 << "dot(handle, " << this->language_extension_.expression(dot_node.n())
@@ -70,8 +70,6 @@ void DotNodeDispatcher_ROCMBLASWithTransfers::dispatch_code(
            << this->language_extension_.expression(dot_node.incy()) << ", &__out);" << std::endl;
     rocmblas_error_checking(stream, this->language_extension_, "err");
     check_rocm_kernel_launch_errors(stream, this->language_extension_);
-
-    destroy_blas_handle(stream, this->language_extension_);
 
     stream << "err_hip = hipFree(dx);" << std::endl;
     rocm_error_checking(stream, this->language_extension_, "err_hip");
@@ -96,10 +94,10 @@ void DotNodeDispatcher_ROCMBLASWithoutTransfers::dispatch_code(
     globals_stream << "#include <hip/hip_runtime.h>" << std::endl;
     globals_stream << "#include <hipblas/hipblas.h>" << std::endl;
 
+    setup_blas_handle(library_snippet_factory, this->language_extension_);
+
     stream << "hipError_t err_hip;" << std::endl;
     stream << "hipblasStatus_t err;" << std::endl;
-
-    create_blas_handle(stream, this->language_extension_);
 
     stream << "err = hipblas";
     switch (dot_node.precision()) {
@@ -118,8 +116,6 @@ void DotNodeDispatcher_ROCMBLASWithoutTransfers::dispatch_code(
 
     rocmblas_error_checking(stream, this->language_extension_, "err");
     check_rocm_kernel_launch_errors(stream, this->language_extension_);
-
-    destroy_blas_handle(stream, this->language_extension_);
 }
 
 } // namespace sdfg::rocm::blas

--- a/opt/src/targets/rocm/blas/gemm.cpp
+++ b/opt/src/targets/rocm/blas/gemm.cpp
@@ -37,8 +37,8 @@ void GEMMNodeDispatcher_ROCMBLASWithTransfers::dispatch_code(
 ) {
     auto& gemm_node = static_cast<const math::blas::GEMMNode&>(this->node_);
 
-    globals_stream << "#include <hip/hip_runtime.h>" << std::endl;
-    globals_stream << "#include <hipblas/hipblas.h>" << std::endl;
+    library_snippet_factory.add_global("#include <hip/hip_runtime.h>");
+    library_snippet_factory.add_global("#include <hipblas/hipblas.h>");
 
     std::string type, type2;
     switch (gemm_node.precision()) {
@@ -113,8 +113,8 @@ void GEMMNodeDispatcher_ROCMBLASWithoutTransfers::dispatch_code(
 ) {
     auto& gemm_node = static_cast<const math::blas::GEMMNode&>(this->node_);
 
-    globals_stream << "#include <hip/hip_runtime.h>" << std::endl;
-    globals_stream << "#include <hipblas/hipblas.h>" << std::endl;
+    library_snippet_factory.add_global("#include <hip/hip_runtime.h>");
+    library_snippet_factory.add_global("#include <hipblas/hipblas.h>");
 
     add_guard_clause(stream, this->language_extension_, gemm_node);
 

--- a/opt/src/targets/rocm/blas/gemm.cpp
+++ b/opt/src/targets/rocm/blas/gemm.cpp
@@ -81,7 +81,7 @@ void GEMMNodeDispatcher_ROCMBLASWithTransfers::dispatch_code(
     stream << "err_hip = hipMemcpy(dC, __C, " << size_C << ", hipMemcpyHostToDevice);" << std::endl;
     rocm_error_checking(stream, this->language_extension_, "err_hip");
 
-    create_blas_handle(stream, this->language_extension_);
+    setup_blas_handle(library_snippet_factory, this->language_extension_);
 
     generate_kernel_gemm(stream, this->language_extension_, gemm_node);
 
@@ -94,8 +94,6 @@ void GEMMNodeDispatcher_ROCMBLASWithTransfers::dispatch_code(
     rocm_error_checking(stream, this->language_extension_, "err_hip");
     stream << "err_hip = hipFree(dC);" << std::endl;
     rocm_error_checking(stream, this->language_extension_, "err_hip");
-
-    destroy_blas_handle(stream, this->language_extension_);
 
     remove_guard_clause(stream);
 }
@@ -120,11 +118,10 @@ void GEMMNodeDispatcher_ROCMBLASWithoutTransfers::dispatch_code(
 
     add_guard_clause(stream, this->language_extension_, gemm_node);
 
-    create_blas_handle(stream, this->language_extension_);
+    setup_blas_handle(library_snippet_factory, this->language_extension_);
 
     generate_kernel_gemm(stream, this->language_extension_, gemm_node);
 
-    destroy_blas_handle(stream, this->language_extension_);
     remove_guard_clause(stream);
 }
 

--- a/opt/src/targets/rocm/blas/utils.cpp
+++ b/opt/src/targets/rocm/blas/utils.cpp
@@ -1,5 +1,6 @@
 #include "sdfg/targets/rocm/blas/utils.h"
 
+#include "sdfg/codegen/code_snippet_factory.h"
 #include "sdfg/codegen/language_extension.h"
 #include "sdfg/codegen/utils.h"
 #include "sdfg/targets/rocm/rocm.h"
@@ -9,13 +10,34 @@ namespace blas {
 
 void create_blas_handle(codegen::PrettyPrinter& stream, const codegen::LanguageExtension& language_extension) {
     stream << "hipblasHandle_t handle;" << std::endl;
+    stream << "{" << std::endl;
+    stream.setIndent(stream.indent() + 4);
     stream << "hipblasStatus_t status_create = hipblasCreate(&handle);" << std::endl;
     rocmblas_error_checking(stream, language_extension, "status_create");
+    stream.setIndent(stream.indent() - 4);
+    stream << "}" << std::endl;
 }
 
 void destroy_blas_handle(codegen::PrettyPrinter& stream, const codegen::LanguageExtension& language_extension) {
+    stream << "{" << std::endl;
+    stream.setIndent(stream.indent() + 4);
     stream << "hipblasStatus_t status_destroy = hipblasDestroy(handle);" << std::endl;
     rocmblas_error_checking(stream, language_extension, "status_destroy");
+    stream.setIndent(stream.indent() - 4);
+    stream << "}" << std::endl;
+}
+
+void setup_blas_handle(codegen::CodeSnippetFactory& factory, const codegen::LanguageExtension& language_extension) {
+    {
+        codegen::PrettyPrinter setup_stream;
+        create_blas_handle(setup_stream, language_extension);
+        factory.add_setup(setup_stream.str());
+    }
+    {
+        codegen::PrettyPrinter teardown_stream;
+        destroy_blas_handle(teardown_stream, language_extension);
+        factory.add_teardown(teardown_stream.str());
+    }
 }
 
 void rocmblas_error_checking(

--- a/opt/src/targets/rocm/rocm_map_dispatcher.cpp
+++ b/opt/src/targets/rocm/rocm_map_dispatcher.cpp
@@ -143,8 +143,8 @@ void ROCMMapDispatcher::dispatch_node(
             arguments_device
         );
 
-        globals_stream << "#include <cstdio>" << std::endl;
-        globals_stream << "#include <hip/hip_runtime.h>" << std::endl;
+        library_snippet_factory.add_global("#include <cstdio>");
+        library_snippet_factory.add_global("#include <hip/hip_runtime.h>");
         // Kernel Declaration
         this->dispatch_header(globals_stream, kernel_name, arguments_declaration);
         globals_stream << ";" << std::endl;

--- a/opt/src/targets/rocm/stdlib/memset.cpp
+++ b/opt/src/targets/rocm/stdlib/memset.cpp
@@ -18,7 +18,7 @@ void MemsetNodeDispatcher_ROCMWithTransfers::dispatch_code(
 ) {
     auto& node = static_cast<const sdfg::stdlib::MemsetNode&>(node_);
 
-    globals_stream << "#include <hip/hip_runtime.h>" << std::endl;
+    library_snippet_factory.add_global("#include <hip/hip_runtime.h>");
 
     stream << "hipError_t err_hip;" << std::endl;
 
@@ -55,7 +55,7 @@ void MemsetNodeDispatcher_ROCMWithoutTransfers::dispatch_code(
 ) {
     auto& node = static_cast<const sdfg::stdlib::MemsetNode&>(node_);
 
-    globals_stream << "#include <hip/hip_runtime.h>" << std::endl;
+    library_snippet_factory.add_global("#include <hip/hip_runtime.h>");
 
     stream << "hipError_t err_hip;" << std::endl;
     stream << "err_hip = hipMemset(" << node.outputs().at(0) << ", " << language_extension_.expression(node.value())

--- a/opt/tests/cuda/cuda_kernel_test.cpp
+++ b/opt/tests/cuda/cuda_kernel_test.cpp
@@ -69,7 +69,8 @@ TEST(CUDAKernel, DispatcherTest) {
     // Check if the generated code contains the expected function call
     EXPECT_EQ(library_snippet_factory.snippets().size(), 1);
 
-    EXPECT_EQ(globals_stream.str(), "#include <cstdio>\n__global__ void " + kernel_name + "(float *__daisy_cuda_A);\n");
+    EXPECT_TRUE(library_snippet_factory.globals_snippets().count("#include <cstdio>"));
+    EXPECT_EQ(globals_stream.str(), "__global__ void " + kernel_name + "(float *__daisy_cuda_A);\n");
 
     EXPECT_EQ(
         main_stream.str(),
@@ -157,7 +158,8 @@ TEST(CUDAKernel, NestedXYDispatcherTest) {
     // Check if the generated code contains the expected function call
     EXPECT_EQ(library_snippet_factory.snippets().size(), 1);
 
-    EXPECT_EQ(globals_stream.str(), "#include <cstdio>\n__global__ void " + kernel_name + "(float *__daisy_cuda_A);\n");
+    EXPECT_TRUE(library_snippet_factory.globals_snippets().count("#include <cstdio>"));
+    EXPECT_EQ(globals_stream.str(), "__global__ void " + kernel_name + "(float *__daisy_cuda_A);\n");
 
     EXPECT_EQ(
         main_stream.str(),
@@ -247,7 +249,8 @@ TEST(CUDAKernel, NestedXZDispatcherTest) {
     // Check if the generated code contains the expected function call
     EXPECT_EQ(library_snippet_factory.snippets().size(), 1);
 
-    EXPECT_EQ(globals_stream.str(), "#include <cstdio>\n__global__ void " + kernel_name + "(float *__daisy_cuda_A);\n");
+    EXPECT_TRUE(library_snippet_factory.globals_snippets().count("#include <cstdio>"));
+    EXPECT_EQ(globals_stream.str(), "__global__ void " + kernel_name + "(float *__daisy_cuda_A);\n");
 
     EXPECT_EQ(
         main_stream.str(),
@@ -354,7 +357,8 @@ TEST(CUDAKernel, NestedXYZDispatcherTest) {
     // Check if the generated code contains the expected function call
     EXPECT_EQ(library_snippet_factory.snippets().size(), 1);
 
-    EXPECT_EQ(globals_stream.str(), "#include <cstdio>\n__global__ void " + kernel_name + "(float *__daisy_cuda_A);\n");
+    EXPECT_TRUE(library_snippet_factory.globals_snippets().count("#include <cstdio>"));
+    EXPECT_EQ(globals_stream.str(), "__global__ void " + kernel_name + "(float *__daisy_cuda_A);\n");
 
     EXPECT_EQ(
         main_stream.str(),

--- a/sdfg/include/sdfg/codegen/code_snippet_factory.h
+++ b/sdfg/include/sdfg/codegen/code_snippet_factory.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <unordered_set>
 
 #include "utils.h"
 
@@ -37,6 +38,9 @@ protected:
     const std::filesystem::path output_path_;
     const std::filesystem::path header_path_;
 
+    std::unordered_set<std::string> setup_snippets_;
+    std::unordered_set<std::string> teardown_snippets_;
+
 public:
     CodeSnippetFactory(const std::pair<std::filesystem::path, std::filesystem::path>* config = nullptr);
 
@@ -50,6 +54,11 @@ public:
 
     const std::filesystem::path& output_path() const { return output_path_; }
     const std::filesystem::path& header_path() const { return header_path_; }
+
+    void add_setup(const std::string& snippet);
+    void add_teardown(const std::string& snippet);
+    const std::unordered_set<std::string>& setup_snippets() const;
+    const std::unordered_set<std::string>& teardown_snippets() const;
 };
 
 

--- a/sdfg/include/sdfg/codegen/code_snippet_factory.h
+++ b/sdfg/include/sdfg/codegen/code_snippet_factory.h
@@ -40,6 +40,7 @@ protected:
 
     std::unordered_set<std::string> setup_snippets_;
     std::unordered_set<std::string> teardown_snippets_;
+    std::unordered_set<std::string> globals_snippets_;
 
 public:
     CodeSnippetFactory(const std::pair<std::filesystem::path, std::filesystem::path>* config = nullptr);
@@ -57,8 +58,10 @@ public:
 
     void add_setup(const std::string& snippet);
     void add_teardown(const std::string& snippet);
+    void add_global(const std::string& snippet);
     const std::unordered_set<std::string>& setup_snippets() const;
     const std::unordered_set<std::string>& teardown_snippets() const;
+    const std::unordered_set<std::string>& globals_snippets() const;
 };
 
 

--- a/sdfg/src/codegen/code_generators/c_style_base_code_generator.cpp
+++ b/sdfg/src/codegen/code_generators/c_style_base_code_generator.cpp
@@ -51,6 +51,9 @@ bool CStyleBaseCodeGenerator::as_source(const std::filesystem::path& header_path
     ofs_header.close();
 
     ofs_source << "#include \"" << header_path.filename().string() << "\"" << std::endl;
+    for (auto& snippet : library_snippet_factory_->globals_snippets()) {
+        ofs_source << snippet << std::endl;
+    }
     ofs_source << this->globals_stream_.str() << std::endl;
 
     append_function_source(ofs_source);

--- a/sdfg/src/codegen/code_generators/c_style_base_code_generator.cpp
+++ b/sdfg/src/codegen/code_generators/c_style_base_code_generator.cpp
@@ -74,7 +74,15 @@ void CStyleBaseCodeGenerator::append_function_source(std::ofstream& ofs_source) 
         ofs_source << init_once->second.stream().str() << std::endl;
     }
 
+    for (auto& snippet : library_snippet_factory_->setup_snippets()) {
+        ofs_source << snippet << std::endl;
+    }
+
     ofs_source << this->main_stream_.str() << std::endl;
+
+    for (auto& snippet : library_snippet_factory_->teardown_snippets()) {
+        ofs_source << snippet << std::endl;
+    }
 
     auto deinit_once = library_snippet_factory_->find(CODE_SNIPPET_DEINIT_ONCE);
     if (deinit_once != library_snippet_factory_->snippets().end()) {

--- a/sdfg/src/codegen/code_snippet_factory.cpp
+++ b/sdfg/src/codegen/code_snippet_factory.cpp
@@ -1,4 +1,5 @@
 #include "sdfg/codegen/code_snippet_factory.h"
+#include <unordered_set>
 
 namespace sdfg::codegen {
 
@@ -23,5 +24,13 @@ std::unordered_map<std::string, CodeSnippet>::iterator CodeSnippetFactory::find(
     return snippets_.find(name);
 }
 const std::unordered_map<std::string, CodeSnippet>& CodeSnippetFactory::snippets() const { return snippets_; }
+
+void CodeSnippetFactory::add_setup(const std::string& snippet) { setup_snippets_.insert(snippet); }
+
+void CodeSnippetFactory::add_teardown(const std::string& snippet) { teardown_snippets_.insert(snippet); }
+
+const std::unordered_set<std::string>& CodeSnippetFactory::setup_snippets() const { return setup_snippets_; }
+
+const std::unordered_set<std::string>& CodeSnippetFactory::teardown_snippets() const { return teardown_snippets_; }
 
 } // namespace sdfg::codegen

--- a/sdfg/src/codegen/code_snippet_factory.cpp
+++ b/sdfg/src/codegen/code_snippet_factory.cpp
@@ -29,8 +29,12 @@ void CodeSnippetFactory::add_setup(const std::string& snippet) { setup_snippets_
 
 void CodeSnippetFactory::add_teardown(const std::string& snippet) { teardown_snippets_.insert(snippet); }
 
+void CodeSnippetFactory::add_global(const std::string& snippet) { globals_snippets_.insert(snippet); }
+
 const std::unordered_set<std::string>& CodeSnippetFactory::setup_snippets() const { return setup_snippets_; }
 
 const std::unordered_set<std::string>& CodeSnippetFactory::teardown_snippets() const { return teardown_snippets_; }
+
+const std::unordered_set<std::string>& CodeSnippetFactory::globals_snippets() const { return globals_snippets_; }
 
 } // namespace sdfg::codegen

--- a/sdfg/src/codegen/dispatchers/while_dispatcher.cpp
+++ b/sdfg/src/codegen/dispatchers/while_dispatcher.cpp
@@ -92,6 +92,11 @@ ReturnDispatcher::ReturnDispatcher(
 void ReturnDispatcher::dispatch_node(
     PrettyPrinter& main_stream, PrettyPrinter& globals_stream, CodeSnippetFactory& library_snippet_factory
 ) {
+    // Emit teardown snippets before return
+    for (auto& snippet : library_snippet_factory.teardown_snippets()) {
+        main_stream << snippet;
+    }
+
     // Free heap allocations
     for (auto& container : sdfg_.containers()) {
         if (sdfg_.is_external(container)) {

--- a/sdfg/src/data_flow/library_nodes/load_const_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/load_const_node.cpp
@@ -163,8 +163,7 @@ void LoadConstNodeDispatcher::
 
     if (code_snippet_factory.find(marker) == code_snippet_factory.snippets().end()) {
         code_snippet_factory.require(marker, "", false);
-        // hacky way to only emit to global once
-        globals_stream << "#include <daisy_rtl/arg_capture_io.h>" << std::endl;
+        code_snippet_factory.add_global("#include <daisy_rtl/arg_capture_io.h>");
 
         globals_stream << std::endl;
     }

--- a/sdfg/src/data_flow/library_nodes/stdlib/assert.cpp
+++ b/sdfg/src/data_flow/library_nodes/stdlib/assert.cpp
@@ -161,9 +161,9 @@ void AssertNodeDispatcher::dispatch_code(
 #endif
     // Should be in include stream. Change when include handling is reworked!
     if (this->language_extension_.language() == "C") {
-        globals_stream << "#include <assert.h>" << std::endl;
+        library_snippet_factory.add_global("#include <assert.h>");
     } else {
-        globals_stream << "#include <cassert>" << std::endl;
+        library_snippet_factory.add_global("#include <cassert>");
 #ifndef __APPLE__
         bool_cast = "static_cast<bool>";
 #endif

--- a/targets/et/src/et/blas/gemm.cpp
+++ b/targets/et/src/et/blas/gemm.cpp
@@ -261,9 +261,9 @@ void GEMMNodeDispatcher_ETSOC_WithTransfers::dispatch(
     codegen::PrettyPrinter& globals_stream,
     codegen::CodeSnippetFactory& library_snippet_factory
 ) {
-    globals_stream << "#include <docc/rt/et/et.h>" << std::endl;
-    globals_stream << "#include <filesystem>" << std::endl;
-    globals_stream << "#include <iostream>" << std::endl;
+    library_snippet_factory.add_global("#include <docc/rt/et/et.h>");
+    library_snippet_factory.add_global("#include <filesystem>");
+    library_snippet_factory.add_global("#include <iostream>");
 
     stream << kernel_stream_setup << std::endl;
 


### PR DESCRIPTION
* reduce the number of cublas/rocblas handle creations and destruction to 1
* wrap includes into a set to avoid redefinition of headers per dispatcher call 