### PR TITLE
Read only offloads reuse

### DIFF
--- a/opt/include/sdfg/analysis/data_transfer_elimination_analysis.h
+++ b/opt/include/sdfg/analysis/data_transfer_elimination_analysis.h
@@ -24,27 +24,38 @@ struct OffloadHolder {
     const data_flow::AccessNode* host_data;
     const data_flow::Memlet* host_access;
     const data_flow::AccessNode* dev_data;
+    bool starts_dev_lifetime;
+    bool ends_dev_lifetime;
+    bool updates_on_dev;
+    bool updates_on_host;
 
     OffloadHolder(
         offloading::DataOffloadingNode* offload_node,
         const data_flow::AccessNode* host_data,
         const data_flow::Memlet* host_access,
-        const data_flow::AccessNode* dev_data
+        const data_flow::AccessNode* dev_data,
+        bool starts_dev_lifetime,
+        bool ends_dev_lifetime,
+        bool updates_on_dev,
+        bool updates_on_host
     )
         : offload_node(offload_node), malloc_node(nullptr), host_data(host_data), host_access(host_access),
-          dev_data(dev_data) {}
+          dev_data(dev_data), starts_dev_lifetime(starts_dev_lifetime), ends_dev_lifetime(ends_dev_lifetime),
+          updates_on_dev(updates_on_dev), updates_on_host(updates_on_host) {}
 
     OffloadHolder(
         stdlib::MallocNode* malloc_node, const data_flow::AccessNode* host_data, const data_flow::Memlet* host_access
     )
         : offload_node(nullptr), malloc_node(malloc_node), host_data(host_data), host_access(host_access),
-          dev_data(nullptr) {}
+          dev_data(nullptr), starts_dev_lifetime(false), ends_dev_lifetime(false), updates_on_dev(false),
+          updates_on_host(false) {}
 
     void remove_host_side();
 };
 
 struct ExposedOffload {
     OffloadHolder* offload;
+    std::string container;
     int read_count = 0;
 };
 
@@ -88,7 +99,18 @@ protected:
     bool full_kill_ = false;
     DataTransferEliminationCandidateCollector& collector_;
 
-    enum class KillingType { None, Basic, DeviceReuse, EmptyHostMalloc };
+    enum class KillingType {
+        // No match
+        None,
+        // kill the current node from live-set
+        Basic,
+        // the killing node is a H2D after a D2H of same data -> can elide H2D
+        DeviceReuse,
+        // the killing node is a H2D with alloc that is the first use of host malloc. Can elide H2D
+        EmptyHostMalloc,
+        // the killing node is a device free of a device alloc of clean data -> can treat it similar to D2H
+        DeviceFree
+    };
 
 public:
     OffloadState(DataTransferEliminationCandidateCollector& collector);

--- a/opt/src/analysis/data_transfer_elimination_analysis.cpp
+++ b/opt/src/analysis/data_transfer_elimination_analysis.cpp
@@ -35,24 +35,53 @@ void OffloadState::found_full_barrier(ControlFlowNode& node) {
 std::pair<OffloadState::KillingType, OffloadHolder*> OffloadState::find_killing_entry_node(const ExposedOffload&
                                                                                                in_flight) const {
     auto& holder = *in_flight.offload;
-    auto& host_access_type = holder.host_access->base_type();
+    static const types::Scalar void_type(types::Void);
+    auto& host_access_type = holder.host_access ? holder.host_access->base_type() : void_type;
 
     auto* offload_node = holder.offload_node;
     auto* malloc_node = holder.malloc_node;
 
-    for (const auto& entry_node : h2d_nodes_ | std::views::values) {
-        auto& entry_holder = *entry_node;
-        if (entry_holder.host_data->data() == holder.host_data->data()) {
-            if (offload_node) {
-                bool is_elim_candidate = holder.offload_node->redundant_with(*entry_holder.offload_node);
-                return {is_elim_candidate ? KillingType::DeviceReuse : KillingType::Basic, &entry_holder};
-            } else if (malloc_node) { // mallocs should only be in flight as long as they are untouched
-                bool can_be_removed = entry_holder.offload_node->is_alloc() && entry_holder.offload_node->is_h2d();
-                return {can_be_removed ? KillingType::EmptyHostMalloc : KillingType::Basic, &entry_holder};
+    if (holder.ends_dev_lifetime || holder.updates_on_host || malloc_node) {
+        for (const auto& entry : h2d_nodes_ | std::views::values) {
+            auto& entry_holder = *entry;
+            auto& entry_host_access_type = entry_holder.host_access ? entry_holder.host_access->base_type() : void_type;
+            bool host_ptr_matches = entry_holder.host_data && in_flight.container == entry_holder.host_data->data();
+
+            if (host_ptr_matches) {
+                if (offload_node && (holder.updates_on_host || holder.ends_dev_lifetime)) {
+                    // D2H -> H2D
+                    bool is_elim_candidate = holder.offload_node->is_compatible_with(*entry_holder.offload_node) &&
+                                             entry_holder.updates_on_dev;
+                    return {is_elim_candidate ? KillingType::DeviceReuse : KillingType::Basic, &entry_holder};
+                } else if (malloc_node) {
+                    // Malloc -> H2D
+                    // mallocs should only be in flight as long as they are untouched
+                    bool can_be_removed = entry_holder.offload_node->is_alloc() && entry_holder.offload_node->is_h2d();
+                    return {can_be_removed ? KillingType::EmptyHostMalloc : KillingType::Basic, &entry_holder};
+                } else {
+                    return {KillingType::Basic, &entry_holder};
+                }
+            } else if (host_access_type == entry_host_access_type) { // aliases
+                // any -> any with aliasing types
+                // return &entry_node; // TODO left unhandled for now, because then most situations like a matmul could
+                // never be eliminated
             }
-        } else if (host_access_type == entry_holder.host_access->base_type()) { // aliases
-            // return &entry_node; // TODO left unhandled for now, because then most situations like a matmul could
-            // never be eliminated
+        }
+    } else if (holder.starts_dev_lifetime) {
+        for (const auto& entry : generated_ | std::views::values) {
+            auto& entry_holder = *entry;
+
+            bool dev_ptr_matches = false;
+            if (holder.dev_data && entry_holder.dev_data) {
+                dev_ptr_matches = in_flight.container == entry_holder.dev_data->data();
+            }
+
+            if (dev_ptr_matches) {
+                // D_ALLOC -> D_FREE is the expected case, but kill for any match
+                bool is_elim_candidate = holder.offload_node->is_compatible_with(*entry_holder.offload_node) &&
+                                         entry_holder.ends_dev_lifetime && !entry_holder.updates_on_host;
+                return {is_elim_candidate ? KillingType::DeviceFree : KillingType::Basic, &entry_holder};
+            }
         }
     }
 
@@ -81,12 +110,35 @@ void OffloadState::found_offload_node(Block& block, offloading::DataOffloadingNo
     bool dst_is_dev = false;
     bool dst_is_host = false;
 
-    if (is_D2H(offload.transfer_direction())) {
+    bool starts_dev_lifetime = false;
+    bool ends_dev_lifetime = false;
+    bool updates_on_dev = false;
+    bool updates_on_host = false;
+
+    auto transfer_direction = offload.transfer_direction();
+    auto lifecycle = offload.buffer_lifecycle();
+    if (transfer_direction == offloading::DataTransferDirection::D2H) {
         src_is_dev = true;
         dst_is_host = true;
-    } else if (is_H2D(offload.transfer_direction())) {
+        updates_on_host = true;
+        if (lifecycle == offloading::BufferLifecycle::FREE) {
+            ends_dev_lifetime = true;
+        }
+    } else if (transfer_direction == offloading::DataTransferDirection::H2D) {
         src_is_host = true;
         dst_is_dev = true;
+        updates_on_dev = true;
+        if (lifecycle == offloading::BufferLifecycle::ALLOC) {
+            starts_dev_lifetime = true;
+        }
+    } else if (offloading::is_NONE(transfer_direction)) {
+        if (lifecycle == offloading::BufferLifecycle::ALLOC) {
+            starts_dev_lifetime = true;
+            dst_is_dev = true;
+        } else if (lifecycle == offloading::BufferLifecycle::FREE) {
+            ends_dev_lifetime = true;
+            src_is_dev = true;
+        }
     }
 
     const data_flow::AccessNode* found_dev_access = nullptr;
@@ -126,21 +178,37 @@ void OffloadState::found_offload_node(Block& block, offloading::DataOffloadingNo
         }
     }
 
-    if (found_host_access && found_dev_access) {
-        if (dst_is_host) {
-            generated_.emplace(
-                offload.element_id(),
-                std::make_unique<OffloadHolder>(&offload, found_host_access, found_host_memlet, found_dev_access)
-            );
-        } else {
-            add_h2d_entry(OffloadHolder{&offload, found_host_access, found_host_memlet, found_dev_access});
-        }
+    if (ends_dev_lifetime || updates_on_host) {
+        generated_.emplace(
+            offload.element_id(),
+            std::make_unique<OffloadHolder>(
+                &offload,
+                found_host_access,
+                found_host_memlet,
+                found_dev_access,
+                starts_dev_lifetime,
+                ends_dev_lifetime,
+                updates_on_dev,
+                updates_on_host
+            )
+        );
+    } else if (starts_dev_lifetime || updates_on_dev) {
+        add_h2d_entry(OffloadHolder{
+            &offload,
+            found_host_access,
+            found_host_memlet,
+            found_dev_access,
+            starts_dev_lifetime,
+            ends_dev_lifetime,
+            updates_on_dev,
+            updates_on_host
+        });
     }
 }
 
 void OffloadState::add_h2d_entry(const OffloadHolder& entry) {
     h2d_nodes_.emplace(entry.offload_node->element_id(), std::make_unique<OffloadHolder>(entry));
-    // todo also need to remove generated ones killed by this. But right now
+    // todo also need to remove generated ones killed by this. But right now, only max 1 per block anyway
 }
 
 void OffloadState::apply_kills_and_changes(ExposedType& exposed) const {
@@ -148,28 +216,27 @@ void OffloadState::apply_kills_and_changes(ExposedType& exposed) const {
         exposed.clear();
         return;
     }
+    std::list<ExposedOffload> dynamic_inserts;
     for (auto it = exposed.begin(); it != exposed.end();) {
         auto& [id, exposedOffload] = *it;
         auto& holder = *exposedOffload.offload;
 
-        auto* host = exposedOffload.offload->host_data;
-        auto& host_container = host->data();
 
-        auto host_reads = reads_.find(host_container);
-        if (host_reads != reads_.end() && host_reads->second.size() > 0) {
-            if (holder.offload_node) {
-                ++exposedOffload.read_count;
-            } else if (holder.malloc_node) { // mallocs are just killed on first
+        auto container_reads = reads_.find(exposedOffload.container);
+        if (container_reads != reads_.end() && !container_reads->second.empty()) {
+            if (holder.malloc_node) { // mallocs are just killed on first use
                 DEBUG_PRINTLN(
                     "In-flight malloc area of #" << holder.malloc_node->element_id()
                                                  << " is read without being initialized!"
                 );
                 it = exposed.erase(it);
                 continue;
+            } else { // track if a live var is read
+                ++exposedOffload.read_count;
             }
         }
 
-        if (kills_containers_.contains(host_container)) {
+        if (kills_containers_.contains(exposedOffload.container)) {
             it = exposed.erase(it);
             continue;
         }
@@ -180,6 +247,18 @@ void OffloadState::apply_kills_and_changes(ExposedType& exposed) const {
                 collector_.found_transfer_reuse_pair(exposedOffload, *killing_entry);
             } else if (kill_type == KillingType::EmptyHostMalloc) {
                 collector_.found_empty_host_malloc(exposedOffload, *killing_entry);
+            } else if (kill_type == KillingType::DeviceFree) {
+                // we have a on-device-alloc that survived without kills to the on-device-free
+                // -> promote this to a host-relevant D2H point, that might be reused
+
+                // replace the current H2D with the "D2H" that would allow it to live on
+                // this creates a D2H-like exposedOffload, despite us not knowing the host-var at this point
+                auto* host_data = holder.host_data;
+                if (host_data) {
+                    dynamic_inserts.emplace_back(killing_entry, host_data->data(), 0);
+                    it = exposed.erase(it);
+                    continue;
+                }
             }
             it = exposed.erase(it);
             continue;
@@ -188,7 +267,21 @@ void OffloadState::apply_kills_and_changes(ExposedType& exposed) const {
     }
 
     for (auto& [id, gen] : generated_) {
-        exposed.insert({id, ExposedOffload{gen.get(), 0}});
+        auto* holder = gen.get();
+        if (holder->updates_on_host || holder->malloc_node) { // block unidentified host-container ones from being
+                                                              // exposed. If we could reconstruct, it will be a
+                                                              // dynamic_insert
+            exposed.insert({id, ExposedOffload{holder, holder->host_data->data(), 0}});
+        }
+    }
+    for (auto& gen : dynamic_inserts) {
+        exposed.insert({gen.offload->offload_node->element_id(), gen});
+    }
+    for (auto& [id, gen] : h2d_nodes_) {
+        auto* holder = gen.get();
+        if (holder->starts_dev_lifetime) {
+            exposed.insert({id, ExposedOffload{holder, holder->dev_data->data(), 0}});
+        }
     }
 }
 

--- a/opt/src/passes/offloading/data_transfer_minimization_pass.cpp
+++ b/opt/src/passes/offloading/data_transfer_minimization_pass.cpp
@@ -64,14 +64,23 @@ bool DataTransferMinimizationPass::eliminate_transfer_pair(
     DebugInfo copy_out_src_debinfo = copy_out.dev_data->debug_info();
     DebugInfo copy_in_dst_debinfo = copy_in.dev_data->debug_info();
 
+    bool remove_entirely = false;
     // Remove what you can remove
     if (!remove_d2h && copy_out.offload_node->is_free()) {
-        copy_out.offload_node->remove_free();
+        if (copy_out.offload_node->is_d2h()) {
+            copy_out.offload_node->remove_free();
+        } else {
+            remove_entirely = true;
+        }
     } else if (remove_d2h) {
+        remove_entirely = true;
+    }
+    if (remove_entirely) {
         auto* copy_out_block =
             dynamic_cast<structured_control_flow::Block*>(copy_out.offload_node->get_parent().get_parent());
         builder.clear_code_node_legacy(*copy_out_block, *copy_out.offload_node);
     }
+
     auto* copy_in_block = dynamic_cast<structured_control_flow::Block*>(copy_in.offload_node->get_parent().get_parent()
     );
     builder.clear_code_node_legacy(*copy_in_block, *copy_in.offload_node);

--- a/opt/tests/passes/offloading/data_transfer_minimization_pass_test.cpp
+++ b/opt/tests/passes/offloading/data_transfer_minimization_pass_test.cpp
@@ -7,10 +7,14 @@
 #include "sdfg/builder/structured_sdfg_builder.h"
 #include "sdfg/codegen/code_generator.h"
 #include "sdfg/codegen/code_generators/cpp_code_generator.h"
+#include "sdfg/data_flow/library_nodes/call_node.h"
+#include "sdfg/data_flow/library_nodes/stdlib/free.h"
 #include "sdfg/element.h"
 #include "sdfg/function.h"
+#include "sdfg/passes/dataflow/dead_data_elimination.h"
 #include "sdfg/structured_control_flow/map.h"
 #include "sdfg/symbolic/symbolic.h"
+#include "sdfg/targets/cuda/cuda.h"
 #include "sdfg/targets/cuda/cuda_data_offloading_node.h"
 #include "sdfg/targets/offloading/data_offloading_node.h"
 
@@ -269,6 +273,14 @@ TEST(DataTransferMinimizationPassTest, UselessMallocTest) {
 
     EXPECT_EQ(block_malloc.dataflow().nodes().size(), 2);
     EXPECT_EQ(block_h2d.dataflow().nodes().size(), 2);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_h2d).transfer_direction(),
+        offloading::DataTransferDirection::NONE
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_h2d).buffer_lifecycle(),
+        offloading::BufferLifecycle::ALLOC
+    );
     EXPECT_EQ(block_d2h.dataflow().nodes().size(), 3);
 
     auto instrumentation_plan = codegen::InstrumentationPlan::none(builder.subject());
@@ -276,4 +288,642 @@ TEST(DataTransferMinimizationPassTest, UselessMallocTest) {
     codegen::CPPCodeGenerator
         code_generator(builder.subject(), analysis_manager, *instrumentation_plan, *arg_capture_plan);
     code_generator.generate();
+};
+
+TEST(DataTransferMinimizationPassTest, ReadOnlyDataReuseTest) {
+    sdfg::builder::StructuredSDFGBuilder builder("dot", sdfg::FunctionType_CPU);
+    sdfg::analysis::AnalysisManager analysis_manager(builder.subject());
+
+    auto& root = builder.subject().root();
+
+    // Add containers
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    types::Scalar void_type(types::Void);
+    builder.add_container("A", desc, true);
+    builder.add_container("__daisy_offload_A", desc);
+
+    auto& in_type = builder.subject().type("A");
+    auto& out_type = builder.subject().type("A");
+
+    // -- Malloc
+    auto& block_malloc = builder.add_block(root);
+    auto& access_node_malloc = builder.add_access(block_malloc, "A");
+
+    auto& malloc_node = builder.add_library_node<stdlib::MallocNode>(block_malloc, DebugInfo(), symbolic::integer(400));
+
+    builder.add_computational_memlet(block_malloc, malloc_node, "_ret", access_node_malloc, {}, desc);
+
+    // -- host-dirty data
+    auto& block_dirty = builder.add_block(root);
+    auto& access_node_dirty = builder.add_access(block_dirty, "A");
+    std::vector<std::string> blackblox_ins = {"_ptr"};
+    std::vector<std::string> blackbox_outs = {};
+    types::Function func_type(void_type);
+    func_type.add_param(desc);
+    builder.add_external("blackbox", func_type, LinkageType_External);
+    auto& dirty_blackbox =
+        builder
+            .add_library_node<data_flow::CallNode>(block_dirty, DebugInfo(), "blackbox", blackbox_outs, blackblox_ins);
+    builder.add_computational_memlet(block_dirty, access_node_dirty, dirty_blackbox, "_ptr", {}, desc);
+
+
+    // --- Init H2D
+    auto& block_h2d = builder.add_block(root);
+
+    auto& access_node_in2 = builder.add_access(block_h2d, "A");
+    auto& access_node_out2 = builder.add_access(block_h2d, "__daisy_offload_A");
+
+    auto& memcpy_node_h2d = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_h2d,
+        DebugInfo(),
+        symbolic::integer(400),
+        symbolic::integer(0),
+        offloading::DataTransferDirection::H2D,
+        offloading::BufferLifecycle::ALLOC
+    );
+
+    builder.add_computational_memlet(block_h2d, access_node_in2, memcpy_node_h2d, "_src", {}, in_type);
+    builder.add_computational_memlet(block_h2d, memcpy_node_h2d, "_dst", access_node_out2, {}, out_type);
+
+    // --- Init D2H
+    auto& block_d2h = builder.add_block(root);
+    auto& access_d2h_in = builder.add_access(block_d2h, "__daisy_offload_A");
+    auto& access_d2h_out = builder.add_access(block_d2h, "A");
+
+    auto& memcpy_node_d2h = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_d2h,
+        DebugInfo(),
+        symbolic::integer(400),
+        symbolic::integer(0),
+        offloading::DataTransferDirection::D2H,
+        offloading::BufferLifecycle::FREE
+    );
+
+    builder.add_computational_memlet(block_d2h, access_d2h_in, memcpy_node_d2h, "_src", {}, in_type);
+    builder.add_computational_memlet(block_d2h, memcpy_node_d2h, "_dst", access_d2h_out, {}, out_type);
+
+    // ------- reuse H2D
+
+    auto& block_h2d_reuse = builder.add_block(root);
+
+    auto& access_h2d_reuse_in = builder.add_access(block_h2d_reuse, "A");
+    auto& access_h2d_reuse_out = builder.add_access(block_h2d_reuse, "__daisy_offload_A");
+
+    auto& memcpy_node_reuse_h2d = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_h2d_reuse,
+        DebugInfo(),
+        symbolic::integer(400),
+        symbolic::integer(0),
+        offloading::DataTransferDirection::H2D,
+        offloading::BufferLifecycle::ALLOC
+    );
+
+    builder.add_computational_memlet(block_h2d_reuse, access_h2d_reuse_in, memcpy_node_reuse_h2d, "_src", {}, in_type);
+    builder.add_computational_memlet(block_h2d_reuse, memcpy_node_reuse_h2d, "_dst", access_h2d_reuse_out, {}, out_type);
+
+    // --- reuse D2H
+    auto& block_d2h_reuse = builder.add_block(root);
+    auto& access_d2h_reuse_in = builder.add_access(block_d2h_reuse, "__daisy_offload_A");
+    auto& access_d2h_reuse_out = builder.add_access(block_d2h_reuse, "__daisy_offload_A");
+
+    auto& memcpy_node_reuse_d2h = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_d2h_reuse,
+        DebugInfo(),
+        symbolic::integer(400),
+        symbolic::integer(0),
+        offloading::DataTransferDirection::NONE,
+        offloading::BufferLifecycle::FREE
+    );
+
+    builder.add_computational_memlet(block_d2h_reuse, access_d2h_reuse_in, memcpy_node_reuse_d2h, "_ptr", {}, in_type);
+    builder.add_computational_memlet(block_d2h_reuse, memcpy_node_reuse_d2h, "_ptr", access_d2h_reuse_out, {}, out_type);
+
+    // ------- reuse2 H2D
+
+    auto& block_h2d_reuse2 = builder.add_block(root);
+
+    auto& access_h2d_reuse2_in = builder.add_access(block_h2d_reuse2, "A");
+    auto& access_h2d_reuse2_out = builder.add_access(block_h2d_reuse2, "__daisy_offload_A");
+
+    auto& memcpy_node_reuse2_h2d = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_h2d_reuse2,
+        DebugInfo(),
+        symbolic::integer(400),
+        symbolic::integer(0),
+        offloading::DataTransferDirection::H2D,
+        offloading::BufferLifecycle::ALLOC
+    );
+
+    builder
+        .add_computational_memlet(block_h2d_reuse2, access_h2d_reuse2_in, memcpy_node_reuse2_h2d, "_src", {}, in_type);
+    builder
+        .add_computational_memlet(block_h2d_reuse2, memcpy_node_reuse2_h2d, "_dst", access_h2d_reuse2_out, {}, out_type);
+
+    // --- reuse2 D2H
+    auto& block_d2h_reuse2 = builder.add_block(root);
+    auto& access_d2h_reuse2_in = builder.add_access(block_d2h_reuse2, "__daisy_offload_A");
+    auto& access_d2h_reuse2_out = builder.add_access(block_d2h_reuse2, "A");
+
+    auto& memcpy_node_reuse2_d2h = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_d2h_reuse2,
+        DebugInfo(),
+        symbolic::integer(400),
+        symbolic::integer(0),
+        offloading::DataTransferDirection::D2H,
+        offloading::BufferLifecycle::FREE
+    );
+
+    builder
+        .add_computational_memlet(block_d2h_reuse2, access_d2h_reuse2_in, memcpy_node_reuse2_d2h, "_src", {}, in_type);
+    builder
+        .add_computational_memlet(block_d2h_reuse2, memcpy_node_reuse2_d2h, "_dst", access_d2h_reuse2_out, {}, out_type);
+
+    // --- Free
+    auto& block_free = builder.add_block(root);
+    auto& access_node_free_in = builder.add_access(block_free, "A");
+    auto& access_node_free_out = builder.add_access(block_free, "A");
+
+    auto& free_node = builder.add_library_node<stdlib::FreeNode>(block_free, DebugInfo());
+
+    builder.add_computational_memlet(block_free, access_node_free_in, free_node, "_ptr", {}, desc);
+    builder.add_computational_memlet(block_free, free_node, "_ptr", access_node_free_out, {}, desc);
+
+    dump_sdfg(builder.subject(), "0-before");
+
+    passes::DataTransferMinimizationPass pass;
+    EXPECT_TRUE(pass.run(builder, analysis_manager));
+
+    dump_sdfg(builder.subject(), "1-after");
+
+    EXPECT_EQ(block_malloc.dataflow().nodes().size(), 2);
+    EXPECT_EQ(block_h2d.dataflow().nodes().size(), 3);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_h2d).transfer_direction(),
+        offloading::DataTransferDirection::H2D
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_h2d).buffer_lifecycle(),
+        offloading::BufferLifecycle::ALLOC
+    );
+    EXPECT_EQ(block_d2h.dataflow().nodes().size(), 3);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_d2h).transfer_direction(),
+        offloading::DataTransferDirection::D2H
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_d2h).buffer_lifecycle(),
+        offloading::BufferLifecycle::NO_CHANGE
+    );
+    EXPECT_EQ(block_h2d_reuse.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_d2h_reuse.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_h2d_reuse2.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_d2h_reuse2.dataflow().nodes().size(), 3);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse2_d2h).transfer_direction(),
+        offloading::DataTransferDirection::D2H
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse2_d2h).buffer_lifecycle(),
+        offloading::BufferLifecycle::FREE
+    );
+    EXPECT_EQ(block_free.dataflow().nodes().size(), 3);
+
+    passes::DeadDataElimination dde_pass(false);
+    dde_pass.run(builder, analysis_manager);
+
+    EXPECT_EQ(block_malloc.dataflow().nodes().size(), 2);
+    EXPECT_EQ(block_h2d.dataflow().nodes().size(), 3);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_h2d).transfer_direction(),
+        offloading::DataTransferDirection::H2D
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_h2d).buffer_lifecycle(),
+        offloading::BufferLifecycle::ALLOC
+    );
+    EXPECT_EQ(block_d2h.dataflow().nodes().size(), 3);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_d2h).transfer_direction(),
+        offloading::DataTransferDirection::D2H
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_d2h).buffer_lifecycle(),
+        offloading::BufferLifecycle::NO_CHANGE
+    );
+    EXPECT_EQ(block_h2d_reuse.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_d2h_reuse.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_h2d_reuse2.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_d2h_reuse2.dataflow().nodes().size(), 3);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse2_d2h).transfer_direction(),
+        offloading::DataTransferDirection::D2H
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse2_d2h).buffer_lifecycle(),
+        offloading::BufferLifecycle::FREE
+    );
+    EXPECT_EQ(block_free.dataflow().nodes().size(), 3);
+
+    dump_sdfg(builder.subject(), "2-cleanup");
+};
+
+TEST(DataTransferMinimizationPassTest, ReadOnlyDataPureDeviceTest) {
+    sdfg::builder::StructuredSDFGBuilder builder("dot", sdfg::FunctionType_CPU);
+    sdfg::analysis::AnalysisManager analysis_manager(builder.subject());
+
+    auto& root = builder.subject().root();
+
+    // Add containers
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    types::Scalar void_type(types::Void);
+    builder.add_container("A", desc);
+    builder.add_container("__daisy_offload_A", desc);
+
+    auto& in_type = builder.subject().type("A");
+    auto& out_type = builder.subject().type("A");
+
+    // -- Malloc
+    auto& block_malloc = builder.add_block(root);
+    auto& access_node_malloc = builder.add_access(block_malloc, "A");
+
+    auto& malloc_node = builder.add_library_node<stdlib::MallocNode>(block_malloc, DebugInfo(), symbolic::integer(400));
+
+    builder.add_computational_memlet(block_malloc, malloc_node, "_ret", access_node_malloc, {}, desc);
+
+
+    // --- Init H2D
+    auto& block_h2d = builder.add_block(root);
+
+    auto& access_node_in2 = builder.add_access(block_h2d, "A");
+    auto& access_node_out2 = builder.add_access(block_h2d, "__daisy_offload_A");
+
+    auto& memcpy_node_h2d = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_h2d,
+        DebugInfo(),
+        symbolic::integer(400),
+        symbolic::integer(0),
+        offloading::DataTransferDirection::H2D,
+        offloading::BufferLifecycle::ALLOC
+    );
+
+    builder.add_computational_memlet(block_h2d, access_node_in2, memcpy_node_h2d, "_src", {}, in_type);
+    builder.add_computational_memlet(block_h2d, memcpy_node_h2d, "_dst", access_node_out2, {}, out_type);
+
+    // --- Init D2H
+    auto& block_d2h = builder.add_block(root);
+    auto& access_d2h_in = builder.add_access(block_d2h, "__daisy_offload_A");
+    auto& access_d2h_out = builder.add_access(block_d2h, "A");
+
+    auto& memcpy_node_d2h = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_d2h,
+        DebugInfo(),
+        symbolic::integer(400),
+        symbolic::integer(0),
+        offloading::DataTransferDirection::D2H,
+        offloading::BufferLifecycle::FREE
+    );
+
+    builder.add_computational_memlet(block_d2h, access_d2h_in, memcpy_node_d2h, "_src", {}, in_type);
+    builder.add_computational_memlet(block_d2h, memcpy_node_d2h, "_dst", access_d2h_out, {}, out_type);
+
+    // ------- reuse H2D
+
+    auto& block_h2d_reuse = builder.add_block(root);
+
+    auto& access_h2d_reuse_in = builder.add_access(block_h2d_reuse, "A");
+    auto& access_h2d_reuse_out = builder.add_access(block_h2d_reuse, "__daisy_offload_A");
+
+    auto& memcpy_node_reuse_h2d = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_h2d_reuse,
+        DebugInfo(),
+        symbolic::integer(400),
+        symbolic::integer(0),
+        offloading::DataTransferDirection::H2D,
+        offloading::BufferLifecycle::ALLOC
+    );
+
+    builder.add_computational_memlet(block_h2d_reuse, access_h2d_reuse_in, memcpy_node_reuse_h2d, "_src", {}, in_type);
+    builder.add_computational_memlet(block_h2d_reuse, memcpy_node_reuse_h2d, "_dst", access_h2d_reuse_out, {}, out_type);
+
+    // --- reuse D2H
+    auto& block_d2h_reuse = builder.add_block(root);
+    auto& access_d2h_reuse_in = builder.add_access(block_d2h_reuse, "__daisy_offload_A");
+    auto& access_d2h_reuse_out = builder.add_access(block_d2h_reuse, "__daisy_offload_A");
+
+    auto& memcpy_node_reuse_d2h = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_d2h_reuse,
+        DebugInfo(),
+        symbolic::integer(400),
+        symbolic::integer(0),
+        offloading::DataTransferDirection::NONE,
+        offloading::BufferLifecycle::FREE
+    );
+
+    builder.add_computational_memlet(block_d2h_reuse, access_d2h_reuse_in, memcpy_node_reuse_d2h, "_ptr", {}, in_type);
+    builder.add_computational_memlet(block_d2h_reuse, memcpy_node_reuse_d2h, "_ptr", access_d2h_reuse_out, {}, out_type);
+
+    // ------- reuse2 H2D
+
+    auto& block_h2d_reuse2 = builder.add_block(root);
+
+    auto& access_h2d_reuse2_in = builder.add_access(block_h2d_reuse2, "A");
+    auto& access_h2d_reuse2_out = builder.add_access(block_h2d_reuse2, "__daisy_offload_A");
+
+    auto& memcpy_node_reuse2_h2d = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_h2d_reuse2,
+        DebugInfo(),
+        symbolic::integer(400),
+        symbolic::integer(0),
+        offloading::DataTransferDirection::H2D,
+        offloading::BufferLifecycle::ALLOC
+    );
+
+    builder
+        .add_computational_memlet(block_h2d_reuse2, access_h2d_reuse2_in, memcpy_node_reuse2_h2d, "_src", {}, in_type);
+    builder
+        .add_computational_memlet(block_h2d_reuse2, memcpy_node_reuse2_h2d, "_dst", access_h2d_reuse2_out, {}, out_type);
+
+    // --- reuse2 D2H
+    auto& block_d2h_reuse2 = builder.add_block(root);
+    auto& access_d2h_reuse2_in = builder.add_access(block_d2h_reuse2, "__daisy_offload_A");
+    auto& access_d2h_reuse2_out = builder.add_access(block_d2h_reuse2, "A");
+
+    auto& memcpy_node_reuse2_d2h = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_d2h_reuse2,
+        DebugInfo(),
+        symbolic::integer(400),
+        symbolic::integer(0),
+        offloading::DataTransferDirection::D2H,
+        offloading::BufferLifecycle::FREE
+    );
+
+    builder
+        .add_computational_memlet(block_d2h_reuse2, access_d2h_reuse2_in, memcpy_node_reuse2_d2h, "_src", {}, in_type);
+    builder
+        .add_computational_memlet(block_d2h_reuse2, memcpy_node_reuse2_d2h, "_dst", access_d2h_reuse2_out, {}, out_type);
+
+    // --- Free
+    auto& block_free = builder.add_block(root);
+    auto& access_node_free_in = builder.add_access(block_free, "A");
+    auto& access_node_free_out = builder.add_access(block_free, "A");
+
+    auto& free_node = builder.add_library_node<stdlib::FreeNode>(block_free, DebugInfo());
+
+    builder.add_computational_memlet(block_free, access_node_free_in, free_node, "_ptr", {}, desc);
+    builder.add_computational_memlet(block_free, free_node, "_ptr", access_node_free_out, {}, desc);
+
+    dump_sdfg(builder.subject(), "0-before");
+
+    passes::DataTransferMinimizationPass pass;
+    EXPECT_TRUE(pass.run(builder, analysis_manager));
+
+    dump_sdfg(builder.subject(), "1-after");
+
+    EXPECT_EQ(block_malloc.dataflow().nodes().size(), 2);
+    EXPECT_EQ(block_h2d.dataflow().nodes().size(), 2);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_h2d).transfer_direction(),
+        offloading::DataTransferDirection::NONE
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_h2d).buffer_lifecycle(),
+        offloading::BufferLifecycle::ALLOC
+    );
+    EXPECT_EQ(block_d2h.dataflow().nodes().size(), 3);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_d2h).transfer_direction(),
+        offloading::DataTransferDirection::D2H
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_d2h).buffer_lifecycle(),
+        offloading::BufferLifecycle::NO_CHANGE
+    );
+    EXPECT_EQ(block_h2d_reuse.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_d2h_reuse.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_h2d_reuse2.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_d2h_reuse2.dataflow().nodes().size(), 3);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse2_d2h).transfer_direction(),
+        offloading::DataTransferDirection::D2H
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse2_d2h).buffer_lifecycle(),
+        offloading::BufferLifecycle::FREE
+    );
+    EXPECT_EQ(block_free.dataflow().nodes().size(), 3);
+
+    passes::DeadDataElimination dde_pass(false);
+    dde_pass.run(builder, analysis_manager);
+
+    EXPECT_EQ(block_malloc.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_h2d.dataflow().nodes().size(), 2);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_h2d).transfer_direction(),
+        offloading::DataTransferDirection::NONE
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_h2d).buffer_lifecycle(),
+        offloading::BufferLifecycle::ALLOC
+    );
+    EXPECT_EQ(block_d2h.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_h2d_reuse.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_d2h_reuse.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_h2d_reuse2.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_d2h_reuse2.dataflow().nodes().size(), 2);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse2_d2h).transfer_direction(),
+        offloading::DataTransferDirection::NONE
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse2_d2h).buffer_lifecycle(),
+        offloading::BufferLifecycle::FREE
+    );
+    EXPECT_EQ(block_free.dataflow().nodes().size(), 0);
+
+    dump_sdfg(builder.subject(), "2-cleanup");
+};
+
+TEST(DataTransferMinimizationPassTest, NotReadOnlyDataReuseTest) {
+    sdfg::builder::StructuredSDFGBuilder builder("dot", sdfg::FunctionType_CPU);
+    sdfg::analysis::AnalysisManager analysis_manager(builder.subject());
+
+    auto& root = builder.subject().root();
+
+    // Add containers
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    builder.add_container("A", desc, true);
+    builder.add_container("__daisy_offload_A", desc);
+    types::Scalar indvar_desc(types::PrimitiveType::Int32);
+    builder.add_container("i", indvar_desc);
+
+    auto& in_type = builder.subject().type("A");
+    auto& out_type = builder.subject().type("A");
+
+    auto arr_size = symbolic::integer(400);
+    auto device_id = symbolic::integer(0);
+
+    // -- Malloc
+    auto& block_malloc = builder.add_block(root);
+    auto& access_node_malloc = builder.add_access(block_malloc, "A");
+
+    auto& malloc_node = builder.add_library_node<stdlib::MallocNode>(block_malloc, DebugInfo(), symbolic::integer(400));
+
+    builder.add_computational_memlet(block_malloc, malloc_node, "_ret", access_node_malloc, {}, desc);
+
+
+    // --- Init H2D
+    auto& block_h2d = builder.add_block(root);
+
+    auto& access_node_in2 = builder.add_access(block_h2d, "A");
+    auto& access_node_out2 = builder.add_access(block_h2d, "__daisy_offload_A");
+
+    auto& memcpy_node_h2d = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_h2d,
+        DebugInfo(),
+        arr_size,
+        device_id,
+        offloading::DataTransferDirection::H2D,
+        offloading::BufferLifecycle::ALLOC
+    );
+
+    builder.add_computational_memlet(block_h2d, access_node_in2, memcpy_node_h2d, "_src", {}, in_type);
+    builder.add_computational_memlet(block_h2d, memcpy_node_h2d, "_dst", access_node_out2, {}, out_type);
+
+    auto indvar = symbolic::symbol("i");
+    // --- modify on device loop
+    auto& map_modify = builder.add_map(
+        root,
+        indvar,
+        symbolic::Lt(indvar, arr_size),
+        symbolic::zero(),
+        symbolic::add(indvar, symbolic::one()),
+        cuda::ScheduleType_CUDA::create()
+    );
+    auto& block_modify = builder.add_block(map_modify.root());
+
+    auto& access_modify_in = builder.add_access(block_modify, "__daisy_offload_A");
+    auto& const_1 = builder.add_constant(block_modify, "1.0", base_desc);
+    auto& access_modify_out = builder.add_access(block_modify, "__daisy_offload_A");
+    auto& modify_add = builder.add_tasklet(block_modify, data_flow::fp_add, "out", {"a", "b"}, {});
+    builder.add_computational_memlet(block_modify, access_modify_in, modify_add, "a", {indvar}, desc);
+    builder.add_computational_memlet(block_modify, const_1, modify_add, "b", {}, base_desc);
+    builder.add_computational_memlet(block_modify, modify_add, "out", access_modify_out, {indvar}, desc);
+
+
+    // --- Init D2H
+    auto& block_d2h = builder.add_block(root);
+    auto& access_d2h_in = builder.add_access(block_d2h, "__daisy_offload_A");
+    auto& access_d2h_out = builder.add_access(block_d2h, "__daisy_offload_A");
+
+    auto& memcpy_node_d2h = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_d2h,
+        DebugInfo(),
+        arr_size,
+        device_id,
+        offloading::DataTransferDirection::NONE,
+        offloading::BufferLifecycle::FREE
+    );
+
+    builder.add_computational_memlet(block_d2h, access_d2h_in, memcpy_node_d2h, "_ptr", {}, in_type);
+    builder.add_computational_memlet(block_d2h, memcpy_node_d2h, "_ptr", access_d2h_out, {}, out_type);
+
+    // ------- reuse H2D
+
+    auto& block_h2d_reuse = builder.add_block(root);
+
+    auto& access_h2d_reuse_in = builder.add_access(block_h2d_reuse, "A");
+    auto& access_h2d_reuse_out = builder.add_access(block_h2d_reuse, "__daisy_offload_A");
+
+    auto& memcpy_node_reuse_h2d = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_h2d_reuse,
+        DebugInfo(),
+        arr_size,
+        device_id,
+        offloading::DataTransferDirection::H2D,
+        offloading::BufferLifecycle::ALLOC
+    );
+
+    builder.add_computational_memlet(block_h2d_reuse, access_h2d_reuse_in, memcpy_node_reuse_h2d, "_src", {}, in_type);
+    builder.add_computational_memlet(block_h2d_reuse, memcpy_node_reuse_h2d, "_dst", access_h2d_reuse_out, {}, out_type);
+
+    // --- reuse D2H
+    auto& block_d2h_reuse = builder.add_block(root);
+    auto& access_d2h_reuse_in = builder.add_access(block_d2h_reuse, "__daisy_offload_A");
+    auto& access_d2h_reuse_out = builder.add_access(block_d2h_reuse, "A");
+
+    auto& memcpy_node_reuse_d2h = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_d2h_reuse,
+        DebugInfo(),
+        arr_size,
+        device_id,
+        offloading::DataTransferDirection::D2H,
+        offloading::BufferLifecycle::FREE
+    );
+
+    builder.add_computational_memlet(block_d2h_reuse, access_d2h_reuse_in, memcpy_node_reuse_d2h, "_src", {}, in_type);
+    builder.add_computational_memlet(block_d2h_reuse, memcpy_node_reuse_d2h, "_dst", access_d2h_reuse_out, {}, out_type);
+
+    // --- Free
+    auto& block_free = builder.add_block(root);
+    auto& access_node_free_in = builder.add_access(block_free, "A");
+    auto& access_node_free_out = builder.add_access(block_free, "A");
+
+    auto& free_node = builder.add_library_node<stdlib::FreeNode>(block_free, DebugInfo());
+
+    builder.add_computational_memlet(block_free, access_node_free_in, free_node, "_ptr", {}, desc);
+    builder.add_computational_memlet(block_free, free_node, "_ptr", access_node_free_out, {}, desc);
+
+    dump_sdfg(builder.subject(), "0-before");
+
+    passes::DataTransferMinimizationPass pass;
+    EXPECT_TRUE(pass.run(builder, analysis_manager));
+
+    dump_sdfg(builder.subject(), "1-after");
+
+    passes::DeadDataElimination dde_pass(false);
+    dde_pass.run(builder, analysis_manager);
+
+    dump_sdfg(builder.subject(), "2-cleanup");
+
+    EXPECT_EQ(block_malloc.dataflow().nodes().size(), 2);
+    EXPECT_EQ(block_h2d.dataflow().nodes().size(), 2);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_h2d).transfer_direction(),
+        offloading::DataTransferDirection::NONE
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_h2d).buffer_lifecycle(),
+        offloading::BufferLifecycle::ALLOC
+    );
+    EXPECT_EQ(block_d2h.dataflow().nodes().size(), 3);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_d2h).transfer_direction(),
+        offloading::DataTransferDirection::NONE
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_d2h).buffer_lifecycle(),
+        offloading::BufferLifecycle::FREE
+    );
+    EXPECT_EQ(block_h2d_reuse.dataflow().nodes().size(), 3);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse_h2d).transfer_direction(),
+        offloading::DataTransferDirection::H2D
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_h2d).buffer_lifecycle(),
+        offloading::BufferLifecycle::ALLOC
+    );
+    EXPECT_EQ(block_d2h_reuse.dataflow().nodes().size(), 3);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse_d2h).transfer_direction(),
+        offloading::DataTransferDirection::D2H
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse_d2h).buffer_lifecycle(),
+        offloading::BufferLifecycle::FREE
+    );
+    EXPECT_EQ(block_free.dataflow().nodes().size(), 3);
 };

--- a/python/benchmarks/npbench/polybench/test_fdtd_2d.py
+++ b/python/benchmarks/npbench/polybench/test_fdtd_2d.py
@@ -59,7 +59,7 @@ def test_fdtd_2d(target):
             verification={
                 "CUDA": 25,
                 "MAP": 25,
-                "CUDAOffloading": 42,
+                "CUDAOffloading": 38,
                 "FOR": 26,
                 "Malloc": 0,
             }
@@ -69,7 +69,7 @@ def test_fdtd_2d(target):
             verification={
                 "ROCM": 25,
                 "MAP": 25,
-                "ROCMOffloading": 42,
+                "ROCMOffloading": 38,
                 "FOR": 26,
                 "Malloc": 0,
             }

--- a/python/benchmarks/npbench/polybench/test_gemver.py
+++ b/python/benchmarks/npbench/polybench/test_gemver.py
@@ -59,7 +59,7 @@ def test_gemver(target):
                 "CUDA": 3,
                 "FOR": 3,
                 "MAP": 3,
-                "CUDAOffloading": 14,
+                "CUDAOffloading": 12,
                 "Malloc": 2,
                 "GEMM": 4,
             }
@@ -70,7 +70,7 @@ def test_gemver(target):
                 "ROCM": 3,
                 "FOR": 3,
                 "MAP": 3,
-                "ROCMOffloading": 14,
+                "ROCMOffloading": 12,
                 "Malloc": 2,
                 "GEMM": 4,
             }

--- a/sdfg/include/sdfg/targets/offloading/data_offloading_node.h
+++ b/sdfg/include/sdfg/targets/offloading/data_offloading_node.h
@@ -79,8 +79,19 @@ public:
 
     virtual std::string toStr() const override;
 
+    /**
+     * Checks that the nodes operate on the same device and compatible data
+     */
+    virtual bool is_compatible_with(const DataOffloadingNode& other) const;
+
+    /**
+     * The 2 nodes are opposites of each other that could cancel each other out
+     */
     virtual bool redundant_with(const DataOffloadingNode& other) const;
 
+    /**
+     * The 2 nodes do the same thing
+     */
     virtual bool equal_with(const DataOffloadingNode& other) const;
 
     virtual bool is_same_target(const DataOffloadingNode& other) const = 0;

--- a/sdfg/src/offloading/data_offloading_node.cpp
+++ b/sdfg/src/offloading/data_offloading_node.cpp
@@ -89,8 +89,18 @@ std::string DataOffloadingNode::toStr() const {
 
 symbolic::Expression DataOffloadingNode::flop() const { return symbolic::zero(); }
 
-bool DataOffloadingNode::redundant_with(const DataOffloadingNode& other) const {
+bool DataOffloadingNode::is_compatible_with(const DataOffloadingNode& other) const {
     if (code() != other.code()) {
+        return false;
+    }
+    if (!symbolic::null_safe_eq(size(), other.size())) {
+        return false;
+    }
+    return true;
+}
+
+bool DataOffloadingNode::redundant_with(const DataOffloadingNode& other) const {
+    if (!is_compatible_with(other)) {
         return false;
     }
     if ((static_cast<int8_t>(transfer_direction()) + static_cast<int8_t>(other.transfer_direction())) != 0) {
@@ -100,25 +110,17 @@ bool DataOffloadingNode::redundant_with(const DataOffloadingNode& other) const {
         return false;
     }
 
-    if (!symbolic::null_safe_eq(size(), other.size())) {
-        return false;
-    }
-
     return true; // add more checks in sub-classes
 }
 
 bool DataOffloadingNode::equal_with(const DataOffloadingNode& other) const {
-    if (code() != other.code()) {
+    if (!is_compatible_with(other)) {
         return false;
     }
     if (this->transfer_direction() != other.transfer_direction()) {
         return false;
     }
     if (this->buffer_lifecycle() != other.buffer_lifecycle()) {
-        return false;
-    }
-
-    if (!symbolic::null_safe_eq(size(), other.size())) {
         return false;
     }
 

--- a/sdfg/src/passes/dataflow/dead_data_elimination.cpp
+++ b/sdfg/src/passes/dataflow/dead_data_elimination.cpp
@@ -254,6 +254,10 @@ bool MemoryOwnershipAnalysis::visit(sdfg::structured_control_flow::Block& node) 
                 auto* access_node = dynamic_cast<data_flow::AccessNode*>(&oedge.dst());
                 if (access_node && oedge.is_dst_write()) {
                     auto container = access_node->data();
+                    if (!sdfg_.is_transient(container)) {
+                        // was never ours to begin with, even if weird that we run malloc on it
+                        continue;
+                    }
                     auto it = originally_owned_data_.find(container);
                     if (it != originally_owned_data_.end()) {
                         auto& area = it->second;

--- a/sdfg/src/passes/dataflow/dead_data_elimination.cpp
+++ b/sdfg/src/passes/dataflow/dead_data_elimination.cpp
@@ -254,7 +254,7 @@ bool MemoryOwnershipAnalysis::visit(sdfg::structured_control_flow::Block& node) 
                 auto* access_node = dynamic_cast<data_flow::AccessNode*>(&oedge.dst());
                 if (access_node && oedge.is_dst_write()) {
                     auto container = access_node->data();
-                    if (!sdfg_.is_transient(container)) {
+                    if (sdfg_.is_external(container)) {
                         // was never ours to begin with, even if weird that we run malloc on it
                         continue;
                     }
@@ -447,7 +447,9 @@ bool DeadDataElimination::run_pass(builder::StructuredSDFGBuilder& builder, anal
                     auto& area = ownership_analysis.owned_area(owned_area_id);
                     area.remove_from(builder);
                     applied = true;
-                    dead_containers.insert(owned_area_id);
+                    if (sdfg.is_transient(owned_area_id)) {
+                        dead_containers.insert(owned_area_id);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Offloading can determine that the data remains unchanged and will never even generate a matching D2H. Those could not be removed against further H2D transfers using the same, as-of-yet unchanged input.

 + DataOffloadingNode.is_compatible_with (the part of redundant_with & equal_with that does not look at transfer direction & buffer lifecycle)
 + DataTransferMinimizationAnalysis will now track on-device lifetimes as well
 + on-device matches (H2D->D2H) can be used to reconstruct the missing data and detect read-only on-device data that can be reused as if there was a D2H
 + DataTransferMinimizationPass can delete copy-outs if they have nothing left to do
 ~ also includes fix for DDE: tried to remove arg-containers and did not consider external containers as escape.