### PR TITLE
OffloadTransfers: leave all D2H transfers

### DIFF
--- a/opt/include/sdfg/analysis/data_transfer_elimination_analysis.h
+++ b/opt/include/sdfg/analysis/data_transfer_elimination_analysis.h
@@ -50,7 +50,8 @@ struct OffloadHolder {
           dev_data(nullptr), starts_dev_lifetime(false), ends_dev_lifetime(false), updates_on_dev(false),
           updates_on_host(false) {}
 
-    void remove_host_side();
+    void remove_h2d_parts();
+    void remove_d2h_parts();
 };
 
 struct ExposedOffload {
@@ -63,14 +64,19 @@ class DataTransferEliminationCandidateCollector {
 protected:
     std::vector<std::pair<ExposedOffload, OffloadHolder&>> transfer_reuse_candidates_;
     std::vector<std::pair<ExposedOffload, OffloadHolder&>> empty_malloc_candidates_;
+    std::vector<std::pair<ExposedOffload, OffloadHolder&>> redundant_d2h_candidates_;
 
 public:
     void found_transfer_reuse_pair(const ExposedOffload& src, OffloadHolder& dst) {
         transfer_reuse_candidates_.emplace_back(src, dst);
     }
 
-    void found_empty_host_malloc(const ExposedOffload malloc, OffloadHolder& h2d_transfer) {
+    void found_empty_host_malloc(const ExposedOffload& malloc, OffloadHolder& h2d_transfer) {
         empty_malloc_candidates_.emplace_back(malloc, h2d_transfer);
+    }
+
+    void found_redundant_d2h_pair(const ExposedOffload& h2d, OffloadHolder& d2h) {
+        redundant_d2h_candidates_.emplace_back(h2d, d2h);
     }
 
     const std::vector<std::pair<ExposedOffload, OffloadHolder&>>& transfer_reuse_candidates() const {
@@ -78,6 +84,9 @@ public:
     }
     const std::vector<std::pair<ExposedOffload, OffloadHolder&>>& empty_malloc_candidates() const {
         return empty_malloc_candidates_;
+    }
+    const std::vector<std::pair<ExposedOffload, OffloadHolder&>>& redundant_d2h_candidates() const {
+        return redundant_d2h_candidates_;
     }
 };
 
@@ -109,7 +118,10 @@ protected:
         // the killing node is a H2D with alloc that is the first use of host malloc. Can elide H2D
         EmptyHostMalloc,
         // the killing node is a device free of a device alloc of clean data -> can treat it similar to D2H
-        DeviceFree
+        DeviceCleanFree,
+        // the killing node is a D2H matching a H2D, but the on-device data has not changed in between: the host data is
+        // already up-to-date
+        RedundantD2H
     };
 
 public:

--- a/opt/include/sdfg/passes/offloading/data_transfer_minimization_pass.h
+++ b/opt/include/sdfg/passes/offloading/data_transfer_minimization_pass.h
@@ -40,6 +40,9 @@ protected:
         analysis::OffloadHolder& malloc_holder,
         analysis::OffloadHolder& copy_in
     );
+    bool eliminate_redundant_d2h(
+        builder::StructuredSDFGBuilder& builder, analysis::OffloadHolder& h2d, analysis::OffloadHolder& d2h
+    );
 };
 
 class DataTransferMinimizationLegacy : public visitor::NonStoppingStructuredSDFGVisitor {

--- a/opt/src/analysis/data_transfer_elimination_analysis.cpp
+++ b/opt/src/analysis/data_transfer_elimination_analysis.cpp
@@ -6,9 +6,16 @@
 
 namespace sdfg::analysis {
 
-void OffloadHolder::remove_host_side() {
+void OffloadHolder::remove_h2d_parts() {
     host_data = nullptr;
     host_access = nullptr;
+    updates_on_dev = false;
+}
+
+void OffloadHolder::remove_d2h_parts() {
+    host_data = nullptr;
+    host_access = nullptr;
+    updates_on_host = false;
 }
 
 OffloadState::OffloadState(DataTransferEliminationCandidateCollector& collector) : collector_(collector) {}
@@ -78,9 +85,17 @@ std::pair<OffloadState::KillingType, OffloadHolder*> OffloadState::find_killing_
 
             if (dev_ptr_matches) {
                 // D_ALLOC -> D_FREE is the expected case, but kill for any match
-                bool is_elim_candidate = holder.offload_node->is_compatible_with(*entry_holder.offload_node) &&
-                                         entry_holder.ends_dev_lifetime && !entry_holder.updates_on_host;
-                return {is_elim_candidate ? KillingType::DeviceFree : KillingType::Basic, &entry_holder};
+                KillingType killType = KillingType::Basic;
+                if (holder.offload_node->is_compatible_with(*entry_holder.offload_node) &&
+                    entry_holder.ends_dev_lifetime) {
+                    if (entry_holder.updates_on_host) {
+                        killType = KillingType::RedundantD2H;
+                    } else {
+                        killType = KillingType::DeviceCleanFree;
+                    }
+                }
+
+                return {killType, &entry_holder};
             }
         }
     }
@@ -247,7 +262,7 @@ void OffloadState::apply_kills_and_changes(ExposedType& exposed) const {
                 collector_.found_transfer_reuse_pair(exposedOffload, *killing_entry);
             } else if (kill_type == KillingType::EmptyHostMalloc) {
                 collector_.found_empty_host_malloc(exposedOffload, *killing_entry);
-            } else if (kill_type == KillingType::DeviceFree) {
+            } else if (kill_type == KillingType::DeviceCleanFree) {
                 // we have a on-device-alloc that survived without kills to the on-device-free
                 // -> promote this to a host-relevant D2H point, that might be reused
 
@@ -259,6 +274,8 @@ void OffloadState::apply_kills_and_changes(ExposedType& exposed) const {
                     it = exposed.erase(it);
                     continue;
                 }
+            } else if (kill_type == KillingType::RedundantD2H) {
+                collector_.found_redundant_d2h_pair(exposedOffload, *killing_entry);
             }
             it = exposed.erase(it);
             continue;

--- a/opt/src/passes/offloading/data_transfer_minimization_pass.cpp
+++ b/opt/src/passes/offloading/data_transfer_minimization_pass.cpp
@@ -46,10 +46,42 @@ bool DataTransferMinimizationPass::eliminate_malloc_first_transfer(
     auto* h2d_block = dynamic_cast<structured_control_flow::Block*>(copy_in.offload_node->get_parent().get_parent());
     builder.remove_memlet(*h2d_block, *copy_in.host_access);
     builder.remove_node(*h2d_block, *copy_in.host_data);
-    copy_in.remove_host_side();
+    copy_in.remove_h2d_parts();
     copy_in.offload_node->remove_h2d();
 
     return true;
+}
+
+bool DataTransferMinimizationPass::eliminate_redundant_d2h(
+    builder::StructuredSDFGBuilder& builder, analysis::OffloadHolder& h2d, analysis::OffloadHolder& d2h
+) {
+    // Get all relevant information
+    std::string copy_out_device_container = d2h.dev_data->data();
+    DebugInfo copy_out_dst_debinfo = d2h.dev_data->debug_info();
+
+    // leave the malloc itself, because we have not proven yet that there is no more d2H transfer that needs it
+    // DDE needs to be able to find it
+
+    auto* d2h_block = dynamic_cast<structured_control_flow::Block*>(d2h.offload_node->get_parent().get_parent());
+    if (d2h.offload_node->is_d2h()) {
+        if (d2h.offload_node->is_free()) {
+            std::string out_conn = d2h.host_access->src_conn();
+            auto access_type = d2h.host_access->base_type().clone();
+            builder.remove_memlet(*d2h_block, *d2h.host_access);
+            builder.remove_node(*d2h_block, *d2h.host_data);
+            d2h.offload_node->remove_d2h();
+            auto& free_write = builder.add_access(*d2h_block, copy_out_device_container, copy_out_dst_debinfo);
+            builder.add_computational_memlet(
+                *d2h_block, *d2h.offload_node, out_conn, free_write, {}, *access_type, copy_out_dst_debinfo
+            );
+        } else { // remove it entirely
+            builder.clear_code_node_legacy(*d2h_block, *d2h.offload_node);
+        }
+        d2h.remove_d2h_parts();
+        return true;
+    } else {
+        return false;
+    }
 }
 
 bool DataTransferMinimizationPass::eliminate_transfer_pair(
@@ -111,8 +143,7 @@ bool DataTransferMinimizationPass::
 
     int removed = 0;
 
-    auto& useless_mallocs = transfer_analysis.empty_malloc_candidates();
-    for (auto& [malloc_cand, first_h2d] : useless_mallocs) {
+    for (auto& [malloc_cand, first_h2d] : transfer_analysis.empty_malloc_candidates()) {
         auto& malloc_holder = *malloc_cand.offload;
 
         DEBUG_PRINTLN(
@@ -130,25 +161,37 @@ bool DataTransferMinimizationPass::
         }
     }
 
-    auto& transfer_reuse_candidates = transfer_analysis.transfer_reuse_candidates();
+    for (auto& [h2d_cand, redundant_d2h] : transfer_analysis.redundant_d2h_candidates()) {
+        auto& h2d_holder = *h2d_cand.offload;
 
-    for (auto& candidate : transfer_reuse_candidates) {
+        if (h2d_holder.updates_on_dev) {
+            DEBUG_PRINTLN(
+                "  Elim h2d: " << "#" << h2d_holder.offload_node->element_id() << " -> " << h2d_holder.host_data->data()
+                               << " -> " << h2d_holder.dev_data->data() << " / "
+                               << "clean d2h: #" << redundant_d2h.offload_node->element_id() << " "
+                               << redundant_d2h.dev_data->data() << " -> " << redundant_d2h.host_data->data()
+            );
+            bool success = eliminate_redundant_d2h(builder, h2d_holder, redundant_d2h);
+
+            if (success) {
+                ++removed;
+            }
+        }
+    }
+
+    for (auto& candidate : transfer_analysis.transfer_reuse_candidates()) {
         auto reads = candidate.first.read_count;
         auto& copy_out = *candidate.first.offload;
         auto& copy_in = candidate.second;
         auto& copy_in_container = copy_in.host_data->data();
 
-#ifndef NDEBUG
-        std::cerr << "  Elim transfer "
-                  << "copy-out: #" << copy_out.offload_node->element_id() << " " << copy_out.dev_data->data() << " -> "
-                  << (copy_out.host_data ? copy_out.host_data->data() : "-") << " / ";
-        if (reads) {
-            std::cerr << reads << " reads / ";
-        }
-        std::cerr << "copy-in: #" << copy_in.offload_node->element_id() << " "
-                  << (copy_in.host_data ? copy_in.host_data->data() : "-") << " -> " << copy_in.dev_data->data()
-                  << std::endl;
-#endif
+        DEBUG_PRINTLN(
+            "  Elim hd2: #" << copy_out.offload_node->element_id() << " " << copy_out.dev_data->data() << " -> "
+                            << (copy_out.host_data ? copy_out.host_data->data() : "-") << " / "
+                            << "d2h: #" << copy_in.offload_node->element_id() << " "
+                            << (copy_in.host_data ? copy_in.host_data->data() : "-") << " -> "
+                            << copy_in.dev_data->data()
+        );
 
         bool success = eliminate_transfer_pair(builder, copy_out, copy_in, false);
 

--- a/opt/src/passes/offloading/data_transfer_minimization_pass.cpp
+++ b/opt/src/passes/offloading/data_transfer_minimization_pass.cpp
@@ -131,28 +131,12 @@ bool DataTransferMinimizationPass::
     }
 
     auto& transfer_reuse_candidates = transfer_analysis.transfer_reuse_candidates();
-    auto& users = analysis_manager.get<analysis::Users>();
 
     for (auto& candidate : transfer_reuse_candidates) {
         auto reads = candidate.first.read_count;
         auto& copy_out = *candidate.first.offload;
         auto& copy_in = candidate.second;
         auto& copy_in_container = copy_in.host_data->data();
-
-        // copy from legacy version as hack: checking for users after the copy_in container (because current analysis
-        // stops looking at that point)
-        // TODO unsafe: this does not cover all ways that still need the data on host. Safe is: only manage device-side
-        // things here and let dead-data find the unused host stuff
-        auto* read = users.get_user(
-            copy_in.host_data->data(), const_cast<data_flow::AccessNode*>(copy_in.host_data), analysis::Use::READ
-        );
-
-        for (auto* after_use : users.all_uses_after(*read)) {
-            if (after_use->container() == copy_in_container && after_use->use() == analysis::Use::READ &&
-                after_use != read) {
-                ++reads;
-            }
-        }
 
 #ifndef NDEBUG
         std::cerr << "  Elim transfer "
@@ -166,7 +150,7 @@ bool DataTransferMinimizationPass::
                   << std::endl;
 #endif
 
-        bool success = eliminate_transfer_pair(builder, copy_out, copy_in, reads == 0);
+        bool success = eliminate_transfer_pair(builder, copy_out, copy_in, false);
 
         if (success) {
             ++removed;

--- a/opt/tests/passes/offloading/data_transfer_minimization_pass_test.cpp
+++ b/opt/tests/passes/offloading/data_transfer_minimization_pass_test.cpp
@@ -67,12 +67,12 @@ TEST(DataTransferMinimizationPassTest, MultiMapTest) {
     builder.add_container("A", desc, true);
     builder.add_container("__daisy_offload_A", desc);
 
-    auto& block = builder.add_block(root);
-    auto& access_node_in = builder.add_access(block, "__daisy_offload_A");
-    auto& access_node_out = builder.add_access(block, "A");
+    auto& block_d2h = builder.add_block(root);
+    auto& access_node_in = builder.add_access(block_d2h, "__daisy_offload_A");
+    auto& access_node_out = builder.add_access(block_d2h, "A");
 
-    auto& memcpy_node = builder.add_library_node<cuda::CUDADataOffloadingNode>(
-        block,
+    auto& memcpy_d2h = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_d2h,
         DebugInfo(),
         symbolic::integer(400),
         symbolic::integer(0),
@@ -81,18 +81,18 @@ TEST(DataTransferMinimizationPassTest, MultiMapTest) {
     );
 
     auto& in_type = builder.subject().type("A");
-    builder.add_computational_memlet(block, access_node_in, memcpy_node, "_src", {}, in_type);
+    builder.add_computational_memlet(block_d2h, access_node_in, memcpy_d2h, "_src", {}, in_type);
 
     auto& out_type = builder.subject().type("A");
-    builder.add_computational_memlet(block, memcpy_node, "_dst", access_node_out, {}, out_type);
+    builder.add_computational_memlet(block_d2h, memcpy_d2h, "_dst", access_node_out, {}, out_type);
 
-    auto& block2 = builder.add_block(root);
+    auto& block_h2d = builder.add_block(root);
 
-    auto& access_node_in2 = builder.add_access(block2, "A");
-    auto& access_node_out2 = builder.add_access(block2, "__daisy_offload_A");
+    auto& access_node_in2 = builder.add_access(block_h2d, "A");
+    auto& access_node_out2 = builder.add_access(block_h2d, "__daisy_offload_A");
 
-    auto& memcpy_node2 = builder.add_library_node<cuda::CUDADataOffloadingNode>(
-        block2,
+    auto& memcpy_h2d = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_h2d,
         DebugInfo(),
         symbolic::integer(400),
         symbolic::integer(0),
@@ -101,10 +101,10 @@ TEST(DataTransferMinimizationPassTest, MultiMapTest) {
     );
 
     auto& in_type2 = builder.subject().type("A");
-    builder.add_computational_memlet(block2, access_node_in2, memcpy_node2, "_src", {}, in_type2);
+    builder.add_computational_memlet(block_h2d, access_node_in2, memcpy_h2d, "_src", {}, in_type2);
 
     auto& out_type2 = builder.subject().type("A");
-    builder.add_computational_memlet(block2, memcpy_node2, "_dst", access_node_out2, {}, out_type2);
+    builder.add_computational_memlet(block_h2d, memcpy_h2d, "_dst", access_node_out2, {}, out_type2);
 
     dump_sdfg(builder.subject(), "0-before");
 
@@ -113,8 +113,16 @@ TEST(DataTransferMinimizationPassTest, MultiMapTest) {
 
     dump_sdfg(builder.subject(), "1-after");
 
-    EXPECT_EQ(block.dataflow().nodes().size(), 0);
-    EXPECT_EQ(block2.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_d2h.dataflow().nodes().size(), 3);
+    EXPECT_EQ(
+        dynamic_cast<const cuda::CUDADataOffloadingNode&>(memcpy_d2h).transfer_direction(),
+        offloading::DataTransferDirection::D2H
+    );
+    EXPECT_EQ(
+        dynamic_cast<const cuda::CUDADataOffloadingNode&>(memcpy_d2h).buffer_lifecycle(),
+        offloading::BufferLifecycle::NO_CHANGE
+    );
+    EXPECT_EQ(block_h2d.dataflow().nodes().size(), 0);
 };
 
 TEST(DataTransferMinimizationPassTest, MultiMapWithLatterUseTest) {
@@ -466,22 +474,14 @@ TEST(DataTransferMinimizationPassTest, ReadOnlyDataReuseTest) {
         dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_h2d).buffer_lifecycle(),
         offloading::BufferLifecycle::ALLOC
     );
-    EXPECT_EQ(block_d2h.dataflow().nodes().size(), 3);
-    EXPECT_EQ(
-        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_d2h).transfer_direction(),
-        offloading::DataTransferDirection::D2H
-    );
-    EXPECT_EQ(
-        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_d2h).buffer_lifecycle(),
-        offloading::BufferLifecycle::NO_CHANGE
-    );
+    EXPECT_EQ(block_d2h.dataflow().nodes().size(), 0);
     EXPECT_EQ(block_h2d_reuse.dataflow().nodes().size(), 0);
     EXPECT_EQ(block_d2h_reuse.dataflow().nodes().size(), 0);
     EXPECT_EQ(block_h2d_reuse2.dataflow().nodes().size(), 0);
     EXPECT_EQ(block_d2h_reuse2.dataflow().nodes().size(), 3);
     EXPECT_EQ(
         dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse2_d2h).transfer_direction(),
-        offloading::DataTransferDirection::D2H
+        offloading::DataTransferDirection::NONE
     );
     EXPECT_EQ(
         dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse2_d2h).buffer_lifecycle(),
@@ -502,22 +502,14 @@ TEST(DataTransferMinimizationPassTest, ReadOnlyDataReuseTest) {
         dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_h2d).buffer_lifecycle(),
         offloading::BufferLifecycle::ALLOC
     );
-    EXPECT_EQ(block_d2h.dataflow().nodes().size(), 3);
-    EXPECT_EQ(
-        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_d2h).transfer_direction(),
-        offloading::DataTransferDirection::D2H
-    );
-    EXPECT_EQ(
-        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_d2h).buffer_lifecycle(),
-        offloading::BufferLifecycle::NO_CHANGE
-    );
+    EXPECT_EQ(block_d2h.dataflow().nodes().size(), 0);
     EXPECT_EQ(block_h2d_reuse.dataflow().nodes().size(), 0);
     EXPECT_EQ(block_d2h_reuse.dataflow().nodes().size(), 0);
     EXPECT_EQ(block_h2d_reuse2.dataflow().nodes().size(), 0);
     EXPECT_EQ(block_d2h_reuse2.dataflow().nodes().size(), 3);
     EXPECT_EQ(
         dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse2_d2h).transfer_direction(),
-        offloading::DataTransferDirection::D2H
+        offloading::DataTransferDirection::NONE
     );
     EXPECT_EQ(
         dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse2_d2h).buffer_lifecycle(),
@@ -706,7 +698,7 @@ TEST(DataTransferMinimizationPassTest, ReadOnlyDataPureDeviceTest) {
     EXPECT_EQ(block_d2h_reuse2.dataflow().nodes().size(), 3);
     EXPECT_EQ(
         dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse2_d2h).transfer_direction(),
-        offloading::DataTransferDirection::D2H
+        offloading::DataTransferDirection::NONE
     );
     EXPECT_EQ(
         dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse2_d2h).buffer_lifecycle(),
@@ -731,7 +723,7 @@ TEST(DataTransferMinimizationPassTest, ReadOnlyDataPureDeviceTest) {
     EXPECT_EQ(block_h2d_reuse.dataflow().nodes().size(), 0);
     EXPECT_EQ(block_d2h_reuse.dataflow().nodes().size(), 0);
     EXPECT_EQ(block_h2d_reuse2.dataflow().nodes().size(), 0);
-    EXPECT_EQ(block_d2h_reuse2.dataflow().nodes().size(), 2);
+    EXPECT_EQ(block_d2h_reuse2.dataflow().nodes().size(), 3);
     EXPECT_EQ(
         dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse2_d2h).transfer_direction(),
         offloading::DataTransferDirection::NONE
@@ -919,11 +911,149 @@ TEST(DataTransferMinimizationPassTest, NotReadOnlyDataReuseTest) {
     EXPECT_EQ(block_d2h_reuse.dataflow().nodes().size(), 3);
     EXPECT_EQ(
         dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse_d2h).transfer_direction(),
-        offloading::DataTransferDirection::D2H
+        offloading::DataTransferDirection::NONE
     );
     EXPECT_EQ(
         dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_node_reuse_d2h).buffer_lifecycle(),
         offloading::BufferLifecycle::FREE
     );
     EXPECT_EQ(block_free.dataflow().nodes().size(), 3);
+};
+
+TEST(DataTransferMinimizationPassTest, RemoveRedundantD2HTest) {
+    sdfg::builder::StructuredSDFGBuilder builder("dot", sdfg::FunctionType_CPU);
+    sdfg::analysis::AnalysisManager analysis_manager(builder.subject());
+
+    auto& root = builder.subject().root();
+
+    // Add containers
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    builder.add_container("A", desc, true);
+    builder.add_container("__daisy_offload_A", desc);
+    builder.add_container("i", types::Scalar(types::PrimitiveType::Int32));
+    auto indvar = symbolic::symbol("i");
+
+    auto device_id = symbolic::integer(0);
+    auto arr_size = symbolic::integer(400);
+
+    // --- H2D initial
+
+    auto& block_h2d = builder.add_block(root);
+
+    auto& access_in_h2d = builder.add_access(block_h2d, "A");
+    auto& access_out_h2d = builder.add_access(block_h2d, "__daisy_offload_A");
+
+    auto& memcpy_h2d = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_h2d,
+        DebugInfo(),
+        arr_size,
+        device_id,
+        offloading::DataTransferDirection::H2D,
+        offloading::BufferLifecycle::ALLOC
+    );
+
+    builder.add_computational_memlet(block_h2d, access_in_h2d, memcpy_h2d, "_src", {}, desc);
+    builder.add_computational_memlet(block_h2d, memcpy_h2d, "_dst", access_out_h2d, {}, desc);
+
+    // --- D2H initial
+
+    auto& block_d2h = builder.add_block(root);
+    auto& access_in_d2h = builder.add_access(block_d2h, "__daisy_offload_A");
+    auto& access_out_d2h = builder.add_access(block_d2h, "A");
+
+    auto& memcpy_d2h = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_d2h,
+        DebugInfo(),
+        arr_size,
+        device_id,
+        offloading::DataTransferDirection::D2H,
+        offloading::BufferLifecycle::FREE
+    );
+
+    builder.add_computational_memlet(block_d2h, access_in_d2h, memcpy_d2h, "_src", {}, desc);
+    builder.add_computational_memlet(block_d2h, memcpy_d2h, "_dst", access_out_d2h, {}, desc);
+
+    // --- H2D reuse
+
+    auto& block_h2d_reuse = builder.add_block(root);
+
+    auto& access_in_h2d_reuse = builder.add_access(block_h2d_reuse, "A");
+    auto& access_out_h2d_reuse = builder.add_access(block_h2d_reuse, "__daisy_offload_A");
+
+    auto& memcpy_h2d_reuse = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_h2d_reuse,
+        DebugInfo(),
+        arr_size,
+        device_id,
+        offloading::DataTransferDirection::H2D,
+        offloading::BufferLifecycle::ALLOC
+    );
+
+    builder.add_computational_memlet(block_h2d_reuse, access_in_h2d_reuse, memcpy_h2d_reuse, "_src", {}, desc);
+    builder.add_computational_memlet(block_h2d_reuse, memcpy_h2d_reuse, "_dst", access_out_h2d_reuse, {}, desc);
+
+    // --- modify on device loop
+    auto& map_modify = builder.add_map(
+        root,
+        indvar,
+        symbolic::Lt(indvar, arr_size),
+        symbolic::zero(),
+        symbolic::add(indvar, symbolic::one()),
+        cuda::ScheduleType_CUDA::create()
+    );
+    auto& block_modify = builder.add_block(map_modify.root());
+
+    auto& access_modify_in = builder.add_access(block_modify, "__daisy_offload_A");
+    auto& const_1 = builder.add_constant(block_modify, "1.0", base_desc);
+    auto& access_modify_out = builder.add_access(block_modify, "__daisy_offload_A");
+    auto& modify_add = builder.add_tasklet(block_modify, data_flow::fp_add, "out", {"a", "b"}, {});
+    builder.add_computational_memlet(block_modify, access_modify_in, modify_add, "a", {indvar}, desc);
+    builder.add_computational_memlet(block_modify, const_1, modify_add, "b", {}, base_desc);
+    builder.add_computational_memlet(block_modify, modify_add, "out", access_modify_out, {indvar}, desc);
+
+    // --- D2H reuse
+
+    auto& block_d2h_reuse = builder.add_block(root);
+    auto& access_in_d2h_reuse = builder.add_access(block_d2h_reuse, "__daisy_offload_A");
+    auto& access_out_d2h_reuse = builder.add_access(block_d2h_reuse, "A");
+
+    auto& memcpy_d2h_reuse = builder.add_library_node<cuda::CUDADataOffloadingNode>(
+        block_d2h_reuse,
+        DebugInfo(),
+        arr_size,
+        device_id,
+        offloading::DataTransferDirection::D2H,
+        offloading::BufferLifecycle::FREE
+    );
+
+    builder.add_computational_memlet(block_d2h_reuse, access_in_d2h_reuse, memcpy_d2h_reuse, "_src", {}, desc);
+    builder.add_computational_memlet(block_d2h_reuse, memcpy_d2h_reuse, "_dst", access_out_d2h_reuse, {}, desc);
+
+    dump_sdfg(builder.subject(), "0-before");
+
+    passes::DataTransferMinimizationPass pass;
+    EXPECT_TRUE(pass.run(builder, analysis_manager));
+
+    dump_sdfg(builder.subject(), "1-after");
+
+    EXPECT_EQ(block_h2d.dataflow().nodes().size(), 3);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_h2d).transfer_direction(),
+        offloading::DataTransferDirection::H2D
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_h2d).buffer_lifecycle(), offloading::BufferLifecycle::ALLOC
+    );
+    EXPECT_EQ(block_d2h.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_h2d_reuse.dataflow().nodes().size(), 0);
+    EXPECT_EQ(block_d2h_reuse.dataflow().nodes().size(), 3);
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_d2h_reuse).transfer_direction(),
+        offloading::DataTransferDirection::D2H
+    );
+    EXPECT_EQ(
+        dynamic_cast<cuda::CUDADataOffloadingNode&>(memcpy_d2h_reuse).buffer_lifecycle(),
+        offloading::BufferLifecycle::FREE
+    );
 };

--- a/sdfg/include/sdfg/targets/offloading/data_offloading_node.h
+++ b/sdfg/include/sdfg/targets/offloading/data_offloading_node.h
@@ -108,6 +108,7 @@ public:
     void remove_free();
 
     void remove_h2d();
+    void remove_d2h();
 
     data_flow::PointerAccessType pointer_access_type(int input_idx) const override;
 

--- a/sdfg/src/offloading/data_offloading_node.cpp
+++ b/sdfg/src/offloading/data_offloading_node.cpp
@@ -165,6 +165,15 @@ void DataOffloadingNode::remove_free() {
     }
 }
 
+void DataOffloadingNode::remove_d2h() {
+    if (this->is_d2h()) {
+        if (!this->is_free()) {
+            throw InvalidSDFGException("DataOffloadingNode: Tried removing d2h but node has no other purpose");
+        }
+        this->transfer_direction_ = DataTransferDirection::NONE;
+    }
+}
+
 data_flow::EdgeRemoveOption DataOffloadingNode::
     can_remove_out_edge(const data_flow::DataFlowGraph& graph, const data_flow::Memlet* memlet) const {
     if (graph.out_edges_for_connector(*this, memlet->src_conn()).size() > 1) {


### PR DESCRIPTION
Now that DDE is smart enough, it will clean up those D2H transfers, providing better separation of concerns.
UserAnalysis in TransferMinimization was a major contributor to runtime, while providing very little input.

Extended DataTransferMin to use its clean-on-device data information to remove unneeded D2H transfers, when the data was from the host and has not changed on device.