### PR TITLE
Make *LocalStorage* transformations interfaces compatible with Transer Tuning

### DIFF
--- a/opt/include/sdfg/transformations/accumulator_tile.h
+++ b/opt/include/sdfg/transformations/accumulator_tile.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "sdfg/data_flow/access_node.h"
 #include "sdfg/data_flow/memlet.h"
 #include "sdfg/structured_control_flow/sequence.h"
 #include "sdfg/transformations/transformation.h"
@@ -67,6 +68,7 @@ public:
 
 private:
     structured_control_flow::StructuredLoop& loop_;
+    const data_flow::AccessNode& access_node_;
     std::string container_;
     std::string local_name_; ///< Name of the created tile buffer
     TileInfo tile_info_; ///< Populated by can_be_applied
@@ -75,9 +77,9 @@ public:
     /**
      * @brief Construct an accumulator tile transformation
      * @param loop The outer loop defining the tile scope
-     * @param container Name of the container to tile
+     * @param access_node The access node referencing the container to tile
      */
-    AccumulatorTile(structured_control_flow::StructuredLoop& loop, std::string container);
+    AccumulatorTile(structured_control_flow::StructuredLoop& loop, const data_flow::AccessNode& access_node);
 
     /**
      * @brief Get the name of this transformation

--- a/opt/include/sdfg/transformations/in_local_storage.h
+++ b/opt/include/sdfg/transformations/in_local_storage.h
@@ -70,6 +70,7 @@ public:
 
 private:
     structured_control_flow::StructuredLoop& loop_;
+    const data_flow::AccessNode& access_node_;
     std::string container_;
     std::string local_name_; ///< Name of the created local buffer
     AccessInfo access_info_; ///< Populated by can_be_applied
@@ -78,9 +79,9 @@ public:
     /**
      * @brief Construct an in-local storage transformation
      * @param loop The loop defining the scope for localization
-     * @param container Name of the container to localize
+     * @param access_node The access node referencing the container to localize
      */
-    InLocalStorage(structured_control_flow::StructuredLoop& loop, std::string container);
+    InLocalStorage(structured_control_flow::StructuredLoop& loop, const data_flow::AccessNode& access_node);
 
     /**
      * @brief Get the name of this transformation

--- a/opt/include/sdfg/transformations/offloading/gpu_tiling.h
+++ b/opt/include/sdfg/transformations/offloading/gpu_tiling.h
@@ -13,6 +13,7 @@ class GPUTiling : public Transformation {
 
     structured_control_flow::StructuredLoop* inner_loop_ = nullptr;
     structured_control_flow::StructuredLoop* outer_loop_ = nullptr;
+    std::set<std::string> target_accesses_;
 
 public:
     GPUTiling(structured_control_flow::StructuredLoop& loop, size_t size);

--- a/opt/include/sdfg/transformations/offloading/gpu_tiling.h
+++ b/opt/include/sdfg/transformations/offloading/gpu_tiling.h
@@ -13,7 +13,7 @@ class GPUTiling : public Transformation {
 
     structured_control_flow::StructuredLoop* inner_loop_ = nullptr;
     structured_control_flow::StructuredLoop* outer_loop_ = nullptr;
-    std::set<std::string> target_accesses_;
+    std::set<std::string> target_containers_;
 
 public:
     GPUTiling(structured_control_flow::StructuredLoop& loop, size_t size);

--- a/opt/include/sdfg/transformations/offloading/kernel_local_storage.h
+++ b/opt/include/sdfg/transformations/offloading/kernel_local_storage.h
@@ -13,11 +13,14 @@ class KernelLocalStorage : public Transformation {
 private:
     structured_control_flow::StructuredLoop& loop_;
     symbolic::Expression offset_;
+    const data_flow::AccessNode& access_node_;
     std::string container_;
 
 public:
     KernelLocalStorage(
-        structured_control_flow::StructuredLoop& loop, symbolic::Expression offset, const std::string& container
+        structured_control_flow::StructuredLoop& loop,
+        symbolic::Expression offset,
+        const data_flow::AccessNode& access_node
     );
 
     virtual std::string name() const override;

--- a/opt/include/sdfg/transformations/out_local_storage.h
+++ b/opt/include/sdfg/transformations/out_local_storage.h
@@ -22,15 +22,16 @@ class OutLocalStorage : public Transformation {
 private:
     structured_control_flow::StructuredLoop& loop_;
     std::string container_;
+    const data_flow::AccessNode& access_node_;
     bool requires_array_;
 
 public:
     /**
      * @brief Construct an out-of-loop storage transformation
      * @param loop The loop to optimize
-     * @param container The container name to optimize access for
+     * @param access_node The access node to optimize
      */
-    OutLocalStorage(structured_control_flow::StructuredLoop& loop, std::string container);
+    OutLocalStorage(structured_control_flow::StructuredLoop& loop, const data_flow::AccessNode& access_node);
 
     /**
      * @brief Get the name of this transformation

--- a/opt/src/passes/offloading/gpu_tiling_pass.cpp
+++ b/opt/src/passes/offloading/gpu_tiling_pass.cpp
@@ -36,8 +36,14 @@ bool GPUTilingPass::run_pass(builder::StructuredSDFGBuilder& builder, analysis::
             // Pre-filter: check if any container used in the loop is a KLS candidate
             analysis::UsersView users_view(users, struc_loop->root());
             bool has_kls_candidate = false;
-            for (const auto& container : users_view.all_containers_in_order()) {
-                if (transformations::KernelLocalStorage::is_candidate(*struc_loop, container, builder, analysis_manager)) {
+            for (auto& use : users_view.reads()) {
+                auto element = use->element();
+                if (!dynamic_cast<data_flow::AccessNode*>(element)) {
+                    continue;
+                }
+                auto access_node = dynamic_cast<data_flow::AccessNode*>(element);
+                if (transformations::KernelLocalStorage::
+                        is_candidate(*struc_loop, access_node->data(), builder, analysis_manager)) {
                     has_kls_candidate = true;
                     break;
                 }

--- a/opt/src/transformations/accumulator_tile.cpp
+++ b/opt/src/transformations/accumulator_tile.cpp
@@ -24,8 +24,8 @@
 namespace sdfg {
 namespace transformations {
 
-AccumulatorTile::AccumulatorTile(structured_control_flow::StructuredLoop& loop, std::string container)
-    : loop_(loop), container_(container) {}
+AccumulatorTile::AccumulatorTile(structured_control_flow::StructuredLoop& loop, const data_flow::AccessNode& access_node)
+    : loop_(loop), access_node_(access_node), container_(access_node.data()) {}
 
 std::string AccumulatorTile::name() const { return "AccumulatorTile"; }
 
@@ -409,14 +409,15 @@ void AccumulatorTile::to_json(nlohmann::json& j) const {
     } else {
         throw std::runtime_error("Unsupported loop type for serialization");
     }
-    j["subgraph"] = {{"0", {{"element_id", this->loop_.element_id()}, {"type", loop_type}}}};
+    j["subgraph"] = {
+        {"0", {{"element_id", this->loop_.element_id()}, {"type", loop_type}}},
+        {"1", {{"element_id", this->access_node_.element_id()}, {"type", "access_node"}}}
+    };
     j["transformation_type"] = this->name();
-    j["container"] = container_;
 }
 
 AccumulatorTile AccumulatorTile::from_json(builder::StructuredSDFGBuilder& builder, const nlohmann::json& desc) {
     auto loop_id = desc["subgraph"]["0"]["element_id"].get<size_t>();
-    std::string container = desc["container"].get<std::string>();
     auto element = builder.find_element_by_id(loop_id);
     if (!element) {
         throw InvalidTransformationDescriptionException("Element with ID " + std::to_string(loop_id) + " not found.");
@@ -425,7 +426,17 @@ AccumulatorTile AccumulatorTile::from_json(builder::StructuredSDFGBuilder& build
     if (!loop) {
         throw InvalidTransformationDescriptionException("Element with ID " + std::to_string(loop_id) + " is not a loop.");
     }
-    return AccumulatorTile(*loop, container);
+
+    auto access_node = dynamic_cast<
+        data_flow::AccessNode*>(builder.find_element_by_id(desc.at("subgraph").at("1").at("element_id").get<size_t>()));
+    if (!access_node) {
+        throw InvalidTransformationDescriptionException(
+            "Access node with ID " + std::to_string(desc.at("subgraph").at("1").at("element_id").get<size_t>()) +
+            " not found."
+        );
+    }
+
+    return AccumulatorTile(*loop, *access_node);
 }
 
 } // namespace transformations

--- a/opt/src/transformations/in_local_storage.cpp
+++ b/opt/src/transformations/in_local_storage.cpp
@@ -24,8 +24,8 @@
 namespace sdfg {
 namespace transformations {
 
-InLocalStorage::InLocalStorage(structured_control_flow::StructuredLoop& loop, std::string container)
-    : loop_(loop), container_(std::move(container)) {}
+InLocalStorage::InLocalStorage(structured_control_flow::StructuredLoop& loop, const data_flow::AccessNode& access_node)
+    : loop_(loop), access_node_(access_node), container_(access_node.data()) {}
 
 std::string InLocalStorage::name() const { return "InLocalStorage"; }
 
@@ -359,14 +359,16 @@ void InLocalStorage::to_json(nlohmann::json& j) const {
     } else {
         throw std::runtime_error("Unsupported loop type for serialization of loop: " + loop_.indvar()->get_name());
     }
-    j["subgraph"] = {{"0", {{"element_id", this->loop_.element_id()}, {"type", loop_type}}}};
+    j["subgraph"] = {
+        {"0", {{"element_id", this->loop_.element_id()}, {"type", loop_type}}},
+        {"1", {{"element_id", this->access_node_.element_id()}, {"type", "access_node"}}}
+    };
     j["transformation_type"] = this->name();
     j["container"] = container_;
 }
 
 InLocalStorage InLocalStorage::from_json(builder::StructuredSDFGBuilder& builder, const nlohmann::json& desc) {
     auto loop_id = desc["subgraph"]["0"]["element_id"].get<size_t>();
-    std::string container = desc["container"].get<std::string>();
     auto element = builder.find_element_by_id(loop_id);
     if (!element) {
         throw InvalidTransformationDescriptionException("Element with ID " + std::to_string(loop_id) + " not found.");
@@ -378,7 +380,16 @@ InLocalStorage InLocalStorage::from_json(builder::StructuredSDFGBuilder& builder
         );
     }
 
-    return InLocalStorage(*loop, container);
+    auto access_node = dynamic_cast<
+        data_flow::AccessNode*>(builder.find_element_by_id(desc.at("subgraph").at("1").at("element_id").get<size_t>()));
+    if (!access_node) {
+        throw InvalidTransformationDescriptionException(
+            "Access node with ID " + std::to_string(desc.at("subgraph").at("1").at("element_id").get<size_t>()) +
+            " not found."
+        );
+    }
+
+    return InLocalStorage(*loop, *access_node);
 }
 
 } // namespace transformations

--- a/opt/src/transformations/offloading/gpu_tiling.cpp
+++ b/opt/src/transformations/offloading/gpu_tiling.cpp
@@ -1,5 +1,4 @@
 #include "sdfg/transformations/offloading/gpu_tiling.h"
-#include <iostream>
 #include <set>
 
 #include "sdfg/analysis/analysis.h"
@@ -70,10 +69,10 @@ bool GPUTiling::can_be_applied(builder::StructuredSDFGBuilder& builder, analysis
     for (auto& access : read_accesses) {
         KernelLocalStorage kls(*inner_loop, outer_loop->indvar(), *access);
         if (kls.can_be_applied(builder_local, analysis_manager_local)) {
-            target_accesses_.insert(access->data());
+            target_containers_.insert(access->data());
         }
     }
-    if (target_accesses_.empty()) {
+    if (target_containers_.empty()) {
         return false;
     }
 
@@ -88,7 +87,7 @@ void GPUTiling::apply(builder::StructuredSDFGBuilder& builder, analysis::Analysi
 
     analysis::UsersView users_view(analysis_manager.get<analysis::Users>(), inner_loop->root());
 
-    for (const auto& container_name : target_accesses_) {
+    for (const auto& container_name : target_containers_) {
         auto& users = analysis_manager.get<analysis::Users>();
         analysis::UsersView users_view(users, inner_loop->root());
 
@@ -114,23 +113,17 @@ void GPUTiling::apply(builder::StructuredSDFGBuilder& builder, analysis::Analysi
     auto& users = analysis_manager.get<analysis::Users>();
     analysis::UsersView users_view_inner_loop(users, inner_loop->root());
 
-    std::set<data_flow::AccessNode*> target_containers;
-    std::set<data_flow::AccessNode*> write_accesses;
-    for (auto& write : users_view_inner_loop.writes()) {
+    analysis::TypeAnalysis type_analysis(builder.subject(), inner_loop, analysis_manager);
+    for (const auto& write : users_view_inner_loop.writes()) {
         if (!dynamic_cast<data_flow::AccessNode*>(write->element())) {
             continue;
         }
-        auto access_node = dynamic_cast<data_flow::AccessNode*>(write->element());
-        target_containers.insert(access_node);
-    }
-
-    analysis::TypeAnalysis type_analysis(builder.subject(), inner_loop, analysis_manager);
-    for (const auto& container : target_containers) {
-        if (type_analysis.get_outer_type(container->data())->type_id() == types::TypeID::Scalar ||
-            type_analysis.get_outer_type(container->data())->type_id() == types::TypeID::Structure) {
+        if (type_analysis.get_outer_type(write->container())->type_id() == types::TypeID::Scalar ||
+            type_analysis.get_outer_type(write->container())->type_id() == types::TypeID::Structure) {
             continue;
         }
-        OutLocalStorage ols(*inner_loop, *container);
+        auto access_node = dynamic_cast<data_flow::AccessNode*>(write->element());
+        OutLocalStorage ols(*inner_loop, *access_node);
         if (ols.can_be_applied(builder, analysis_manager)) {
             ols.apply(builder, analysis_manager);
         }

--- a/opt/src/transformations/offloading/gpu_tiling.cpp
+++ b/opt/src/transformations/offloading/gpu_tiling.cpp
@@ -1,10 +1,12 @@
 #include "sdfg/transformations/offloading/gpu_tiling.h"
+#include <iostream>
 #include <set>
 
 #include "sdfg/analysis/analysis.h"
 #include "sdfg/analysis/type_analysis.h"
 #include "sdfg/analysis/users.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/data_flow/access_node.h"
 #include "sdfg/passes/offloading/sync_condition_propagation.h"
 #include "sdfg/structured_control_flow/for.h"
 #include "sdfg/structured_control_flow/map.h"
@@ -46,24 +48,32 @@ bool GPUTiling::can_be_applied(builder::StructuredSDFGBuilder& builder, analysis
 
     analysis::UsersView users_view(users, inner_loop->root());
 
-    std::set<std::string> read_containers;
+    std::set<data_flow::AccessNode*> read_accesses;
+    std::set<std::string> read_container_names;
+
     for (auto read : users_view.reads()) {
-        read_containers.insert(read->container());
+        if (!dynamic_cast<data_flow::AccessNode*>(read->element())) {
+            continue;
+        }
+        if (read_container_names.find(read->container()) != read_container_names.end()) {
+            continue;
+        }
+        auto access_node = dynamic_cast<data_flow::AccessNode*>(read->element());
+        read_container_names.insert(read->container());
+        read_accesses.insert(std::move(access_node));
     }
 
-    if (read_containers.empty()) {
+    if (read_accesses.empty()) {
         return false;
     }
 
-    std::set<std::string> target_containers;
-    int i = 0;
-    for (const auto& container : read_containers) {
-        KernelLocalStorage kls(*inner_loop, outer_loop->indvar(), container);
+    for (auto& access : read_accesses) {
+        KernelLocalStorage kls(*inner_loop, outer_loop->indvar(), *access);
         if (kls.can_be_applied(builder_local, analysis_manager_local)) {
-            target_containers.insert(container);
+            target_accesses_.insert(access->data());
         }
     }
-    if (target_containers.empty()) {
+    if (target_accesses_.empty()) {
         return false;
     }
 
@@ -78,13 +88,17 @@ void GPUTiling::apply(builder::StructuredSDFGBuilder& builder, analysis::Analysi
 
     analysis::UsersView users_view(analysis_manager.get<analysis::Users>(), inner_loop->root());
 
-    std::set<std::string> read_containers;
-    for (auto read : users_view.reads()) {
-        read_containers.insert(read->container());
-    }
+    for (const auto& container_name : target_accesses_) {
+        auto& users = analysis_manager.get<analysis::Users>();
+        analysis::UsersView users_view(users, inner_loop->root());
 
-    for (const auto& container : read_containers) {
-        KernelLocalStorage kls(*inner_loop, outer_loop->indvar(), container);
+        auto reads = users_view.reads(container_name);
+        if (reads.empty()) continue;
+
+        auto* access = dynamic_cast<data_flow::AccessNode*>(reads.front()->element());
+        if (!access) continue;
+
+        KernelLocalStorage kls(*inner_loop, outer_loop->indvar(), *access);
         if (kls.can_be_applied(builder, analysis_manager)) {
             kls.apply(builder, analysis_manager);
         }
@@ -100,18 +114,23 @@ void GPUTiling::apply(builder::StructuredSDFGBuilder& builder, analysis::Analysi
     auto& users = analysis_manager.get<analysis::Users>();
     analysis::UsersView users_view_inner_loop(users, inner_loop->root());
 
-    std::set<std::string> target_containers;
+    std::set<data_flow::AccessNode*> target_containers;
+    std::set<data_flow::AccessNode*> write_accesses;
     for (auto& write : users_view_inner_loop.writes()) {
-        target_containers.insert(write->container());
+        if (!dynamic_cast<data_flow::AccessNode*>(write->element())) {
+            continue;
+        }
+        auto access_node = dynamic_cast<data_flow::AccessNode*>(write->element());
+        target_containers.insert(access_node);
     }
 
     analysis::TypeAnalysis type_analysis(builder.subject(), inner_loop, analysis_manager);
     for (const auto& container : target_containers) {
-        if (type_analysis.get_outer_type(container)->type_id() == types::TypeID::Scalar ||
-            type_analysis.get_outer_type(container)->type_id() == types::TypeID::Structure) {
+        if (type_analysis.get_outer_type(container->data())->type_id() == types::TypeID::Scalar ||
+            type_analysis.get_outer_type(container->data())->type_id() == types::TypeID::Structure) {
             continue;
         }
-        OutLocalStorage ols(*inner_loop, container);
+        OutLocalStorage ols(*inner_loop, *container);
         if (ols.can_be_applied(builder, analysis_manager)) {
             ols.apply(builder, analysis_manager);
         }

--- a/opt/src/transformations/offloading/kernel_local_storage.cpp
+++ b/opt/src/transformations/offloading/kernel_local_storage.cpp
@@ -37,9 +37,9 @@ namespace sdfg {
 namespace transformations {
 
 KernelLocalStorage::KernelLocalStorage(
-    structured_control_flow::StructuredLoop& loop, symbolic::Expression offset, const std::string& container
+    structured_control_flow::StructuredLoop& loop, symbolic::Expression offset, const data_flow::AccessNode& access_node
 )
-    : loop_(loop), offset_(offset), container_(container) {};
+    : loop_(loop), offset_(offset), access_node_(access_node), container_{access_node.data()} {};
 
 std::string KernelLocalStorage::name() const { return "KernelLocalStorage"; };
 
@@ -599,14 +599,12 @@ void KernelLocalStorage::to_json(nlohmann::json& j) const {
         loop_type = "unknown";
     }
 
-    j["subgraph"] = {{"0", {{"element_id", this->loop_.element_id()}, {"type", loop_type}}}};
+    j["subgraph"] = {
+        {"0", {{"element_id", this->loop_.element_id()}, {"type", loop_type}}},
+        {"1", {{"element_id", this->access_node_.element_id()}, {"type", "access_node"}}}
+    };
 
-    j["parameters"] = {{"offset", serializer::JSONSerializer::expression(offset_)}, {"container", this->container_}};
-
-    // Legacy fields for backward compatibility
-    j["loop_element_id"] = this->loop_.element_id();
-    j["offset"] = serializer::JSONSerializer::expression(offset_);
-    j["container"] = this->container_;
+    j["parameters"] = {{"offset", serializer::JSONSerializer::expression(offset_)}};
 };
 
 KernelLocalStorage KernelLocalStorage::from_json(builder::StructuredSDFGBuilder& builder, const nlohmann::json& desc) {
@@ -624,6 +622,15 @@ KernelLocalStorage KernelLocalStorage::from_json(builder::StructuredSDFGBuilder&
     }
     auto outer_loop = dynamic_cast<structured_control_flow::For*>(element);
 
+    auto access_node = dynamic_cast<
+        data_flow::AccessNode*>(builder.find_element_by_id(desc.at("subgraph").at("1").at("element_id").get<size_t>()));
+    if (!access_node) {
+        throw InvalidTransformationDescriptionException(
+            "Access node with ID " + std::to_string(desc.at("subgraph").at("1").at("element_id").get<size_t>()) +
+            " not found."
+        );
+    }
+
     nlohmann::json offset_json;
     std::string container;
     if (desc.contains("parameters")) {
@@ -631,20 +638,10 @@ KernelLocalStorage KernelLocalStorage::from_json(builder::StructuredSDFGBuilder&
         if (params.contains("offset")) {
             offset_json = params.at("offset");
         }
-        if (params.contains("container")) {
-            container = params.at("container").get<std::string>();
-        }
     }
-    if (offset_json.is_null() && desc.contains("offset")) {
-        offset_json = desc.at("offset");
-    }
-    if (container.empty() && desc.contains("container")) {
-        container = desc.at("container").get<std::string>();
-    }
-
     auto offset = symbolic::parse(offset_json);
 
-    return KernelLocalStorage(*outer_loop, offset, container);
+    return KernelLocalStorage(*outer_loop, offset, *access_node);
 };
 
 } // namespace transformations

--- a/opt/src/transformations/out_local_storage.cpp
+++ b/opt/src/transformations/out_local_storage.cpp
@@ -21,8 +21,8 @@
 namespace sdfg {
 namespace transformations {
 
-OutLocalStorage::OutLocalStorage(structured_control_flow::StructuredLoop& loop, std::string container)
-    : loop_(loop), container_(container) {};
+OutLocalStorage::OutLocalStorage(structured_control_flow::StructuredLoop& loop, const data_flow::AccessNode& access_node)
+    : loop_(loop), access_node_(access_node), container_(access_node.data()) {};
 
 std::string OutLocalStorage::name() const { return "OutLocalStorage"; };
 
@@ -284,21 +284,31 @@ void OutLocalStorage::to_json(nlohmann::json& j) const {
     } else {
         throw std::runtime_error("Unsupported loop type for serialization of loop: " + loop_.indvar()->get_name());
     }
-    j["subgraph"] = {{"0", {{"element_id", this->loop_.element_id()}, {"type", loop_type}}}};
+    j["subgraph"] = {
+        {"0", {{"element_id", this->loop_.element_id()}, {"type", loop_type}}},
+        {"1", {{"element_id", this->access_node_.element_id()}, {"type", "access_node"}}}
+    };
     j["transformation_type"] = this->name();
-    j["container"] = container_;
 };
 
 OutLocalStorage OutLocalStorage::from_json(builder::StructuredSDFGBuilder& builder, const nlohmann::json& desc) {
     auto loop_id = desc["subgraph"]["0"]["element_id"].get<size_t>();
-    std::string container = desc["container"].get<std::string>();
     auto element = builder.find_element_by_id(loop_id);
     if (!element) {
         throw InvalidTransformationDescriptionException("Element with ID " + std::to_string(loop_id) + " not found.");
     }
     auto loop = dynamic_cast<structured_control_flow::StructuredLoop*>(element);
 
-    return OutLocalStorage(*loop, container);
+    auto access_node = dynamic_cast<
+        data_flow::AccessNode*>(builder.find_element_by_id(desc.at("subgraph").at("1").at("element_id").get<size_t>()));
+    if (!access_node) {
+        throw InvalidTransformationDescriptionException(
+            "Access node with ID " + std::to_string(desc.at("subgraph").at("1").at("element_id").get<size_t>()) +
+            " not found."
+        );
+    }
+
+    return OutLocalStorage(*loop, *access_node);
 };
 
 } // namespace transformations

--- a/opt/tests/CMakeLists.txt
+++ b/opt/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ set(TEST_FILES
     transformations/recorder_test.cpp
     transformations/optimizations/diamond_tiling_test.cpp
     transformations/optimizations/blocking_test.cpp
+    transformations/transformation_serialization_test.cpp
     test.cpp
 )
 
@@ -69,6 +70,9 @@ set(TEST_FILES
 add_executable(sdfgopt_test ${TEST_FILES})
 target_include_directories(sdfgopt_test PRIVATE ./)
 target_link_libraries(sdfgopt_test gtest_main sdfg::opt)
+if(DOCC_BUILD_TARGET_TENSTORRENT)
+    target_link_libraries(sdfgopt_test docc::target::tenstorrent)
+endif()
 if(SDFG_ENABLE_COVERAGE)
   target_compile_options(sdfgopt_test PRIVATE
     -fprofile-instr-generate

--- a/opt/tests/CMakeLists.txt
+++ b/opt/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ set(TEST_FILES
     transformations/tile_fusion_test.cpp
     transformations/out_local_storage_test.cpp
     transformations/in_local_storage_test.cpp
+    transformations/accumulator_tile_test.cpp
     transformations/recorder_test.cpp
     transformations/optimizations/diamond_tiling_test.cpp
     transformations/optimizations/blocking_test.cpp

--- a/opt/tests/transformations/accumulator_tile_test.cpp
+++ b/opt/tests/transformations/accumulator_tile_test.cpp
@@ -1,0 +1,368 @@
+#include "sdfg/transformations/accumulator_tile.h"
+
+#include <gtest/gtest.h>
+
+#include "sdfg/analysis/analysis.h"
+#include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/data_flow/access_node.h"
+#include "sdfg/structured_control_flow/block.h"
+#include "sdfg/structured_control_flow/for.h"
+#include "sdfg/structured_control_flow/sequence.h"
+#include "sdfg/symbolic/symbolic.h"
+
+using namespace sdfg;
+
+/**
+ * Test: AccumulatorTile on a 1D accumulator pattern
+ *
+ * Before:
+ *   for i = 0..4:
+ *       for j = 0..8:
+ *           C[j] += A[j]
+ *
+ * After AccumulatorTile(i_loop, C[j]):
+ *   // init: copy C into tile
+ *   for __j = 0..8: C_tile[__j] = C[__j]
+ *   // compute with tile
+ *   for i = 0..4:
+ *       for j = 0..8: C_tile[j] += A[j]
+ *   // writeback
+ *   for __j = 0..8: C[__j] = C_tile[__j]
+ */
+TEST(AccumulatorTile, Basic1D) {
+    builder::StructuredSDFGBuilder builder("acc_tile_1d", FunctionType_CPU);
+
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    builder.add_container("i", sym_desc);
+    builder.add_container("j", sym_desc);
+
+    types::Scalar elem_desc(types::PrimitiveType::Float);
+    types::Array arr_desc(elem_desc, symbolic::integer(8));
+    builder.add_container("A", arr_desc, true);
+    builder.add_container("C", arr_desc);
+
+    auto& root = builder.subject().root();
+
+    // Outer loop: for i = 0..4
+    auto i = symbolic::symbol("i");
+    auto& outer_loop = builder.add_for(
+        root, i, symbolic::Lt(i, symbolic::integer(4)), symbolic::integer(0), symbolic::add(i, symbolic::integer(1))
+    );
+
+    // Inner loop: for j = 0..8
+    auto j = symbolic::symbol("j");
+    auto& inner_loop = builder.add_for(
+        outer_loop.root(),
+        j,
+        symbolic::Lt(j, symbolic::integer(8)),
+        symbolic::integer(0),
+        symbolic::add(j, symbolic::integer(1))
+    );
+
+    // C[j] += A[j]
+    auto& block = builder.add_block(inner_loop.root());
+    auto& a_in = builder.add_access(block, "A");
+    auto& c_in = builder.add_access(block, "C");
+    auto& c_out = builder.add_access(block, "C");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+    builder.add_computational_memlet(block, c_in, tasklet, "_in1", {j}, arr_desc);
+    builder.add_computational_memlet(block, a_in, tasklet, "_in2", {j}, arr_desc);
+    builder.add_computational_memlet(block, tasklet, "_out", c_out, {j}, arr_desc);
+
+    auto structured_sdfg = builder.move();
+
+    builder::StructuredSDFGBuilder builder_opt(structured_sdfg);
+    analysis::AnalysisManager am(builder_opt.subject());
+
+    transformations::AccumulatorTile transformation(outer_loop, c_in);
+    EXPECT_TRUE(transformation.can_be_applied(builder_opt, am));
+    transformation.apply(builder_opt, am);
+
+    // Verify tile buffer was created
+    EXPECT_TRUE(builder_opt.subject().exists("__daisy_accumulator_tile_C"));
+
+    // Structure: root should now contain [init_loop, outer_loop, writeback_loop]
+    auto& new_root = builder_opt.subject().root();
+    EXPECT_EQ(new_root.size(), 3);
+
+    auto* init_loop = dynamic_cast<structured_control_flow::For*>(&new_root.at(0).first);
+    EXPECT_NE(init_loop, nullptr);
+
+    auto* compute_loop = dynamic_cast<structured_control_flow::For*>(&new_root.at(1).first);
+    EXPECT_NE(compute_loop, nullptr);
+
+    auto* wb_loop = dynamic_cast<structured_control_flow::For*>(&new_root.at(2).first);
+    EXPECT_NE(wb_loop, nullptr);
+}
+
+/**
+ * Test: AccumulatorTile fails when container is read-only (no writes)
+ *
+ * for i = 0..4:
+ *     for j = 0..8:
+ *         B[j] = A[j]   (A is read-only, not an accumulator)
+ */
+TEST(AccumulatorTile, FailsOnReadOnly) {
+    builder::StructuredSDFGBuilder builder("acc_tile_ro", FunctionType_CPU);
+
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    builder.add_container("i", sym_desc);
+    builder.add_container("j", sym_desc);
+
+    types::Scalar elem_desc(types::PrimitiveType::Float);
+    types::Array arr_desc(elem_desc, symbolic::integer(8));
+    builder.add_container("A", arr_desc, true);
+    builder.add_container("B", arr_desc);
+
+    auto& root = builder.subject().root();
+
+    auto i = symbolic::symbol("i");
+    auto& outer_loop = builder.add_for(
+        root, i, symbolic::Lt(i, symbolic::integer(4)), symbolic::integer(0), symbolic::add(i, symbolic::integer(1))
+    );
+
+    auto j = symbolic::symbol("j");
+    auto& inner_loop = builder.add_for(
+        outer_loop.root(),
+        j,
+        symbolic::Lt(j, symbolic::integer(8)),
+        symbolic::integer(0),
+        symbolic::add(j, symbolic::integer(1))
+    );
+
+    // B[j] = A[j] — A is only read, not accumulated
+    auto& block = builder.add_block(inner_loop.root());
+    auto& a_in = builder.add_access(block, "A");
+    auto& b_out = builder.add_access(block, "B");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(block, a_in, tasklet, "_in", {j}, arr_desc);
+    builder.add_computational_memlet(block, tasklet, "_out", b_out, {j}, arr_desc);
+
+    auto structured_sdfg = builder.move();
+
+    builder::StructuredSDFGBuilder builder_opt(structured_sdfg);
+    analysis::AnalysisManager am(builder_opt.subject());
+
+    // A is read-only — should fail
+    transformations::AccumulatorTile transformation(outer_loop, a_in);
+    EXPECT_FALSE(transformation.can_be_applied(builder_opt, am));
+}
+
+/**
+ * Test: AccumulatorTile fails on scalar (not array/pointer)
+ *
+ * for i = 0..4:
+ *     for j = 0..8:
+ *         scalar_val += ...
+ */
+TEST(AccumulatorTile, FailsOnScalar) {
+    builder::StructuredSDFGBuilder builder("acc_tile_scalar", FunctionType_CPU);
+
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    builder.add_container("i", sym_desc);
+    builder.add_container("j", sym_desc);
+
+    types::Scalar elem_desc(types::PrimitiveType::Float);
+    builder.add_container("S", elem_desc);
+
+    types::Array arr_desc(elem_desc, symbolic::integer(8));
+    builder.add_container("A", arr_desc, true);
+
+    auto& root = builder.subject().root();
+
+    auto i = symbolic::symbol("i");
+    auto& outer_loop = builder.add_for(
+        root, i, symbolic::Lt(i, symbolic::integer(4)), symbolic::integer(0), symbolic::add(i, symbolic::integer(1))
+    );
+
+    auto j = symbolic::symbol("j");
+    auto& inner_loop = builder.add_for(
+        outer_loop.root(),
+        j,
+        symbolic::Lt(j, symbolic::integer(8)),
+        symbolic::integer(0),
+        symbolic::add(j, symbolic::integer(1))
+    );
+
+    // S += A[j]
+    auto& block = builder.add_block(inner_loop.root());
+    auto& a_in = builder.add_access(block, "A");
+    auto& s_in = builder.add_access(block, "S");
+    auto& s_out = builder.add_access(block, "S");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+    builder.add_computational_memlet(block, s_in, tasklet, "_in1", {}, elem_desc);
+    builder.add_computational_memlet(block, a_in, tasklet, "_in2", {j}, arr_desc);
+    builder.add_computational_memlet(block, tasklet, "_out", s_out, {}, elem_desc);
+
+    auto structured_sdfg = builder.move();
+
+    builder::StructuredSDFGBuilder builder_opt(structured_sdfg);
+    analysis::AnalysisManager am(builder_opt.subject());
+
+    // S is a scalar, not array — should fail
+    transformations::AccumulatorTile transformation(outer_loop, s_in);
+    EXPECT_FALSE(transformation.can_be_applied(builder_opt, am));
+}
+
+/**
+ * Test: AccumulatorTile fails when there are no inner loops
+ *
+ * for i = 0..4:
+ *     C[i] += 1   (no nested loop — use OutLocalStorage instead)
+ */
+TEST(AccumulatorTile, FailsWithoutInnerLoop) {
+    builder::StructuredSDFGBuilder builder("acc_tile_no_inner", FunctionType_CPU);
+
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    builder.add_container("i", sym_desc);
+
+    types::Scalar elem_desc(types::PrimitiveType::Float);
+    types::Array arr_desc(elem_desc, symbolic::integer(4));
+    builder.add_container("C", arr_desc);
+    builder.add_container("one", elem_desc, true);
+
+    auto& root = builder.subject().root();
+
+    auto i = symbolic::symbol("i");
+    auto& loop = builder.add_for(
+        root, i, symbolic::Lt(i, symbolic::integer(4)), symbolic::integer(0), symbolic::add(i, symbolic::integer(1))
+    );
+
+    // C[i] += one (no inner loop)
+    auto& block = builder.add_block(loop.root());
+    auto& c_in = builder.add_access(block, "C");
+    auto& one_in = builder.add_access(block, "one");
+    auto& c_out = builder.add_access(block, "C");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+    builder.add_computational_memlet(block, c_in, tasklet, "_in1", {i}, arr_desc);
+    builder.add_computational_memlet(block, one_in, tasklet, "_in2", {}, elem_desc);
+    builder.add_computational_memlet(block, tasklet, "_out", c_out, {i}, arr_desc);
+
+    auto structured_sdfg = builder.move();
+
+    builder::StructuredSDFGBuilder builder_opt(structured_sdfg);
+    analysis::AnalysisManager am(builder_opt.subject());
+
+    // No inner loops — should fail
+    transformations::AccumulatorTile transformation(loop, c_in);
+    EXPECT_FALSE(transformation.can_be_applied(builder_opt, am));
+}
+
+/**
+ * Test: AccumulatorTile fails when access node is outside the loop
+ *
+ * C[0] = ...         (outside)
+ * for i = 0..4:
+ *     for j = 0..8:
+ *         C[j] += A[j]
+ */
+TEST(AccumulatorTile, FailsOnAccessOutsideLoop) {
+    builder::StructuredSDFGBuilder builder("acc_tile_outside", FunctionType_CPU);
+
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    builder.add_container("i", sym_desc);
+    builder.add_container("j", sym_desc);
+
+    types::Scalar elem_desc(types::PrimitiveType::Float);
+    types::Array arr_desc(elem_desc, symbolic::integer(8));
+    builder.add_container("A", arr_desc, true);
+    builder.add_container("C", arr_desc);
+    builder.add_container("B", arr_desc);
+
+    auto& root = builder.subject().root();
+
+    // Place an access to C outside the loop
+    auto& outer_block = builder.add_block(root);
+    auto& b_outside = builder.add_access(outer_block, "B");
+    auto& i_outside = builder.add_access(outer_block, "i");
+    auto& tasklet_outside = builder.add_tasklet(outer_block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(outer_block, i_outside, tasklet_outside, "_in", {});
+    builder.add_computational_memlet(outer_block, tasklet_outside, "_out", b_outside, {symbolic::integer(0)}, arr_desc);
+
+    auto i = symbolic::symbol("i");
+    auto& outer_loop = builder.add_for(
+        root, i, symbolic::Lt(i, symbolic::integer(4)), symbolic::integer(0), symbolic::add(i, symbolic::integer(1))
+    );
+
+    auto j = symbolic::symbol("j");
+    auto& inner_loop = builder.add_for(
+        outer_loop.root(),
+        j,
+        symbolic::Lt(j, symbolic::integer(8)),
+        symbolic::integer(0),
+        symbolic::add(j, symbolic::integer(1))
+    );
+
+    // C[j] += A[j] inside the loop
+    auto& block = builder.add_block(inner_loop.root());
+    auto& a_in = builder.add_access(block, "A");
+    auto& c_in = builder.add_access(block, "C");
+    auto& c_out = builder.add_access(block, "C");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+    builder.add_computational_memlet(block, c_in, tasklet, "_in1", {j}, arr_desc);
+    builder.add_computational_memlet(block, a_in, tasklet, "_in2", {j}, arr_desc);
+    builder.add_computational_memlet(block, tasklet, "_out", c_out, {j}, arr_desc);
+
+    auto structured_sdfg = builder.move();
+
+    builder::StructuredSDFGBuilder builder_opt(structured_sdfg);
+    analysis::AnalysisManager am(builder_opt.subject());
+
+    // c_outside is not inside the loop — should fail because container "C"
+    // accesses inside the loop are not associated with this access node
+    transformations::AccumulatorTile transformation(outer_loop, b_outside);
+    EXPECT_FALSE(transformation.can_be_applied(builder_opt, am));
+}
+
+/**
+ * Test: AccumulatorTile fails when container is write-only (no reads)
+ *
+ * for i = 0..4:
+ *     for j = 0..8:
+ *         C[j] = A[j]   (C is only written, not read+written)
+ */
+TEST(AccumulatorTile, FailsOnWriteOnly) {
+    builder::StructuredSDFGBuilder builder("acc_tile_wo", FunctionType_CPU);
+
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    builder.add_container("i", sym_desc);
+    builder.add_container("j", sym_desc);
+
+    types::Scalar elem_desc(types::PrimitiveType::Float);
+    types::Array arr_desc(elem_desc, symbolic::integer(8));
+    builder.add_container("A", arr_desc, true);
+    builder.add_container("C", arr_desc);
+
+    auto& root = builder.subject().root();
+
+    auto i = symbolic::symbol("i");
+    auto& outer_loop = builder.add_for(
+        root, i, symbolic::Lt(i, symbolic::integer(4)), symbolic::integer(0), symbolic::add(i, symbolic::integer(1))
+    );
+
+    auto j = symbolic::symbol("j");
+    auto& inner_loop = builder.add_for(
+        outer_loop.root(),
+        j,
+        symbolic::Lt(j, symbolic::integer(8)),
+        symbolic::integer(0),
+        symbolic::add(j, symbolic::integer(1))
+    );
+
+    // C[j] = A[j] — write only, no read-modify-write
+    auto& block = builder.add_block(inner_loop.root());
+    auto& a_in = builder.add_access(block, "A");
+    auto& c_out = builder.add_access(block, "C");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(block, a_in, tasklet, "_in", {j}, arr_desc);
+    builder.add_computational_memlet(block, tasklet, "_out", c_out, {j}, arr_desc);
+
+    auto structured_sdfg = builder.move();
+
+    builder::StructuredSDFGBuilder builder_opt(structured_sdfg);
+    analysis::AnalysisManager am(builder_opt.subject());
+
+    // C is write-only — should fail
+    transformations::AccumulatorTile transformation(outer_loop, c_out);
+    EXPECT_FALSE(transformation.can_be_applied(builder_opt, am));
+}

--- a/opt/tests/transformations/in_local_storage_test.cpp
+++ b/opt/tests/transformations/in_local_storage_test.cpp
@@ -63,7 +63,7 @@ TEST(InLocalStorage, Scalar_ConstantBound) {
     analysis::AnalysisManager am(builder_opt.subject());
 
     // Apply transformation
-    transformations::InLocalStorage transformation(loop, "A");
+    transformations::InLocalStorage transformation(loop, a_in);
     EXPECT_TRUE(transformation.can_be_applied(builder_opt, am));
     transformation.apply(builder_opt, am);
 
@@ -159,11 +159,11 @@ TEST(InLocalStorage, FailsOnWrittenContainer) {
     analysis::AnalysisManager am(builder_opt.subject());
 
     // InLocalStorage should FAIL on C since it's written
-    transformations::InLocalStorage ils_c(loop, "C");
+    transformations::InLocalStorage ils_c(loop, c_in);
     EXPECT_FALSE(ils_c.can_be_applied(builder_opt, am));
 
     // InLocalStorage should SUCCEED on A since A is read-only
-    transformations::InLocalStorage ils_a(loop, "A");
+    transformations::InLocalStorage ils_a(loop, a_in);
     EXPECT_TRUE(ils_a.can_be_applied(builder_opt, am));
 }
 
@@ -211,15 +211,15 @@ TEST(InLocalStorage, FailsOnScalar) {
     analysis::AnalysisManager am(builder_opt.subject());
 
     // InLocalStorage should FAIL on scalar_val
-    transformations::InLocalStorage ils(loop, "scalar_val");
+    transformations::InLocalStorage ils(loop, s_in);
     EXPECT_FALSE(ils.can_be_applied(builder_opt, am));
 }
 
 /**
- * Test: InLocalStorage should fail when container doesn't exist
+ * Test: InLocalStorage should fail when access node is outside the loop
  */
-TEST(InLocalStorage, FailsOnNonexistent) {
-    builder::StructuredSDFGBuilder builder("ils_nonexist_test", FunctionType_CPU);
+TEST(InLocalStorage, FailsOnAccessOutsideLoop) {
+    builder::StructuredSDFGBuilder builder("ils_outside_test", FunctionType_CPU);
 
     types::Scalar sym_desc(types::PrimitiveType::UInt64);
     builder.add_container("i", sym_desc);
@@ -227,8 +227,17 @@ TEST(InLocalStorage, FailsOnNonexistent) {
     types::Scalar elem_desc(types::PrimitiveType::Float);
     types::Array arr_desc(elem_desc, symbolic::integer(4));
     builder.add_container("A", arr_desc, true);
+    builder.add_container("B", arr_desc, true);
 
     auto& root = builder.subject().root();
+
+    // Place an access to B outside the loop
+    auto& outer_block = builder.add_block(root);
+    auto& b_outside = builder.add_access(outer_block, "B");
+    auto& i_outside = builder.add_access(outer_block, "i");
+    auto& tasklet_outside = builder.add_tasklet(outer_block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(outer_block, i_outside, tasklet_outside, "_in", {});
+    builder.add_computational_memlet(outer_block, tasklet_outside, "_out", b_outside, {symbolic::integer(0)}, arr_desc);
 
     auto indvar = symbolic::symbol("i");
     auto& loop = builder.add_for(
@@ -251,8 +260,8 @@ TEST(InLocalStorage, FailsOnNonexistent) {
     builder::StructuredSDFGBuilder builder_opt(structured_sdfg);
     analysis::AnalysisManager am(builder_opt.subject());
 
-    // InLocalStorage should FAIL on nonexistent container
-    transformations::InLocalStorage ils(loop, "B_nonexistent");
+    // InLocalStorage should FAIL on B (not used inside the loop)
+    transformations::InLocalStorage ils(loop, b_outside);
     EXPECT_FALSE(ils.can_be_applied(builder_opt, am));
 }
 
@@ -281,7 +290,15 @@ TEST(InLocalStorage, FailsOnUnusedContainer) {
         symbolic::add(indvar, symbolic::integer(1))
     );
 
-    // Only use A, not B
+    // Place an access to B outside the loop
+    auto& outer_block = builder.add_block(root);
+    auto& b_outside = builder.add_access(outer_block, "B");
+    auto& i_outside = builder.add_access(outer_block, "i");
+    auto& tasklet_outside = builder.add_tasklet(outer_block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(outer_block, i_outside, tasklet_outside, "_in", {});
+    builder.add_computational_memlet(outer_block, tasklet_outside, "_out", b_outside, {symbolic::integer(0)}, arr_desc);
+
+    // Only use A, not B inside the loop
     auto& block = builder.add_block(loop.root());
     auto& a_in = builder.add_access(block, "A");
     auto& a_out = builder.add_access(block, "A");
@@ -295,7 +312,7 @@ TEST(InLocalStorage, FailsOnUnusedContainer) {
     analysis::AnalysisManager am(builder_opt.subject());
 
     // InLocalStorage should FAIL on B (not used in loop body)
-    transformations::InLocalStorage ils(loop, "B");
+    transformations::InLocalStorage ils(loop, b_outside);
     EXPECT_FALSE(ils.can_be_applied(builder_opt, am));
 }
 
@@ -336,7 +353,7 @@ TEST(InLocalStorage, JsonSerialization) {
     analysis::AnalysisManager am(builder.subject());
 
     // Create transformation and serialize
-    transformations::InLocalStorage original(loop, "A");
+    transformations::InLocalStorage original(loop, a_in);
     EXPECT_TRUE(original.can_be_applied(builder, am));
 
     nlohmann::json j;
@@ -419,7 +436,7 @@ TEST(InLocalStorage, NestedLoops_2D) {
     analysis::AnalysisManager am(builder_opt.subject());
 
     // Apply InLocalStorage at outer loop level
-    transformations::InLocalStorage ils(i_loop, "A");
+    transformations::InLocalStorage ils(i_loop, a_in);
 
     std::cout << "Testing InLocalStorage on 2D nested loops..." << std::endl;
     bool can_apply = ils.can_be_applied(builder_opt, am);
@@ -508,7 +525,7 @@ TEST(InLocalStorage, TiledAccess_1D) {
     analysis::AnalysisManager am(builder_opt.subject());
 
     // Apply InLocalStorage at tile loop level
-    transformations::InLocalStorage ils(tile_loop, "A");
+    transformations::InLocalStorage ils(tile_loop, a_in);
 
     std::cout << "Testing InLocalStorage on tiled 1D access..." << std::endl;
     bool can_apply = ils.can_be_applied(builder_opt, am);
@@ -617,7 +634,7 @@ TEST(InLocalStorage, TiledAccess_2D_Panel) {
     analysis::AnalysisManager am(builder_opt.subject());
 
     // Apply InLocalStorage at k_tile loop level (like BLIS packing A at k_tile)
-    transformations::InLocalStorage ils(k_tile_loop, "A");
+    transformations::InLocalStorage ils(k_tile_loop, a_in);
 
     std::cout << "Testing InLocalStorage on 2D tiled panel access (BLIS-style)..." << std::endl;
     bool can_apply = ils.can_be_applied(builder_opt, am);

--- a/opt/tests/transformations/offloading/kernel_local_storage_test.cpp
+++ b/opt/tests/transformations/offloading/kernel_local_storage_test.cpp
@@ -80,8 +80,7 @@ TEST(KernelLocalStorageTest, json_serialization) {
     builder.add_computational_memlet(block, tasklet, "out_", access_out, {symbolic::symbol("i"), symbolic::symbol("j")});
 
     // Transformation
-    std::string container = "A";
-    transformations::KernelLocalStorage kernel_local_storage(loop, symbolic::zero(), container);
+    transformations::KernelLocalStorage kernel_local_storage(loop, symbolic::zero(), access_in);
 
     nlohmann::json j;
     kernel_local_storage.to_json(j);
@@ -107,19 +106,9 @@ TEST(KernelLocalStorageTest, json_serialization) {
     // Parameters section
     ASSERT_TRUE(j.contains("parameters"));
     ASSERT_TRUE(j["parameters"].is_object());
-    ASSERT_TRUE(j["parameters"].contains("container"));
-    EXPECT_EQ(j["parameters"]["container"].get<std::string>(), "A");
     ASSERT_TRUE(j["parameters"].contains("offset"));
     // Offsets are serialized as string expressions
     EXPECT_EQ(j["parameters"]["offset"].get<std::string>(), "0");
-
-    // Legacy fields kept for backward compatibility
-    ASSERT_TRUE(j.contains("loop_element_id"));
-    EXPECT_EQ(j["loop_element_id"].get<size_t>(), loop.element_id());
-    ASSERT_TRUE(j.contains("container"));
-    EXPECT_EQ(j["container"].get<std::string>(), "A");
-    ASSERT_TRUE(j.contains("offset"));
-    EXPECT_EQ(j["offset"].get<std::string>(), "0");
 }
 
 TEST(KernelLocalStorageTest, NoOffset) {
@@ -175,9 +164,8 @@ TEST(KernelLocalStorageTest, NoOffset) {
     builder.add_computational_memlet(block, access_in3, tasklet, "in3_", {symbolic::symbol("i"), symbolic::symbol("j")});
     builder.add_computational_memlet(block, tasklet, "out_", access_out, {symbolic::symbol("i"), symbolic::symbol("j")});
 
-    std::string container = "A";
     // Transformation
-    transformations::KernelLocalStorage kernel_local_storage(loop, symbolic::zero(), container);
+    transformations::KernelLocalStorage kernel_local_storage(loop, symbolic::zero(), access_in);
 
     analysis::AnalysisManager analysis_manager(builder.subject());
     EXPECT_TRUE(kernel_local_storage.can_be_applied(builder, analysis_manager));
@@ -328,8 +316,7 @@ TEST(KernelLocalStorageTest, WithOffset) {
     auto inner_loop = tiling.inner_loop();
     auto outer_loop = tiling.outer_loop();
 
-    std::string container = "A";
-    transformations::KernelLocalStorage kernel_local_storage(*inner_loop, outer_loop->indvar(), container);
+    transformations::KernelLocalStorage kernel_local_storage(*inner_loop, outer_loop->indvar(), access_in);
 
     EXPECT_TRUE(kernel_local_storage.can_be_applied(builder, analysis_manager));
 
@@ -493,7 +480,7 @@ TEST(KernelLocalStorageTest, CannotApply_TargetIsGPUMap) {
     builder.add_computational_memlet(block, tasklet, "out_", access_out, {symbolic::symbol("i"), symbolic::symbol("j")});
 
     // Passing map_y (a GPU map) as the "loop" must be rejected.
-    transformations::KernelLocalStorage kls(*map_y, symbolic::zero(), "A");
+    transformations::KernelLocalStorage kls(*map_y, symbolic::zero(), access_in);
     analysis::AnalysisManager am(builder.subject());
     EXPECT_FALSE(kls.can_be_applied(builder, am));
 }
@@ -534,7 +521,7 @@ TEST(KernelLocalStorageTest, CannotApply_NotInGPUScope) {
     builder.add_computational_memlet(block, access_in, tasklet, "in_", {symbolic::symbol("i"), symbolic::symbol("k")});
     builder.add_computational_memlet(block, tasklet, "out_", access_out, {symbolic::symbol("i"), symbolic::symbol("j")});
 
-    transformations::KernelLocalStorage kls(loop, symbolic::zero(), "A");
+    transformations::KernelLocalStorage kls(loop, symbolic::zero(), access_in);
     analysis::AnalysisManager am(builder.subject());
     EXPECT_FALSE(kls.can_be_applied(builder, am));
 }
@@ -557,9 +544,8 @@ TEST(KernelLocalStorageTest, CannotApply_ContainerIsPointerToPointer) {
 
     auto [map_x, map_y, loop] = build_standard_gpu_scaffold(builder);
 
-    // Loop body intentionally left empty; the check fails before inspecting accesses.
-    std::string container = "A";
-    transformations::KernelLocalStorage kls(*loop, symbolic::zero(), container);
+    data_flow::AccessNode& access_in = builder.add_access(builder.add_block(loop->root()), "A");
+    transformations::KernelLocalStorage kls(*loop, symbolic::zero(), access_in);
     analysis::AnalysisManager am(builder.subject());
     EXPECT_FALSE(kls.can_be_applied(builder, am));
 }
@@ -621,7 +607,7 @@ TEST(KernelLocalStorageTest, CannotApply_UnknownIterationCount) {
     builder.add_computational_memlet(block, tasklet, "out_", access_out, {symbolic::symbol("i"), symbolic::symbol("j")});
 
     std::string container = "A";
-    transformations::KernelLocalStorage kls(loop, symbolic::zero(), container);
+    transformations::KernelLocalStorage kls(loop, symbolic::zero(), access_in);
     analysis::AnalysisManager am(builder.subject());
     EXPECT_FALSE(kls.can_be_applied(builder, am));
 }
@@ -680,16 +666,28 @@ TEST(KernelLocalStorageTest, CannotApply_ContainerNotRead) {
 
     auto [map_x, map_y, loop] = build_standard_gpu_scaffold(builder);
 
+    // Place an access to A outside the loop (before it, in the map body).
+    auto& outer_block = builder.add_block(map_y->root());
+    auto& access_A_outside = builder.add_access(outer_block, "A");
+    auto& access_C_outside = builder.add_access(outer_block, "C");
+    auto& tasklet_outside = builder.add_tasklet(outer_block, data_flow::TaskletCode::assign, "out_", {"in_"});
+    builder.add_computational_memlet(
+        outer_block, access_A_outside, tasklet_outside, "in_", {symbolic::symbol("i"), symbolic::symbol("j")}
+    );
+    builder.add_computational_memlet(
+        outer_block, tasklet_outside, "out_", access_C_outside, {symbolic::symbol("i"), symbolic::symbol("j")}
+    );
+
+    // Inside the loop, only B and C are accessed; A is never read here.
     auto& block = builder.add_block(loop->root());
-    // Only B and C are accessed; A is declared but never read inside the loop.
     auto& access_B = builder.add_access(block, "B");
     auto& access_C = builder.add_access(block, "C");
     auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "out_", {"in_"});
     builder.add_computational_memlet(block, access_B, tasklet, "in_", {symbolic::symbol("i"), symbolic::symbol("k")});
     builder.add_computational_memlet(block, tasklet, "out_", access_C, {symbolic::symbol("i"), symbolic::symbol("j")});
 
-    std::string container = "A";
-    transformations::KernelLocalStorage kls(*loop, symbolic::zero(), container);
+    // Pass the outside access node — A has no reads in the loop body.
+    transformations::KernelLocalStorage kls(*loop, symbolic::zero(), access_A_outside);
     analysis::AnalysisManager am(builder.subject());
     EXPECT_FALSE(kls.can_be_applied(builder, am));
 }
@@ -730,8 +728,8 @@ TEST(KernelLocalStorageTest, CannotApply_MultipleReads) {
     builder
         .add_computational_memlet(block, tasklet2, "out_", access_out2, {symbolic::symbol("i"), symbolic::symbol("j")});
 
-    std::string container = "A";
-    transformations::KernelLocalStorage kls(*loop, symbolic::zero(), container);
+    auto& access_in = builder.add_access(block, "A");
+    transformations::KernelLocalStorage kls(*loop, symbolic::zero(), access_in);
     analysis::AnalysisManager am(builder.subject());
     EXPECT_FALSE(kls.can_be_applied(builder, am));
 }
@@ -762,8 +760,7 @@ TEST(KernelLocalStorageTest, CannotApply_InnerIndvarNotUsed) {
     builder.add_computational_memlet(block, access_in, tasklet, "in_", {symbolic::symbol("i"), symbolic::symbol("j")});
     builder.add_computational_memlet(block, tasklet, "out_", access_out, {symbolic::symbol("i"), symbolic::symbol("j")});
 
-    std::string container = "A";
-    transformations::KernelLocalStorage kls(*loop, symbolic::zero(), container);
+    transformations::KernelLocalStorage kls(*loop, symbolic::zero(), access_in);
     analysis::AnalysisManager am(builder.subject());
     EXPECT_FALSE(kls.can_be_applied(builder, am));
 }
@@ -813,8 +810,7 @@ TEST(KernelLocalStorageTest, CannotApply_OnlyOneGPUDimension) {
     builder.add_computational_memlet(block, access_in, tasklet, "in_", {symbolic::symbol("i"), symbolic::symbol("k")});
     builder.add_computational_memlet(block, tasklet, "out_", access_out, {symbolic::symbol("i"), symbolic::symbol("k")});
 
-    std::string container = "A";
-    transformations::KernelLocalStorage kls(loop, symbolic::zero(), container);
+    transformations::KernelLocalStorage kls(loop, symbolic::zero(), access_in);
     analysis::AnalysisManager am(builder.subject());
     EXPECT_FALSE(kls.can_be_applied(builder, am));
 }
@@ -859,8 +855,7 @@ TEST(KernelLocalStorageTest, CannotApply_SubsetVariableWritten) {
     builder.add_computational_memlet(block, access_n_in, tasklet_n, "in_", {});
     builder.add_computational_memlet(block, tasklet_n, "out_", access_n_out, {});
 
-    std::string container = "A";
-    transformations::KernelLocalStorage kls(*loop, symbolic::zero(), container);
+    transformations::KernelLocalStorage kls(*loop, symbolic::zero(), access_A);
     analysis::AnalysisManager am(builder.subject());
     EXPECT_FALSE(kls.can_be_applied(builder, am));
 }
@@ -906,8 +901,7 @@ TEST(KernelLocalStorageTest, CannotApply_SubsetDependsOnNestedLoopIndvar) {
     builder.add_computational_memlet(block, access_in, tasklet, "in_", {symbolic::symbol("i"), symbolic::symbol("m")});
     builder.add_computational_memlet(block, tasklet, "out_", access_out, {symbolic::symbol("i"), symbolic::symbol("j")});
 
-    std::string container = "A";
-    transformations::KernelLocalStorage kls(*loop, symbolic::zero(), container);
+    transformations::KernelLocalStorage kls(*loop, symbolic::zero(), access_in);
     analysis::AnalysisManager am(builder.subject());
     EXPECT_FALSE(kls.can_be_applied(builder, am));
 }
@@ -947,8 +941,7 @@ TEST(KernelLocalStorageTest, CannotApply_NoFreeDimension) {
     );
     builder.add_computational_memlet(block, tasklet, "out_", access_out, {symbolic::symbol("i"), symbolic::symbol("j")});
 
-    std::string container = "A";
-    transformations::KernelLocalStorage kls(*loop, symbolic::zero(), container);
+    transformations::KernelLocalStorage kls(*loop, symbolic::zero(), access_in);
     analysis::AnalysisManager am(builder.subject());
     EXPECT_FALSE(kls.can_be_applied(builder, am));
 }

--- a/opt/tests/transformations/offloading/kernel_local_storage_test.cpp
+++ b/opt/tests/transformations/offloading/kernel_local_storage_test.cpp
@@ -642,8 +642,7 @@ TEST(KernelLocalStorageTest, CannotApply_ContainerIsWritten) {
     builder
         .add_computational_memlet(block, tasklet, "out_", access_write, {symbolic::symbol("i"), symbolic::symbol("j")});
 
-    std::string container = "A";
-    transformations::KernelLocalStorage kls(*loop, symbolic::zero(), container);
+    transformations::KernelLocalStorage kls(*loop, symbolic::zero(), access_in);
     analysis::AnalysisManager am(builder.subject());
     EXPECT_FALSE(kls.can_be_applied(builder, am));
 }

--- a/opt/tests/transformations/optimizations/blocking_test.cpp
+++ b/opt/tests/transformations/optimizations/blocking_test.cpp
@@ -5,7 +5,9 @@
 #include <vector>
 
 #include "sdfg/analysis/analysis.h"
+#include "sdfg/analysis/users.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/data_flow/access_node.h"
 #include "sdfg/passes/structured_control_flow/dead_cfg_elimination.h"
 #include "sdfg/passes/structured_control_flow/sequence_fusion.h"
 #include "sdfg/structured_control_flow/for.h"
@@ -51,6 +53,19 @@ std::vector<std::string> get_loop_order(builder::StructuredSDFGBuilder& builder)
         loop = find_last_for(loop->root());
     }
     return order;
+}
+
+// Find an access node for a container within a loop body
+data_flow::AccessNode& find_access_node(
+    analysis::AnalysisManager& am, structured_control_flow::StructuredLoop& loop, const std::string& container
+) {
+    auto& users = am.get<analysis::Users>();
+    analysis::UsersView view(users, loop.root());
+    auto accesses = view.uses(container);
+    assert(!accesses.empty());
+    auto* node = dynamic_cast<data_flow::AccessNode*>(accesses.front()->element());
+    assert(node);
+    return *node;
 }
 
 } // namespace
@@ -377,8 +392,9 @@ TEST(BlockingTest, GEMM_Phase2_Packing) {
     i_tile = dynamic_cast<structured_control_flow::For*>(&builder.subject().root().at(0).first);
     k_tile = dynamic_cast<structured_control_flow::For*>(&i_tile->root().at(0).first);
 
-    ASSERT_TRUE(transformations::InLocalStorage(*k_tile, "A").can_be_applied(builder, am));
-    recorder.apply<transformations::InLocalStorage>(builder, am, false, *k_tile, "A");
+    auto& a_access_p2 = find_access_node(am, *k_tile, "A");
+    ASSERT_TRUE(transformations::InLocalStorage(*k_tile, a_access_p2).can_be_applied(builder, am));
+    recorder.apply<transformations::InLocalStorage>(builder, am, false, *k_tile, a_access_p2);
     am.invalidate_all();
     cleanup(builder, am);
 
@@ -388,8 +404,9 @@ TEST(BlockingTest, GEMM_Phase2_Packing) {
     structured_control_flow::For* j_tile_loop = find_last_for(k_tile->root());
     ASSERT_NE(j_tile_loop, nullptr);
 
-    ASSERT_TRUE(transformations::InLocalStorage(*j_tile_loop, "B").can_be_applied(builder, am));
-    recorder.apply<transformations::InLocalStorage>(builder, am, false, *j_tile_loop, "B");
+    auto& b_access_p2 = find_access_node(am, *j_tile_loop, "B");
+    ASSERT_TRUE(transformations::InLocalStorage(*j_tile_loop, b_access_p2).can_be_applied(builder, am));
+    recorder.apply<transformations::InLocalStorage>(builder, am, false, *j_tile_loop, b_access_p2);
     am.invalidate_all();
     cleanup(builder, am);
 
@@ -507,19 +524,21 @@ TEST(BlockingTest, GEMM_Phase3_RegisterBlocking) {
     i_tile = dynamic_cast<structured_control_flow::For*>(&builder.subject().root().at(0).first);
     k_tile = dynamic_cast<structured_control_flow::For*>(&i_tile->root().at(0).first);
 
-    ASSERT_TRUE(transformations::InLocalStorage(*k_tile, "A").can_be_applied(builder, am));
-    recorder.apply<transformations::InLocalStorage>(builder, am, false, *k_tile, "A");
+    auto& a_access_p3 = find_access_node(am, *k_tile, "A");
+    ASSERT_TRUE(transformations::InLocalStorage(*k_tile, a_access_p3).can_be_applied(builder, am));
+    recorder.apply<transformations::InLocalStorage>(builder, am, false, *k_tile, a_access_p3);
     am.invalidate_all();
     cleanup(builder, am);
 
     // Step 9: InLocalStorage(j_tile, "B")
     i_tile = dynamic_cast<structured_control_flow::For*>(&builder.subject().root().at(0).first);
     k_tile = dynamic_cast<structured_control_flow::For*>(&i_tile->root().at(0).first);
-    structured_control_flow::For* j_tile_loop = find_last_for(k_tile->root());
+    auto* j_tile_loop = find_last_for(k_tile->root());
     ASSERT_NE(j_tile_loop, nullptr);
 
-    ASSERT_TRUE(transformations::InLocalStorage(*j_tile_loop, "B").can_be_applied(builder, am));
-    recorder.apply<transformations::InLocalStorage>(builder, am, false, *j_tile_loop, "B");
+    auto& b_access_p3 = find_access_node(am, *j_tile_loop, "B");
+    ASSERT_TRUE(transformations::InLocalStorage(*j_tile_loop, b_access_p3).can_be_applied(builder, am));
+    recorder.apply<transformations::InLocalStorage>(builder, am, false, *j_tile_loop, b_access_p3);
     am.invalidate_all();
     cleanup(builder, am);
 
@@ -609,8 +628,9 @@ TEST(BlockingTest, GEMM_Phase3_RegisterBlocking) {
     j_tile_loop = find_last_for(k_tile->root());
     i_micro = find_last_for(j_tile_loop->root());
 
-    ASSERT_TRUE(transformations::AccumulatorTile(*i_micro, "C").can_be_applied(builder, am));
-    recorder.apply<transformations::AccumulatorTile>(builder, am, false, *i_micro, "C");
+    auto& c_access_p3 = find_access_node(am, *i_micro, "C");
+    ASSERT_TRUE(transformations::AccumulatorTile(*i_micro, c_access_p3).can_be_applied(builder, am));
+    recorder.apply<transformations::AccumulatorTile>(builder, am, false, *i_micro, c_access_p3);
     am.invalidate_all();
     cleanup(builder, am);
 
@@ -738,8 +758,9 @@ TEST(BlockingTest, GEMV_Optimized) {
     auto* j_loop = dynamic_cast<structured_control_flow::For*>(&i_loop->root().at(0).first);
 
     // Step 1: OutLocalStorage(j_loop, "y") - scalar accumulator for y[i]
-    ASSERT_TRUE(transformations::OutLocalStorage(*j_loop, "y").can_be_applied(builder, am));
-    recorder.apply<transformations::OutLocalStorage>(builder, am, false, *j_loop, "y");
+    auto& y_access = find_access_node(am, *j_loop, "y");
+    ASSERT_TRUE(transformations::OutLocalStorage(*j_loop, y_access).can_be_applied(builder, am));
+    recorder.apply<transformations::OutLocalStorage>(builder, am, false, *j_loop, y_access);
     am.invalidate_all();
     cleanup(builder, am);
 
@@ -758,8 +779,9 @@ TEST(BlockingTest, GEMV_Optimized) {
     auto* j_tile = find_last_for(i_loop->root());
     ASSERT_NE(j_tile, nullptr);
 
-    ASSERT_TRUE(transformations::InLocalStorage(*j_tile, "x").can_be_applied(builder, am));
-    recorder.apply<transformations::InLocalStorage>(builder, am, false, *j_tile, "x");
+    auto& x_access = find_access_node(am, *j_tile, "x");
+    ASSERT_TRUE(transformations::InLocalStorage(*j_tile, x_access).can_be_applied(builder, am));
+    recorder.apply<transformations::InLocalStorage>(builder, am, false, *j_tile, x_access);
     am.invalidate_all();
     cleanup(builder, am);
 

--- a/opt/tests/transformations/out_local_storage_test.cpp
+++ b/opt/tests/transformations/out_local_storage_test.cpp
@@ -58,7 +58,7 @@ TEST(OutLocalStorage, Scalar) {
 
     auto& new_root = builder_opt.subject().root();
     // Apply
-    transformations::OutLocalStorage transformation(loop, "C");
+    transformations::OutLocalStorage transformation(loop, access_out);
     EXPECT_TRUE(transformation.can_be_applied(builder_opt, analysis_manager));
     transformation.apply(builder_opt, analysis_manager);
 
@@ -194,7 +194,7 @@ TEST(OutLocalStorage, Array) {
 
     auto& new_root = builder_opt.subject().root();
     // Apply
-    transformations::OutLocalStorage transformation(loop, "C");
+    transformations::OutLocalStorage transformation(loop, access_out);
     EXPECT_TRUE(transformation.can_be_applied(builder_opt, analysis_manager));
     transformation.apply(builder_opt, analysis_manager);
 
@@ -326,10 +326,19 @@ TEST(OutLocalStorage, Fail) {
 
     types::Pointer opaque_desc;
     builder.add_container("A", opaque_desc, true);
+    builder.add_container("C", opaque_desc, true);
 
     types::Scalar sym_desc(types::PrimitiveType::UInt64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
+
+    // Place an access to A outside the loop (before it, in the root sequence).
+    auto& outer_block = builder.add_block(root);
+    auto& access_outside = builder.add_access(outer_block, "C");
+    auto& access_i_outside = builder.add_access(outer_block, "i");
+    auto& tasklet_outside = builder.add_tasklet(outer_block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(outer_block, access_i_outside, tasklet_outside, "_in", {});
+    builder.add_computational_memlet(outer_block, tasklet_outside, "_out", access_outside, {symbolic::integer(0)}, desc);
 
     // Define loop
     auto bound = symbolic::symbol("N");
@@ -341,7 +350,7 @@ TEST(OutLocalStorage, Fail) {
     auto& loop = builder.add_for(root, indvar, condition, init, update);
     auto& body = loop.root();
 
-    // Add computation
+    // Add computation inside the loop (only writes to A)
     auto& block = builder.add_block(body);
     auto& access_in = builder.add_access(block, "i");
     auto& access_out = builder.add_access(block, "A");
@@ -354,7 +363,7 @@ TEST(OutLocalStorage, Fail) {
     builder::StructuredSDFGBuilder builder_opt(structured_sdfg);
     analysis::AnalysisManager analysis_manager(builder_opt.subject());
 
-    // Apply
-    transformations::OutLocalStorage transformation(loop, "C");
+    // Apply with the outside access node — should fail
+    transformations::OutLocalStorage transformation(loop, access_outside);
     EXPECT_FALSE(transformation.can_be_applied(builder_opt, analysis_manager));
 }

--- a/opt/tests/transformations/transformation_serialization_test.cpp
+++ b/opt/tests/transformations/transformation_serialization_test.cpp
@@ -1,0 +1,232 @@
+#include <gtest/gtest.h>
+
+#include <nlohmann/json.hpp>
+
+#include <sdfg/analysis/analysis.h>
+#include <sdfg/builder/structured_sdfg_builder.h>
+#include <sdfg/data_flow/access_node.h>
+#include <sdfg/structured_control_flow/block.h>
+#include <sdfg/structured_control_flow/map.h>
+#include <sdfg/structured_control_flow/structured_loop.h>
+#include <sdfg/structured_sdfg.h>
+#include <sdfg/symbolic/symbolic.h>
+
+#include <sdfg/transformations/loop_distribute.h>
+#include <sdfg/transformations/loop_interchange.h>
+#include <sdfg/transformations/loop_skewing.h>
+#include <sdfg/transformations/loop_tiling.h>
+#include <sdfg/transformations/out_local_storage.h>
+
+#include <sdfg/transformations/highway_transform.h>
+#include <sdfg/transformations/offloading/cuda_parallelize_nested_map.h>
+#include <sdfg/transformations/offloading/cuda_transform.h>
+#include <sdfg/transformations/offloading/gpu_condition_propagation.h>
+#include <sdfg/transformations/offloading/gpu_loop_reordering.h>
+#include <sdfg/transformations/offloading/gpu_tiling.h>
+#include <sdfg/transformations/offloading/kernel_local_storage.h>
+#include <sdfg/transformations/omp_transform.h>
+
+#ifdef DOCC_HAS_TARGET_TENSTORRENT
+#include <docc/target/tenstorrent/tenstorrent_transform.h>
+#endif
+
+using namespace sdfg;
+
+namespace {
+
+void ValidateSerialization(const nlohmann::json& j, std::size_t expected_subgraph_size) {
+    ASSERT_TRUE(j.contains("transformation_type"));
+    ASSERT_TRUE(j["transformation_type"].is_string());
+
+    ASSERT_TRUE(j.contains("subgraph"));
+    ASSERT_TRUE(j["subgraph"].is_object());
+    ASSERT_EQ(j["subgraph"].size(), expected_subgraph_size);
+
+    for (std::size_t i = 0; i < expected_subgraph_size; ++i) {
+        auto key = std::to_string(i);
+        ASSERT_TRUE(j["subgraph"].contains(key));
+        const auto& node = j["subgraph"][key];
+        ASSERT_TRUE(node.contains("element_id"));
+        ASSERT_TRUE(node["element_id"].is_number_unsigned());
+        ASSERT_TRUE(node.contains("type"));
+        ASSERT_TRUE(node["type"].is_string());
+    }
+}
+
+// Build a minimal SDFG with one map nest i->j suitable for most loop-based transforms.
+struct LoopFixture {
+    builder::StructuredSDFGBuilder builder;
+    structured_control_flow::Map* outer_map;
+    structured_control_flow::Map* inner_map;
+    data_flow::AccessNode* access_A;
+
+    LoopFixture()
+        : builder("serialization_test", FunctionType_CPU), outer_map(nullptr), inner_map(nullptr), access_A(nullptr) {
+        auto& root = builder.subject().root();
+
+        auto bound = symbolic::integer(16);
+        auto indvar_i = symbolic::symbol("i");
+        outer_map = &builder.add_map(
+            root,
+            indvar_i,
+            symbolic::Lt(indvar_i, bound),
+            symbolic::integer(0),
+            symbolic::add(indvar_i, symbolic::one()),
+            structured_control_flow::ScheduleType_Sequential::create()
+        );
+
+        auto& body = outer_map->root();
+        auto indvar_j = symbolic::symbol("j");
+        inner_map = &builder.add_map(
+            body,
+            indvar_j,
+            symbolic::Lt(indvar_j, bound),
+            symbolic::integer(0),
+            symbolic::add(indvar_j, symbolic::one()),
+            structured_control_flow::ScheduleType_Sequential::create()
+        );
+
+        // One container for OutLocalStorage / KernelLocalStorage
+        types::Scalar base_desc(types::PrimitiveType::Float);
+        types::Array arr_desc(base_desc, symbolic::integer(16));
+        types::Pointer ptr_desc(arr_desc);
+        builder.add_container("A", ptr_desc, true);
+
+        // Add a block with an access node for "A" inside the inner map
+        auto& inner_body = inner_map->root();
+        auto& block = builder.add_block(inner_body);
+        access_A = &builder.add_access(block, "A");
+    }
+};
+
+TEST(TransformationSerializationTest, CoreLoopTransformationsShape) {
+    LoopFixture f;
+
+    // LoopTiling
+    transformations::LoopTiling tiling(*f.outer_map, 4);
+    nlohmann::json j;
+    tiling.to_json(j);
+    ValidateSerialization(j, 1);
+
+    auto tiling2 = transformations::LoopTiling::from_json(f.builder, j);
+    ASSERT_EQ(tiling2.name(), tiling.name());
+
+    // LoopDistribute
+    transformations::LoopDistribute distribute(*f.outer_map);
+    nlohmann::json jd;
+    distribute.to_json(jd);
+    ValidateSerialization(jd, 1);
+    auto distribute2 = transformations::LoopDistribute::from_json(f.builder, jd);
+    ASSERT_EQ(distribute2.name(), distribute.name());
+
+    // LoopInterchange
+    transformations::LoopInterchange interchange(*f.outer_map, *f.inner_map);
+    nlohmann::json ji;
+    interchange.to_json(ji);
+    ValidateSerialization(ji, 2);
+    auto interchange2 = transformations::LoopInterchange::from_json(f.builder, ji);
+    ASSERT_EQ(interchange2.name(), interchange.name());
+
+    // OutLocalStorage
+    transformations::OutLocalStorage ols(*f.outer_map, *f.access_A);
+    nlohmann::json jo;
+    ols.to_json(jo);
+    ValidateSerialization(jo, 2);
+    auto ols2 = transformations::OutLocalStorage::from_json(f.builder, jo);
+    ASSERT_EQ(ols2.name(), ols.name());
+
+    // LoopSkewing
+    transformations::LoopSkewing skew(*f.outer_map, *f.inner_map, 1);
+    nlohmann::json js;
+    skew.to_json(js);
+    ValidateSerialization(js, 2);
+    auto skew2 = transformations::LoopSkewing::from_json(f.builder, js);
+    ASSERT_EQ(skew2.name(), skew.name());
+}
+
+TEST(TransformationSerializationTest, OffloadingAndGPUTransformationsShape) {
+    LoopFixture f;
+
+    // CUDATransform
+    cuda::CUDATransform cuda_t(*f.outer_map, 32);
+    nlohmann::json jc;
+    cuda_t.to_json(jc);
+    ValidateSerialization(jc, 1);
+    auto cuda_t2 = cuda::CUDATransform::from_json(f.builder, jc);
+    ASSERT_EQ(cuda_t2.name(), cuda_t.name());
+
+    // CUDAParallelizeNestedMap
+    transformations::CUDAParallelizeNestedMap nested(*f.inner_map, 32);
+    nlohmann::json jn;
+    nested.to_json(jn);
+    ValidateSerialization(jn, 1);
+    auto nested2 = transformations::CUDAParallelizeNestedMap::from_json(f.builder, jn);
+    ASSERT_EQ(nested2.name(), nested.name());
+
+    // GPUTiling
+    transformations::GPUTiling gpu_tiling(*static_cast<structured_control_flow::StructuredLoop*>(f.outer_map), 4);
+    nlohmann::json jgt;
+    gpu_tiling.to_json(jgt);
+    ValidateSerialization(jgt, 1);
+    auto gpu_tiling2 = transformations::GPUTiling::from_json(f.builder, jgt);
+    ASSERT_EQ(gpu_tiling2.name(), gpu_tiling.name());
+
+    // KernelLocalStorage
+    symbolic::Expression offset = symbolic::integer(0);
+    transformations::KernelLocalStorage
+        kls(*static_cast<structured_control_flow::StructuredLoop*>(f.outer_map), offset, *f.access_A);
+    nlohmann::json jkls;
+    kls.to_json(jkls);
+    ValidateSerialization(jkls, 2);
+    auto kls2 = transformations::KernelLocalStorage::from_json(f.builder, jkls);
+    ASSERT_EQ(kls2.name(), kls.name());
+
+    // GPULoopReordering
+    transformations::GPULoopReordering reordering(*f.outer_map);
+    nlohmann::json jr;
+    reordering.to_json(jr);
+    ValidateSerialization(jr, 1);
+    auto reordering2 = transformations::GPULoopReordering::from_json(f.builder, jr);
+    ASSERT_EQ(reordering2.name(), reordering.name());
+
+    // GPUConditionPropagation
+    transformations::GPUConditionPropagation cond_prop(*f.outer_map);
+    nlohmann::json jcp;
+    cond_prop.to_json(jcp);
+    ValidateSerialization(jcp, 1);
+    auto cond_prop2 = transformations::GPUConditionPropagation::from_json(f.builder, jcp);
+    ASSERT_EQ(cond_prop2.name(), cond_prop.name());
+}
+
+TEST(TransformationSerializationTest, OtherScheduleTransformationsShape) {
+    LoopFixture f;
+
+    // OMPTransform
+    transformations::OMPTransform omp_t(*f.outer_map);
+    nlohmann::json jo;
+    omp_t.to_json(jo);
+    ValidateSerialization(jo, 1);
+    auto omp_t2 = transformations::OMPTransform::from_json(f.builder, jo);
+    ASSERT_EQ(omp_t2.name(), omp_t.name());
+
+    // HighwayTransform
+    transformations::HighwayTransform hw_t(*f.outer_map);
+    nlohmann::json jh;
+    hw_t.to_json(jh);
+    ValidateSerialization(jh, 1);
+    auto hw_t2 = transformations::HighwayTransform::from_json(f.builder, jh);
+    ASSERT_EQ(hw_t2.name(), hw_t.name());
+
+#ifdef DOCC_HAS_TARGET_TENSTORRENT
+    // TenstorrentTransform
+    sdfg::analysis::AnalysisManager analysis_manager(f.builder.subject());
+    tenstorrent::TenstorrentTransform tt_t(f.builder, analysis_manager, *f.outer_map);
+    nlohmann::json jtt;
+    tt_t.to_json(jtt);
+    ValidateSerialization(jtt, 1);
+    auto tt_t2 = tenstorrent::TenstorrentTransform::from_json(f.builder, analysis_manager, jtt);
+    ASSERT_EQ(tt_t2.name(), tt_t.name());
+#endif
+}
+
+} // namespace

--- a/python/bindings/transformations/py_transformations.cpp
+++ b/python/bindings/transformations/py_transformations.cpp
@@ -3,6 +3,7 @@
 #include <nlohmann/json.hpp>
 #include <sstream>
 
+#include <sdfg/data_flow/access_node.h>
 #include <sdfg/transformations/loop_distribute.h>
 #include <sdfg/transformations/loop_interchange.h>
 #include <sdfg/transformations/loop_skewing.h>
@@ -143,13 +144,13 @@ void register_transformations(py::module& m) {
     // OutLocalStorage transformation
     py::class_<OutLocalStorage, Transformation>(m, "OutLocalStorage")
         .def(
-            py::init<StructuredLoop&, std::string>(),
+            py::init<StructuredLoop&, const sdfg::data_flow::AccessNode&>(),
             py::arg("loop"),
-            py::arg("container"),
+            py::arg("access_node"),
             "Create an out-of-loop local storage transformation.\n\n"
             "Args:\n"
             "    loop: The loop to optimize\n"
-            "    container: The container name to extract to local storage"
+            "    access_node: The access node to extract to local storage"
         )
         .def("__repr__", [](const OutLocalStorage& t) {
             std::ostringstream oss;


### PR DESCRIPTION
- Adapts the constructor of InLocalStorage, OutLocalStorage, AccumulatorTile, and KernelLocalStorage to take an access node instead of a container
- Adapts GPUTiling to find all reads that are candidates for the KernelLocalStorage Transform instead of container
- Adapts all unit tests and the blocking tests to use the new interface

May change again once the IR is reworked, as access nodes will not exist in this form anymore. Information may be encapsulated in the loop node itself instead.