### PR TITLE
Modular Compile process

### DIFF
--- a/.github/workflows/unit_tests_macos.yml
+++ b/.github/workflows/unit_tests_macos.yml
@@ -10,10 +10,13 @@ on:
     - cron: "0 4 * * *"
 
 jobs:
-  cpp-tests-macos:
+  primary-tests-macos:
     runs-on:
       group: dahlia
       labels: macOS
+
+    env:
+      python_version: "3.14"
 
     steps:
       - uses: actions/checkout@v4
@@ -25,6 +28,19 @@ jobs:
           brew install ninja cmake
           brew install gmp isl nlohmann-json boost
           brew install highway libomp
+          brew install uv
+
+      - name: Set up Python ${{ env.python_version }}
+        run: |
+          uv python install ${{ env.python_version }}
+          uv venv --python ${{ env.python_version }} .venv
+          echo "$PWD/.venv/bin" >> $GITHUB_PATH
+          echo "PYTHONPATH=$PWD/python" >> $GITHUB_ENV
+
+      - name: Install Python dependencies
+        run: |
+          uv pip install pybind11 pytest coverage black==25.9.0 build scikit-build-core
+          uv pip install numpy scipy ml_dtypes
 
       - name: Build
         run: |
@@ -33,9 +49,11 @@ jobs:
           cmake \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
+            -DPYTHON_BUILD_FRONTEND=ON \
+            -Dpybind11_DIR=$GITHUB_WORKSPACE/.venv/lib/python${{ env.python_version }}/site-packages/pybind11/share/cmake/pybind11 \
             -DBUILD_TESTS:BOOL=OFF \
             -DBUILD_BENCHMARKS:BOOL=OFF \
-            -DBUILD_BENCHMARKS_GOOGLE:BOOL=OFF  \
+            -DBUILD_BENCHMARKS_GOOGLE:BOOL=OFF \
             ..
           ninja
 
@@ -51,6 +69,18 @@ jobs:
           cd build
           ./arg-capture-io/tests/capture_io_test
 
+      - name: Python Unit Tests
+        env:
+          DOCC_ACCESS_TOKEN: ${{ secrets.DOCC_CI_TOKEN }}
+        run: |
+          export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+          pytest -v python/tests
+
+      - name: Python Integration Tests
+        run: |
+          export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+          pytest -v python/benchmarks/
+
       # - name: Test RTL
       #   run: |
       #     export CPATH=/usr/local/include:$CPATH
@@ -63,51 +93,3 @@ jobs:
 
       #     cd rtl/tests
       #     pytest -v -s rtl_tests.py
-
-  python-tests-macos:
-    runs-on:
-      group: dahlia
-      labels: macOS
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.14"]
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install dependencies
-        run: |
-          brew install ninja cmake
-          brew install gmp isl nlohmann-json boost
-          brew install highway libomp
-          brew install uv
-
-      - name: Set up Python ${{ matrix.python-version }}
-        run: |
-          uv python install ${{ matrix.python-version }}
-          uv venv --python ${{ matrix.python-version }} .venv
-          echo "$PWD/.venv/bin" >> $GITHUB_PATH
-
-      - name: Install Python dependencies
-        run: |
-          uv pip install pybind11 pytest coverage black==25.9.0 build scikit-build-core
-          uv pip install numpy scipy ml_dtypes
-
-      - name: Build
-        run: |
-          uv pip install --no-build-isolation -v -e python/
-
-      - name: Unit Tests
-        env:
-          DOCC_ACCESS_TOKEN: ${{ secrets.DOCC_CI_TOKEN }}
-        run: |
-          export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-          pytest -v python/tests
-
-      - name: Integration Tests
-        run: |
-          export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-          pytest -v python/benchmarks/

--- a/c-compile/CMakeLists.txt
+++ b/c-compile/CMakeLists.txt
@@ -2,7 +2,9 @@
 
 set(SOURCE_FILES
     src/compile/codegen_build_pool.cpp
-    src/compile/file_compiler.cpp
+    src/compile/codegen_compiler.cpp
+    src/compile/src_file_compiler.cpp
+    src/compile/src_file_compiler_builder.cpp
     src/target/docc_target.cpp
     src/util/docc_paths.cpp
     src/util/offloading_instrumentation_plan.cpp

--- a/c-compile/CMakeLists.txt
+++ b/c-compile/CMakeLists.txt
@@ -1,6 +1,9 @@
 
 
 set(SOURCE_FILES
+    src/compile/codegen_build_pool.cpp
+    src/compile/file_compiler.cpp
+    src/target/docc_target.cpp
     src/util/docc_paths.cpp
     src/util/offloading_instrumentation_plan.cpp
     src/util/offloading_type_collector.cpp

--- a/c-compile/include/docc/compile/codegen_build_pool.h
+++ b/c-compile/include/docc/compile/codegen_build_pool.h
@@ -1,0 +1,104 @@
+#pragma once
+#include <list>
+#include <memory>
+
+#include "docc/util/docc_paths.h"
+#include "sdfg/codegen/code_generator.h"
+#include "sdfg/codegen/code_snippet_factory.h"
+#include "sdfg/structured_sdfg.h"
+
+namespace docc::compile {
+
+class CompileState;
+
+class CodegenCompiler {
+protected:
+    std::unordered_map<std::string, std::unique_ptr<CodegenCompiler>> redirects_;
+
+public:
+    CodegenCompiler() = default;
+    CodegenCompiler(std::unordered_map<std::string, std::unique_ptr<CodegenCompiler>>&& redirects);
+    virtual ~CodegenCompiler() = default;
+
+    std::unique_ptr<CompileState> create_compile(
+        const sdfg::StructuredSDFG& sdfg,
+        const sdfg::codegen::CodeSnippet* snippet,
+        std::function<void(std::ostream&)> generator
+    );
+
+    virtual std::unique_ptr<CompileState> do_create_compile(
+        const sdfg::StructuredSDFG& sdfg,
+        const sdfg::codegen::CodeSnippet* snippet,
+        std::function<void(std::ostream&)> generator
+    ) = 0;
+};
+
+class NoopCompiler : public CodegenCompiler {
+public:
+    NoopCompiler() = default;
+
+    std::unique_ptr<CompileState> do_create_compile(
+        const sdfg::StructuredSDFG& sdfg,
+        const sdfg::codegen::CodeSnippet* snippet,
+        std::function<void(std::ostream&)> generator
+    ) override;
+};
+
+template<typename T>
+class CodegenCompilerBuilderBase {
+protected:
+    std::unordered_map<std::string, std::unique_ptr<CodegenCompiler>> redirects_;
+    std::shared_ptr<util::DefaultDoccPaths> docc_paths_;
+
+public:
+    virtual ~CodegenCompilerBuilderBase() = default;
+
+
+    T& redirect_snippet(const std::string& ext, std::unique_ptr<CodegenCompiler> handler) {
+        redirects_[ext] = std::move(handler);
+        return *dynamic_cast<T*>(this);
+    }
+
+    virtual T& set_from_paths(std::shared_ptr<util::DefaultDoccPaths> paths) {
+        docc_paths_ = paths;
+        return *dynamic_cast<T*>(this);
+    }
+
+    const util::DefaultDoccPaths& docc_paths() const { return *docc_paths_; }
+};
+
+class CompileExecutor {
+public:
+    virtual ~CompileExecutor() = default;
+
+    virtual void add_compile_state(std::unique_ptr<CompileState> state) = 0;
+    virtual void await_compiles_finished() = 0;
+
+    virtual void for_each_src(std::function<void(CompileState&)> fn) = 0;
+};
+
+class CodegenBuildPool : public CompileExecutor {
+private:
+    std::vector<std::unique_ptr<CompileState>> srcs_;
+    std::mutex mutex_;
+    int num_threads_;
+    std::atomic_int outstanding_compiles_ = 0;
+
+public:
+    CodegenBuildPool(int num_threads);
+
+    void add_compile_state(std::unique_ptr<CompileState> state) override;
+    void await_compiles_finished() override;
+
+    void for_each_src(std::function<void(CompileState&)> fn) override;
+};
+
+class CompileState {
+public:
+    virtual ~CompileState() = default;
+    virtual bool codegen() = 0;
+    virtual bool compile() = 0;
+    [[nodiscard]] virtual CodegenCompiler& creator() const = 0;
+};
+
+} // namespace docc::compile

--- a/c-compile/include/docc/compile/codegen_build_pool.h
+++ b/c-compile/include/docc/compile/codegen_build_pool.h
@@ -5,70 +5,13 @@
 #include <queue>
 #include <thread>
 
+#include "docc/compile/codegen_compiler.h"
 #include "docc/util/docc_paths.h"
 #include "sdfg/codegen/code_generator.h"
 #include "sdfg/codegen/code_snippet_factory.h"
 #include "sdfg/structured_sdfg.h"
 
 namespace docc::compile {
-
-class CompileState;
-
-class CodegenCompiler {
-protected:
-    std::unordered_map<std::string, std::unique_ptr<CodegenCompiler>> redirects_;
-
-public:
-    CodegenCompiler() = default;
-    CodegenCompiler(std::unordered_map<std::string, std::unique_ptr<CodegenCompiler>>&& redirects);
-    virtual ~CodegenCompiler() = default;
-
-    std::unique_ptr<CompileState> create_compile(
-        const sdfg::StructuredSDFG& sdfg,
-        const sdfg::codegen::CodeSnippet* snippet,
-        std::function<void(std::ostream&)> generator
-    );
-
-    virtual std::unique_ptr<CompileState> do_create_compile(
-        const sdfg::StructuredSDFG& sdfg,
-        const sdfg::codegen::CodeSnippet* snippet,
-        std::function<void(std::ostream&)> generator
-    ) = 0;
-};
-
-class NoopCompiler : public CodegenCompiler {
-public:
-    NoopCompiler() = default;
-
-    std::unique_ptr<CompileState> do_create_compile(
-        const sdfg::StructuredSDFG& sdfg,
-        const sdfg::codegen::CodeSnippet* snippet,
-        std::function<void(std::ostream&)> generator
-    ) override;
-};
-
-template<typename T>
-class CodegenCompilerBuilderBase {
-protected:
-    std::unordered_map<std::string, std::unique_ptr<CodegenCompiler>> redirects_;
-    std::shared_ptr<util::DefaultDoccPaths> docc_paths_;
-
-public:
-    virtual ~CodegenCompilerBuilderBase() = default;
-
-
-    T& redirect_snippet(const std::string& ext, std::unique_ptr<CodegenCompiler> handler) {
-        redirects_[ext] = std::move(handler);
-        return *dynamic_cast<T*>(this);
-    }
-
-    virtual T& set_from_paths(std::shared_ptr<util::DefaultDoccPaths> paths) {
-        docc_paths_ = paths;
-        return *dynamic_cast<T*>(this);
-    }
-
-    const util::DefaultDoccPaths& docc_paths() const { return *docc_paths_; }
-};
 
 class CompileExecutor {
 public:
@@ -108,14 +51,6 @@ public:
     void for_each_src(std::function<void(CompileState&)> fn) override;
 
     bool is_parallel() override { return workers_.size() > 1; }
-};
-
-class CompileState {
-public:
-    virtual ~CompileState() = default;
-    virtual bool codegen() = 0;
-    virtual bool compile() = 0;
-    [[nodiscard]] virtual CodegenCompiler& creator() const = 0;
 };
 
 } // namespace docc::compile

--- a/c-compile/include/docc/compile/codegen_build_pool.h
+++ b/c-compile/include/docc/compile/codegen_build_pool.h
@@ -1,6 +1,9 @@
 #pragma once
+#include <condition_variable>
 #include <list>
 #include <memory>
+#include <queue>
+#include <thread>
 
 #include "docc/util/docc_paths.h"
 #include "sdfg/codegen/code_generator.h"
@@ -75,22 +78,36 @@ public:
     virtual void await_compiles_finished() = 0;
 
     virtual void for_each_src(std::function<void(CompileState&)> fn) = 0;
+
+    virtual bool is_parallel() = 0;
 };
 
 class CodegenBuildPool : public CompileExecutor {
 private:
     std::vector<std::unique_ptr<CompileState>> srcs_;
     std::mutex mutex_;
-    int num_threads_;
     std::atomic_int outstanding_compiles_ = 0;
+
+    // Thread pool members
+    std::vector<std::thread> workers_;
+    std::queue<CompileState*> work_queue_;
+    std::mutex queue_mutex_;
+    std::condition_variable queue_cv_;
+    std::condition_variable done_cv_;
+    bool stop_ = false;
+
+    void worker_loop();
 
 public:
     CodegenBuildPool(int num_threads);
+    ~CodegenBuildPool() override;
 
     void add_compile_state(std::unique_ptr<CompileState> state) override;
     void await_compiles_finished() override;
 
     void for_each_src(std::function<void(CompileState&)> fn) override;
+
+    bool is_parallel() override { return workers_.size() > 1; }
 };
 
 class CompileState {

--- a/c-compile/include/docc/compile/codegen_compiler.h
+++ b/c-compile/include/docc/compile/codegen_compiler.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <functional>
+#include <memory>
+#include <sdfg/codegen/code_snippet_factory.h>
+#include <sdfg/structured_sdfg.h>
+
+namespace docc::compile {
+
+class CodegenCompiler;
+
+class CompileState {
+public:
+    virtual ~CompileState() = default;
+    virtual bool codegen() = 0;
+    virtual bool compile() = 0;
+    [[nodiscard]] virtual CodegenCompiler& creator() const = 0;
+};
+
+class CodegenCompiler {
+public:
+    virtual ~CodegenCompiler() = default;
+
+    virtual std::unique_ptr<CompileState> create_compile(
+        const sdfg::StructuredSDFG& sdfg,
+        const sdfg::codegen::CodeSnippet* snippet,
+        std::function<void(std::ostream&)> generator
+    ) = 0;
+};
+
+class NoopCompiler : public CodegenCompiler {
+public:
+    NoopCompiler() = default;
+
+    std::unique_ptr<CompileState> create_compile(
+        const sdfg::StructuredSDFG& sdfg,
+        const sdfg::codegen::CodeSnippet* snippet,
+        std::function<void(std::ostream&)> generator
+    ) override;
+};
+
+} // namespace docc::compile

--- a/c-compile/include/docc/compile/file_compiler.h
+++ b/c-compile/include/docc/compile/file_compiler.h
@@ -58,7 +58,7 @@ class SrcFileCompiler : public CodegenCompiler {
     std::string main_header_ext_;
     std::string bin_ext_;
     bool link_immediately_;
-    sdfg::passes::CodegenStatistics* stats_;
+    sdfg::passes::CodegenStatistics* stats_ = nullptr;
 
     inline static constexpr auto COMPILE_ONLY_FLAG = "-c";
     inline static constexpr auto OUTPUT_FILE_ARG = "-o";
@@ -104,7 +104,9 @@ protected:
     bool run_compile_and_link_single(const std::filesystem::path& src, const std::filesystem::path& bin) const;
     std::filesystem::path emit_header(const sdfg::StructuredSDFG& sdfg, sdfg::codegen::CodeGenerator& generator);
     void for_each_file_snippet(
-        sdfg::codegen::CodeGenerator& generator, std::function<void(const sdfg::codegen::CodeSnippet&)> callback
+        sdfg::codegen::CodeGenerator& generator,
+        CompileExecutor& executor,
+        std::function<void(const sdfg::codegen::CodeSnippet&)> callback
     );
 };
 

--- a/c-compile/include/docc/compile/file_compiler.h
+++ b/c-compile/include/docc/compile/file_compiler.h
@@ -1,0 +1,145 @@
+#pragma once
+#include "docc/compile/codegen_build_pool.h"
+#include "docc/util/docc_paths.h"
+
+namespace docc::compile {
+
+class SrcFileCompiler;
+
+class FileCompileState : public CompileState {
+    friend class SrcFileCompiler;
+    SrcFileCompiler& compiler_;
+    std::filesystem::path src_path_;
+    std::filesystem::path out_path_;
+    bool link_immediately_;
+    std::function<void(std::ostream&)> generator_;
+
+    bool src_done_ = false;
+    bool obj_done_ = false;
+
+public:
+    FileCompileState(
+        SrcFileCompiler& compiler,
+        const std::filesystem::path& src_path,
+        const std::filesystem::path& obj_path,
+        bool link_immediately,
+        std::function<void(std::ostream&)>& generator
+    );
+
+    [[nodiscard]] CodegenCompiler& creator() const override;
+
+    bool codegen() override;
+    bool compile() override;
+
+    const std::filesystem::path& out_path() const;
+
+    bool has_obj_to_link() const;
+};
+
+class SrcFileCompiler : public CodegenCompiler {
+    friend class FileCompileState;
+
+    std::mutex mutex_;
+    std::filesystem::path output_dir_;
+    std::string compiler_;
+    std::optional<std::string> linker_;
+    std::string common_args_;
+    std::string compile_args_;
+    std::vector<std::filesystem::path> library_paths_;
+    std::vector<std::string> link_options_;
+    std::string main_src_ext_;
+    std::string main_header_ext_;
+    std::string bin_ext_;
+    bool link_immediately_;
+
+    inline static constexpr auto COMPILE_ONLY_FLAG = "-c";
+    inline static constexpr auto OUTPUT_FILE_ARG = "-o";
+
+public:
+    SrcFileCompiler(
+        const std::filesystem::path& output_dir,
+        const std::string& main_src_ext,
+        const std::string& main_header_ext,
+        const std::string& bin_ext,
+        const std::string& compiler,
+        const std::optional<std::string>& linker,
+        const std::string& common_args,
+        const std::string& compile_args,
+        const std::vector<std::filesystem::path>& library_paths,
+        const std::vector<std::string>& link_options,
+        bool link_immediately,
+        std::unordered_map<std::string, std::unique_ptr<CodegenCompiler>>&& redirects
+    );
+
+    std::unique_ptr<CompileState> do_create_compile(
+        const sdfg::StructuredSDFG& sdfg,
+        const sdfg::codegen::CodeSnippet* snippet,
+        std::function<void(std::ostream&)> generator
+    ) override;
+
+    std::filesystem::path
+    process(sdfg::codegen::CodeGenerator& generator, CompileExecutor& executor, const std::string& output_file_name);
+    std::filesystem::path process(sdfg::codegen::CodeGenerator& generator, CompileExecutor& executor) {
+        return process(generator, executor, generator.sdfg().name());
+    }
+
+    std::shared_ptr<sdfg::codegen::CodeSnippetFactory> create_snippet_factory(const sdfg::StructuredSDFG& sdfg) const;
+
+protected:
+    std::filesystem::path generate_header_path(const sdfg::StructuredSDFG& sdfg) const;
+    bool run_compiler(const std::filesystem::path& src, const std::filesystem::path& obj) const;
+
+    void add_link_args(std::stringstream& cmd) const;
+
+    bool run_link(const sdfg::StructuredSDFG& sdfg, CompileExecutor& executor, const std::filesystem::path& bin_file)
+        const;
+    bool run_compile_and_link_single(const std::filesystem::path& src, const std::filesystem::path& bin) const;
+    std::filesystem::path emit_header(const sdfg::StructuredSDFG& sdfg, sdfg::codegen::CodeGenerator& generator);
+    void for_each_file_snippet(
+        sdfg::codegen::CodeGenerator& generator, std::function<void(const sdfg::codegen::CodeSnippet&)> callback
+    );
+};
+
+class SrcFileCompilerBuilder : public CodegenCompilerBuilderBase<SrcFileCompilerBuilder> {
+    std::optional<std::filesystem::path> output_dir_;
+    std::optional<std::filesystem::path> compiler_;
+    std::optional<std::filesystem::path> linker_;
+    std::optional<std::string> main_src_ext_;
+    std::string bin_ext_ = "elf";
+    std::vector<std::string> common_options_;
+    std::vector<std::string> compile_options_;
+    std::vector<std::string> link_options_;
+    std::vector<std::filesystem::path> include_paths_;
+    std::vector<std::filesystem::path> library_paths_;
+    bool link_immediately_ = false;
+    std::vector<std::string> parent_link_options_;
+
+public:
+    SrcFileCompilerBuilder();
+
+    SrcFileCompilerBuilder& set_src_extension(const std::string& ext);
+    SrcFileCompilerBuilder& set_output_dir(const std::filesystem::path& output_dir);
+    SrcFileCompilerBuilder& add_compile_option(const std::string& opt);
+    SrcFileCompilerBuilder& add_link_option(const std::string& opt);
+    SrcFileCompilerBuilder& add_common_option(const std::string& opt);
+    SrcFileCompilerBuilder& add_include_path(const std::filesystem::path& path);
+    SrcFileCompilerBuilder& add_library_path(const std::filesystem::path& path);
+    SrcFileCompilerBuilder& set_compiler(const std::filesystem::path& compiler);
+    SrcFileCompilerBuilder& set_linker(const std::filesystem::path& linker);
+    SrcFileCompilerBuilder& set_from_paths(std::shared_ptr<util::DefaultDoccPaths> paths) override;
+    SrcFileCompilerBuilder& set_bin_extension(const std::string& ext);
+    SrcFileCompilerBuilder& inherit(const SrcFileCompilerBuilder& builder, bool compile_options = false);
+    /**
+     * There is only 1 source and no need to compile an object file and then link all object files.
+     * Fuse compile and link options. Expects the [compiler-executable] to be a gcc-like driver that can also handle
+     * linking
+     */
+    SrcFileCompilerBuilder& set_link_immediately(bool link_imm);
+    SrcFileCompilerBuilder& contribute_parent_link_options(const std::vector<std::string>& opts);
+
+    std::unique_ptr<SrcFileCompiler> build();
+
+    bool remove_compile_option(const std::string& opt);
+};
+
+} // namespace docc::compile

--- a/c-compile/include/docc/compile/file_compiler.h
+++ b/c-compile/include/docc/compile/file_compiler.h
@@ -9,6 +9,7 @@ class SrcFileCompiler;
 class FileCompileState : public CompileState {
     friend class SrcFileCompiler;
     SrcFileCompiler& compiler_;
+    const sdfg::codegen::CodeSnippet* snippet_;
     std::filesystem::path src_path_;
     std::filesystem::path out_path_;
     bool link_immediately_;
@@ -17,9 +18,13 @@ class FileCompileState : public CompileState {
     bool src_done_ = false;
     bool obj_done_ = false;
 
+    std::chrono::duration<std::chrono::milliseconds::rep, std::chrono::milliseconds::period> gen_time_;
+    std::chrono::duration<std::chrono::milliseconds::rep, std::chrono::milliseconds::period> build_time_;
+
 public:
     FileCompileState(
         SrcFileCompiler& compiler,
+        const sdfg::codegen::CodeSnippet* snippet,
         const std::filesystem::path& src_path,
         const std::filesystem::path& obj_path,
         bool link_immediately,
@@ -34,6 +39,8 @@ public:
     const std::filesystem::path& out_path() const;
 
     bool has_obj_to_link() const;
+
+    void record_stats(const sdfg::StructuredSDFG& sdfg, sdfg::passes::CodegenStatistics& stats);
 };
 
 class SrcFileCompiler : public CodegenCompiler {
@@ -51,6 +58,7 @@ class SrcFileCompiler : public CodegenCompiler {
     std::string main_header_ext_;
     std::string bin_ext_;
     bool link_immediately_;
+    sdfg::passes::CodegenStatistics* stats_;
 
     inline static constexpr auto COMPILE_ONLY_FLAG = "-c";
     inline static constexpr auto OUTPUT_FILE_ARG = "-o";

--- a/c-compile/include/docc/compile/src_file_compiler.h
+++ b/c-compile/include/docc/compile/src_file_compiler.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <docc/compile/codegen_compiler.h>
+
 #include "docc/compile/codegen_build_pool.h"
 #include "docc/util/docc_paths.h"
 
@@ -43,7 +45,12 @@ public:
     void record_stats(const sdfg::StructuredSDFG& sdfg, sdfg::passes::CodegenStatistics& stats);
 };
 
-class SrcFileCompiler : public CodegenCompiler {
+class LinkOptContributor {
+public:
+    virtual const std::vector<std::string>* get_contributed_link_options() const = 0;
+};
+
+class SrcFileCompiler : public CodegenCompiler, public LinkOptContributor {
     friend class FileCompileState;
 
     std::mutex mutex_;
@@ -58,6 +65,8 @@ class SrcFileCompiler : public CodegenCompiler {
     std::string main_header_ext_;
     std::string bin_ext_;
     bool link_immediately_;
+    std::unordered_map<std::string, std::unique_ptr<SrcFileCompiler>> redirects_;
+    std::vector<std::string> parent_link_opts_;
     sdfg::passes::CodegenStatistics* stats_ = nullptr;
 
     inline static constexpr auto COMPILE_ONLY_FLAG = "-c";
@@ -76,14 +85,21 @@ public:
         const std::vector<std::filesystem::path>& library_paths,
         const std::vector<std::string>& link_options,
         bool link_immediately,
-        std::unordered_map<std::string, std::unique_ptr<CodegenCompiler>>&& redirects
+        std::unordered_map<std::string, std::unique_ptr<SrcFileCompiler>>&& redirects,
+        const std::vector<std::string>& parent_link_options
     );
+
+    std::unique_ptr<CompileState> create_compile(
+        const sdfg::StructuredSDFG& sdfg,
+        const sdfg::codegen::CodeSnippet* snippet,
+        std::function<void(std::ostream&)> generator
+    ) override;
 
     std::unique_ptr<CompileState> do_create_compile(
         const sdfg::StructuredSDFG& sdfg,
         const sdfg::codegen::CodeSnippet* snippet,
         std::function<void(std::ostream&)> generator
-    ) override;
+    );
 
     std::filesystem::path
     process(sdfg::codegen::CodeGenerator& generator, CompileExecutor& executor, const std::string& output_file_name);
@@ -92,6 +108,8 @@ public:
     }
 
     std::shared_ptr<sdfg::codegen::CodeSnippetFactory> create_snippet_factory(const sdfg::StructuredSDFG& sdfg) const;
+
+    const std::vector<std::string>* get_contributed_link_options() const override;
 
 protected:
     std::filesystem::path generate_header_path(const sdfg::StructuredSDFG& sdfg) const;
@@ -108,48 +126,6 @@ protected:
         CompileExecutor& executor,
         std::function<void(const sdfg::codegen::CodeSnippet&)> callback
     );
-};
-
-class SrcFileCompilerBuilder : public CodegenCompilerBuilderBase<SrcFileCompilerBuilder> {
-    std::optional<std::filesystem::path> output_dir_;
-    std::optional<std::filesystem::path> compiler_;
-    std::optional<std::filesystem::path> linker_;
-    std::optional<std::string> main_src_ext_;
-    std::string bin_ext_ = "elf";
-    std::vector<std::string> common_options_;
-    std::vector<std::string> compile_options_;
-    std::vector<std::string> link_options_;
-    std::vector<std::filesystem::path> include_paths_;
-    std::vector<std::filesystem::path> library_paths_;
-    bool link_immediately_ = false;
-    std::vector<std::string> parent_link_options_;
-
-public:
-    SrcFileCompilerBuilder();
-
-    SrcFileCompilerBuilder& set_src_extension(const std::string& ext);
-    SrcFileCompilerBuilder& set_output_dir(const std::filesystem::path& output_dir);
-    SrcFileCompilerBuilder& add_compile_option(const std::string& opt);
-    SrcFileCompilerBuilder& add_link_option(const std::string& opt);
-    SrcFileCompilerBuilder& add_common_option(const std::string& opt);
-    SrcFileCompilerBuilder& add_include_path(const std::filesystem::path& path);
-    SrcFileCompilerBuilder& add_library_path(const std::filesystem::path& path);
-    SrcFileCompilerBuilder& set_compiler(const std::filesystem::path& compiler);
-    SrcFileCompilerBuilder& set_linker(const std::filesystem::path& linker);
-    SrcFileCompilerBuilder& set_from_paths(std::shared_ptr<util::DefaultDoccPaths> paths) override;
-    SrcFileCompilerBuilder& set_bin_extension(const std::string& ext);
-    SrcFileCompilerBuilder& inherit(const SrcFileCompilerBuilder& builder, bool compile_options = false);
-    /**
-     * There is only 1 source and no need to compile an object file and then link all object files.
-     * Fuse compile and link options. Expects the [compiler-executable] to be a gcc-like driver that can also handle
-     * linking
-     */
-    SrcFileCompilerBuilder& set_link_immediately(bool link_imm);
-    SrcFileCompilerBuilder& contribute_parent_link_options(const std::vector<std::string>& opts);
-
-    std::unique_ptr<SrcFileCompiler> build();
-
-    bool remove_compile_option(const std::string& opt);
 };
 
 } // namespace docc::compile

--- a/c-compile/include/docc/compile/src_file_compiler_builder.h
+++ b/c-compile/include/docc/compile/src_file_compiler_builder.h
@@ -1,0 +1,72 @@
+#pragma once
+#include "docc/util/docc_paths.h"
+
+namespace docc::compile {
+
+class SrcFileCompiler;
+
+template<typename T>
+class CodegenCompilerBuilderBase {
+protected:
+    std::shared_ptr<util::DefaultDoccPaths> docc_paths_;
+
+public:
+    virtual ~CodegenCompilerBuilderBase() = default;
+
+    virtual T& set_from_paths(std::shared_ptr<util::DefaultDoccPaths> paths) {
+        docc_paths_ = paths;
+        return *dynamic_cast<T*>(this);
+    }
+
+    const util::DefaultDoccPaths& docc_paths() const { return *docc_paths_; }
+};
+
+class SrcFileCompilerBuilder : public CodegenCompilerBuilderBase<SrcFileCompilerBuilder> {
+    std::optional<std::filesystem::path> output_dir_;
+    std::optional<std::filesystem::path> compiler_;
+    std::optional<std::filesystem::path> linker_;
+    std::optional<std::string> main_src_ext_;
+    std::string bin_ext_ = "elf";
+    std::vector<std::string> common_options_;
+    std::vector<std::string> compile_options_;
+    std::vector<std::string> link_options_;
+    std::vector<std::filesystem::path> include_paths_;
+    std::vector<std::filesystem::path> library_paths_;
+    bool link_immediately_ = false;
+    std::unordered_map<std::string, std::unique_ptr<SrcFileCompiler>> redirects_;
+    std::vector<std::string> parent_link_options_;
+
+public:
+    SrcFileCompilerBuilder();
+    ~SrcFileCompilerBuilder();
+
+    SrcFileCompilerBuilder(SrcFileCompilerBuilder&&) noexcept;
+    SrcFileCompilerBuilder& operator=(SrcFileCompilerBuilder&&) noexcept;
+
+    SrcFileCompilerBuilder& set_src_extension(const std::string& ext);
+    SrcFileCompilerBuilder& set_output_dir(const std::filesystem::path& output_dir);
+    SrcFileCompilerBuilder& add_compile_option(const std::string& opt);
+    SrcFileCompilerBuilder& add_link_option(const std::string& opt);
+    SrcFileCompilerBuilder& add_common_option(const std::string& opt);
+    SrcFileCompilerBuilder& add_include_path(const std::filesystem::path& path);
+    SrcFileCompilerBuilder& add_library_path(const std::filesystem::path& path);
+    SrcFileCompilerBuilder& set_compiler(const std::filesystem::path& compiler);
+    SrcFileCompilerBuilder& set_linker(const std::filesystem::path& linker);
+    SrcFileCompilerBuilder& set_from_paths(std::shared_ptr<util::DefaultDoccPaths> paths) override;
+    SrcFileCompilerBuilder& set_bin_extension(const std::string& ext);
+    SrcFileCompilerBuilder& inherit(const SrcFileCompilerBuilder& builder, bool compile_options = false);
+    /**
+     * There is only 1 source and no need to compile an object file and then link all object files.
+     * Fuse compile and link options. Expects the [compiler-executable] to be a gcc-like driver that can also handle
+     * linking
+     */
+    SrcFileCompilerBuilder& set_link_immediately(bool link_imm);
+    SrcFileCompilerBuilder& contribute_parent_link_options(const std::vector<std::string>& opts);
+    SrcFileCompilerBuilder& redirect_snippet(const std::string& ext, SrcFileCompilerBuilder sub_builder);
+
+    std::unique_ptr<SrcFileCompiler> build();
+
+    bool remove_compile_option(const std::string& opt);
+};
+
+} // namespace docc::compile

--- a/c-compile/include/docc/target/docc_target.h
+++ b/c-compile/include/docc/target/docc_target.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <string>
+
+#include "sdfg/plugins/plugins.h"
+#include "sdfg/plugins/targets.h"
+
+namespace docc::target {
+
+
+DoccTarget* get_target_handler(const std::string& target);
+
+bool add_highway_build_support(compile::SrcFileCompilerBuilder& builder);
+
+void register_builtin_targets(sdfg::plugins::Context& context);
+
+} // namespace docc::target

--- a/c-compile/include/docc/util/docc_paths.h
+++ b/c-compile/include/docc/util/docc_paths.h
@@ -4,6 +4,8 @@
 #include <optional>
 #include <vector>
 
+#include "sdfg/plugins/plugins.h"
+
 namespace docc::util {
 
 std::optional<std::filesystem::path> find_lib_location();
@@ -12,8 +14,8 @@ class DoccPaths {
 public:
     virtual ~DoccPaths() = default;
 
-    [[nodiscard]] virtual std::vector<std::filesystem::path> get_default_include_paths() = 0;
-    [[nodiscard]] virtual std::vector<std::filesystem::path> get_default_library_paths() = 0;
+    [[nodiscard]] virtual std::vector<std::filesystem::path> get_default_include_paths() const = 0;
+    [[nodiscard]] virtual std::vector<std::filesystem::path> get_default_library_paths() const = 0;
 };
 
 class DefaultDoccPaths : public DoccPaths {
@@ -34,12 +36,19 @@ public:
     DefaultDoccPaths(std::filesystem::path bin_root, std::filesystem::path src_root, DoccRootMode root_mode);
 
     const std::filesystem::path& bin_root() const { return bin_root_; }
+    const std::filesystem::path& src_root() const { return src_root_; }
+    DoccRootMode root_mode() const { return root_mode_; }
 
     static std::unique_ptr<DefaultDoccPaths> from_lib_location(std::optional<std::filesystem::path> lib_location);
 
-    std::vector<std::filesystem::path> get_default_include_paths() override;
-    std::vector<std::filesystem::path> get_default_library_paths() override;
-};
+    std::vector<std::filesystem::path> get_default_include_paths() const override;
+    std::vector<std::filesystem::path> get_default_library_paths() const override;
 
+    std::optional<std::filesystem::path> get_builtin_target_plugin_src_path(const std::string& plugin) const;
+    std::optional<std::filesystem::path> get_builtin_target_plugin_rt_lib_path(const std::string& plugin) const;
+    std::optional<std::filesystem::path> get_builtin_target_plugin_rt_include_path(const std::string& plugin) const;
+    std::optional<std::filesystem::path>
+    get_builtin_target_plugin_rt_libexec_src_path(const std::string& plugin, const std::string& rt_name) const;
+};
 
 } // namespace docc::util

--- a/c-compile/src/compile/codegen_build_pool.cpp
+++ b/c-compile/src/compile/codegen_build_pool.cpp
@@ -2,33 +2,6 @@
 
 namespace docc::compile {
 
-CodegenCompiler::CodegenCompiler(std::unordered_map<std::string, std::unique_ptr<CodegenCompiler>>&& redirects)
-    : redirects_(std::move(redirects)) {}
-
-std::unique_ptr<CompileState> CodegenCompiler::create_compile(
-    const sdfg::StructuredSDFG& sdfg,
-    const sdfg::codegen::CodeSnippet* snippet,
-    std::function<void(std::ostream&)> generator
-) {
-    if (snippet) {
-        auto& ext = snippet->extension();
-        auto it = redirects_.find(ext);
-        if (it != redirects_.end()) {
-            return it->second->do_create_compile(sdfg, snippet, generator);
-        }
-    }
-
-    return do_create_compile(sdfg, snippet, generator);
-}
-
-std::unique_ptr<CompileState> NoopCompiler::do_create_compile(
-    const sdfg::StructuredSDFG& sdfg,
-    const sdfg::codegen::CodeSnippet* snippet,
-    std::function<void(std::ostream&)> generator
-) {
-    return nullptr;
-}
-
 CodegenBuildPool::CodegenBuildPool(int num_threads) {
     if (num_threads > 1) {
         workers_.reserve(num_threads);

--- a/c-compile/src/compile/codegen_build_pool.cpp
+++ b/c-compile/src/compile/codegen_build_pool.cpp
@@ -29,32 +29,74 @@ std::unique_ptr<CompileState> NoopCompiler::do_create_compile(
     return nullptr;
 }
 
-CodegenBuildPool::CodegenBuildPool(int num_threads) : num_threads_(num_threads) {}
+CodegenBuildPool::CodegenBuildPool(int num_threads) {
+    if (num_threads > 1) {
+        workers_.reserve(num_threads);
+        for (int i = 0; i < num_threads; ++i) {
+            workers_.emplace_back(&CodegenBuildPool::worker_loop, this);
+        }
+    }
+}
+
+CodegenBuildPool::~CodegenBuildPool() {
+    {
+        std::lock_guard lock(queue_mutex_);
+        stop_ = true;
+    }
+    queue_cv_.notify_all();
+    for (auto& worker : workers_) {
+        if (worker.joinable()) {
+            worker.join();
+        }
+    }
+}
+
+void CodegenBuildPool::worker_loop() {
+    while (true) {
+        CompileState* task = nullptr;
+        {
+            std::unique_lock lock(queue_mutex_);
+            queue_cv_.wait(lock, [this] { return stop_ || !work_queue_.empty(); });
+            if (stop_ && work_queue_.empty()) {
+                return;
+            }
+            task = work_queue_.front();
+            work_queue_.pop();
+        }
+
+        task->codegen();
+        task->compile();
+
+        if (--outstanding_compiles_ == 0) {
+            done_cv_.notify_all();
+        }
+    }
+}
 
 void CodegenBuildPool::add_compile_state(std::unique_ptr<CompileState> state) {
     auto* ptr = state.get();
     {
         std::lock_guard lock(mutex_);
-
         srcs_.push_back(std::move(state));
         ++outstanding_compiles_;
     }
 
-    if (num_threads_ == 1) {
+    if (workers_.empty()) {
         ptr->codegen();
         ptr->compile();
         --outstanding_compiles_;
     } else {
-        throw std::runtime_error("parallel build not yet implemented");
+        {
+            std::lock_guard lock(queue_mutex_);
+            work_queue_.push(ptr);
+        }
+        queue_cv_.notify_one();
     }
 }
 
 void CodegenBuildPool::await_compiles_finished() {
-    int outstanding = outstanding_compiles_.load();
-    while (outstanding > 0) {
-        outstanding_compiles_.wait(outstanding);
-        outstanding = outstanding_compiles_.load();
-    }
+    std::unique_lock lock(queue_mutex_);
+    done_cv_.wait(lock, [this] { return outstanding_compiles_.load() == 0; });
 }
 
 void CodegenBuildPool::for_each_src(std::function<void(CompileState&)> fn) {

--- a/c-compile/src/compile/codegen_build_pool.cpp
+++ b/c-compile/src/compile/codegen_build_pool.cpp
@@ -1,0 +1,68 @@
+#include "docc/compile/codegen_build_pool.h"
+
+namespace docc::compile {
+
+CodegenCompiler::CodegenCompiler(std::unordered_map<std::string, std::unique_ptr<CodegenCompiler>>&& redirects)
+    : redirects_(std::move(redirects)) {}
+
+std::unique_ptr<CompileState> CodegenCompiler::create_compile(
+    const sdfg::StructuredSDFG& sdfg,
+    const sdfg::codegen::CodeSnippet* snippet,
+    std::function<void(std::ostream&)> generator
+) {
+    if (snippet) {
+        auto& ext = snippet->extension();
+        auto it = redirects_.find(ext);
+        if (it != redirects_.end()) {
+            return it->second->do_create_compile(sdfg, snippet, generator);
+        }
+    }
+
+    return do_create_compile(sdfg, snippet, generator);
+}
+
+std::unique_ptr<CompileState> NoopCompiler::do_create_compile(
+    const sdfg::StructuredSDFG& sdfg,
+    const sdfg::codegen::CodeSnippet* snippet,
+    std::function<void(std::ostream&)> generator
+) {
+    return nullptr;
+}
+
+CodegenBuildPool::CodegenBuildPool(int num_threads) : num_threads_(num_threads) {}
+
+void CodegenBuildPool::add_compile_state(std::unique_ptr<CompileState> state) {
+    auto* ptr = state.get();
+    {
+        std::lock_guard lock(mutex_);
+
+        srcs_.push_back(std::move(state));
+        ++outstanding_compiles_;
+    }
+
+    if (num_threads_ == 1) {
+        ptr->codegen();
+        ptr->compile();
+        --outstanding_compiles_;
+    } else {
+        throw std::runtime_error("parallel build not yet implemented");
+    }
+}
+
+void CodegenBuildPool::await_compiles_finished() {
+    int outstanding = outstanding_compiles_.load();
+    while (outstanding > 0) {
+        outstanding_compiles_.wait(outstanding);
+        outstanding = outstanding_compiles_.load();
+    }
+}
+
+void CodegenBuildPool::for_each_src(std::function<void(CompileState&)> fn) {
+    std::lock_guard lock(mutex_);
+
+    for (auto& src : srcs_) {
+        fn(*src);
+    }
+}
+
+} // namespace docc::compile

--- a/c-compile/src/compile/codegen_compiler.cpp
+++ b/c-compile/src/compile/codegen_compiler.cpp
@@ -1,0 +1,13 @@
+#include "docc/compile/codegen_compiler.h"
+
+namespace docc::compile {
+
+std::unique_ptr<CompileState> NoopCompiler::create_compile(
+    const sdfg::StructuredSDFG& sdfg,
+    const sdfg::codegen::CodeSnippet* snippet,
+    std::function<void(std::ostream&)> generator
+) {
+    return nullptr;
+}
+
+} // namespace docc::compile

--- a/c-compile/src/compile/file_compiler.cpp
+++ b/c-compile/src/compile/file_compiler.cpp
@@ -6,34 +6,41 @@ namespace docc::compile {
 
 FileCompileState::FileCompileState(
     SrcFileCompiler& compiler,
+    const sdfg::codegen::CodeSnippet* snippet,
     const std::filesystem::path& src_path,
     const std::filesystem::path& out_path,
     bool link_immediately,
     std::function<void(std::ostream&)>& generator
 )
-    : CompileState(), compiler_(compiler), src_path_(src_path), out_path_(out_path),
+    : CompileState(), compiler_(compiler), snippet_(snippet), src_path_(src_path), out_path_(out_path),
       link_immediately_(link_immediately), generator_(generator), src_done_(generator == nullptr) {}
 
 CodegenCompiler& FileCompileState::creator() const { return compiler_; }
 
 bool FileCompileState::codegen() {
     if (generator_) {
+        std::chrono::high_resolution_clock::time_point start = std::chrono::high_resolution_clock::now();
         std::ofstream outfile(src_path_, std::ofstream::out | std::ofstream::trunc);
 
         generator_(outfile);
 
         outfile.close();
+        std::chrono::high_resolution_clock::time_point end = std::chrono::high_resolution_clock::now();
         src_done_ = true;
+        gen_time_ = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
     }
     return true;
 }
 
 bool FileCompileState::compile() {
+    std::chrono::high_resolution_clock::time_point start = std::chrono::high_resolution_clock::now();
     auto success = link_immediately_ ? compiler_.run_compile_and_link_single(src_path_, out_path_)
                                      : compiler_.run_compiler(src_path_, out_path_);
+    std::chrono::high_resolution_clock::time_point end = std::chrono::high_resolution_clock::now();
     if (success) {
         obj_done_ = true;
     }
+    build_time_ = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
     return success;
 }
@@ -41,6 +48,14 @@ bool FileCompileState::compile() {
 const std::filesystem::path& FileCompileState::out_path() const { return out_path_; }
 
 bool FileCompileState::has_obj_to_link() const { return !link_immediately_; }
+
+void FileCompileState::record_stats(const sdfg::StructuredSDFG& sdfg, sdfg::passes::CodegenStatistics& stats) {
+    auto name = snippet_ ? sdfg.name() + ":" + snippet_->name() + "." + snippet_->extension() : sdfg.name();
+    stats.add_codegen(name + "@gen", gen_time_.count());
+
+    auto build_name = name + (link_immediately_ ? "@build" : "@compile");
+    stats.add_codegen(name, build_time_.count());
+}
 
 SrcFileCompiler::SrcFileCompiler(
     const std::filesystem::path& output_dir,
@@ -59,7 +74,12 @@ SrcFileCompiler::SrcFileCompiler(
     : CodegenCompiler(std::move(redirects)), output_dir_(output_dir), main_src_ext_(main_src_ext),
       main_header_ext_(main_header_ext), bin_ext_(bin_ext), compiler_(compiler), linker_(linker),
       common_args_(common_args), compile_args_(compile_args), library_paths_(library_paths),
-      link_options_(link_options), link_immediately_(link_immediately) {}
+      link_options_(link_options), link_immediately_(link_immediately) {
+    auto& codegen_statistics = sdfg::passes::CodegenStatistics::instance();
+    if (codegen_statistics.enabled()) {
+        stats_ = &codegen_statistics;
+    }
+}
 
 std::filesystem::path SrcFileCompiler::
     emit_header(const sdfg::StructuredSDFG& sdfg, sdfg::codegen::CodeGenerator& generator) {
@@ -90,7 +110,12 @@ std::unique_ptr<CompileState> SrcFileCompiler::do_create_compile(
     const std::string& out_ext = (link_immediately_ ? bin_ext_ : "o");
 
     auto state = std::make_unique<FileCompileState>(
-        *this, output_dir_ / (*name + "." + *ext), output_dir_ / (*name + "." + out_ext), link_immediately_, generator
+        *this,
+        snippet,
+        output_dir_ / (*name + "." + *ext),
+        output_dir_ / (*name + "." + out_ext),
+        link_immediately_,
+        generator
     );
 
     return std::move(state);
@@ -200,6 +225,9 @@ bool SrcFileCompiler::
     executor.for_each_src([&](CompileState& state) {
         auto& file_state = dynamic_cast<FileCompileState&>(state);
         if (file_state.has_obj_to_link()) {
+            if (stats_) {
+                file_state.record_stats(sdfg, *stats_);
+            }
             assert(file_state.obj_done_);
             cmd << file_state.out_path_ << " ";
         }
@@ -210,9 +238,16 @@ bool SrcFileCompiler::
     cmd << "-o " << bin_file;
 
     DEBUG_PRINTLN("Link: " << cmd.str());
+    std::chrono::high_resolution_clock::time_point start = std::chrono::high_resolution_clock::now();
     int ret = std::system(cmd.str().c_str());
+    std::chrono::high_resolution_clock::time_point end = std::chrono::high_resolution_clock::now();
     if (ret != 0) {
         throw std::runtime_error("Link failed: " + cmd.str());
+    }
+    if (stats_) {
+        stats_->add_codegen(
+            sdfg.name() + "@link", std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()
+        );
     }
 
     return true;

--- a/c-compile/src/compile/file_compiler.cpp
+++ b/c-compile/src/compile/file_compiler.cpp
@@ -139,8 +139,14 @@ std::shared_ptr<sdfg::codegen::CodeSnippetFactory> SrcFileCompiler::create_snipp
  * generation completed, so we do not need to do any of that.
  */
 void SrcFileCompiler::for_each_file_snippet(
-    sdfg::codegen::CodeGenerator& generator, std::function<void(const sdfg::codegen::CodeSnippet&)> callback
+    sdfg::codegen::CodeGenerator& generator,
+    CompileExecutor& executor,
+    std::function<void(const sdfg::codegen::CodeSnippet&)> callback
 ) {
+    // for now, the snippets do not arrive asynchronously, so we need to await the main-dispatch here, before the
+    // snippets will exist
+    executor.await_compiles_finished();
+
     for (auto& [id, snippet] : generator.library_snippets()) {
         if (snippet.is_as_file()) {
             callback(snippet);
@@ -159,13 +165,22 @@ std::filesystem::path SrcFileCompiler::
 
     executor.add_compile_state(std::move(mainCompile));
 
-    for_each_file_snippet(generator, [&](const sdfg::codegen::CodeSnippet& snippet) {
+    std::chrono::high_resolution_clock::time_point start = std::chrono::high_resolution_clock::now();
+    for_each_file_snippet(generator, executor, [&](const sdfg::codegen::CodeSnippet& snippet) {
         auto compile_state = create_compile(sdfg, &snippet, [&](std::ostream& out) { out << snippet.stream().str(); });
 
         executor.add_compile_state(std::move(compile_state));
     });
 
     executor.await_compiles_finished();
+    std::chrono::high_resolution_clock::time_point end = std::chrono::high_resolution_clock::now();
+    if (stats_) {
+        std::string name = "snippet_build_total";
+        if (executor.is_parallel()) {
+            name += "@parallel";
+        }
+        stats_->add_codegen(name, std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
+    }
 
     std::filesystem::path bin_file = output_dir_ / (output_file_name + "." + bin_ext_);
 

--- a/c-compile/src/compile/file_compiler.cpp
+++ b/c-compile/src/compile/file_compiler.cpp
@@ -1,0 +1,348 @@
+#include "docc/compile/file_compiler.h"
+
+#include "docc/util/docc_paths.h"
+
+namespace docc::compile {
+
+FileCompileState::FileCompileState(
+    SrcFileCompiler& compiler,
+    const std::filesystem::path& src_path,
+    const std::filesystem::path& out_path,
+    bool link_immediately,
+    std::function<void(std::ostream&)>& generator
+)
+    : CompileState(), compiler_(compiler), src_path_(src_path), out_path_(out_path),
+      link_immediately_(link_immediately), generator_(generator), src_done_(generator == nullptr) {}
+
+CodegenCompiler& FileCompileState::creator() const { return compiler_; }
+
+bool FileCompileState::codegen() {
+    if (generator_) {
+        std::ofstream outfile(src_path_, std::ofstream::out | std::ofstream::trunc);
+
+        generator_(outfile);
+
+        outfile.close();
+        src_done_ = true;
+    }
+    return true;
+}
+
+bool FileCompileState::compile() {
+    auto success = link_immediately_ ? compiler_.run_compile_and_link_single(src_path_, out_path_)
+                                     : compiler_.run_compiler(src_path_, out_path_);
+    if (success) {
+        obj_done_ = true;
+    }
+
+    return success;
+}
+
+const std::filesystem::path& FileCompileState::out_path() const { return out_path_; }
+
+bool FileCompileState::has_obj_to_link() const { return !link_immediately_; }
+
+SrcFileCompiler::SrcFileCompiler(
+    const std::filesystem::path& output_dir,
+    const std::string& main_src_ext,
+    const std::string& main_header_ext,
+    const std::string& bin_ext,
+    const std::string& compiler,
+    const std::optional<std::string>& linker,
+    const std::string& common_args,
+    const std::string& compile_args,
+    const std::vector<std::filesystem::path>& library_paths,
+    const std::vector<std::string>& link_options,
+    bool link_immediately,
+    std::unordered_map<std::string, std::unique_ptr<CodegenCompiler>>&& redirects
+)
+    : CodegenCompiler(std::move(redirects)), output_dir_(output_dir), main_src_ext_(main_src_ext),
+      main_header_ext_(main_header_ext), bin_ext_(bin_ext), compiler_(compiler), linker_(linker),
+      common_args_(common_args), compile_args_(compile_args), library_paths_(library_paths),
+      link_options_(link_options), link_immediately_(link_immediately) {}
+
+std::filesystem::path SrcFileCompiler::
+    emit_header(const sdfg::StructuredSDFG& sdfg, sdfg::codegen::CodeGenerator& generator) {
+    auto p = generate_header_path(sdfg);
+    std::ofstream header_file(p, std::ofstream::out | std::ofstream::trunc);
+    sdfg::codegen::PrettyPrinter os(header_file);
+    generator.emit_header(os);
+
+    header_file.close();
+
+    return p;
+}
+
+std::unique_ptr<CompileState> SrcFileCompiler::do_create_compile(
+    const sdfg::StructuredSDFG& sdfg,
+    const sdfg::codegen::CodeSnippet* snippet,
+    std::function<void(std::ostream&)> generator
+) {
+    const std::string* name;
+    const std::string* ext;
+    if (snippet) {
+        name = &snippet->name();
+        ext = &snippet->extension();
+    } else {
+        name = &sdfg.name();
+        ext = &main_src_ext_;
+    }
+    const std::string& out_ext = (link_immediately_ ? bin_ext_ : "o");
+
+    auto state = std::make_unique<FileCompileState>(
+        *this, output_dir_ / (*name + "." + *ext), output_dir_ / (*name + "." + out_ext), link_immediately_, generator
+    );
+
+    return std::move(state);
+}
+
+std::filesystem::path SrcFileCompiler::generate_header_path(const sdfg::StructuredSDFG& sdfg) const {
+    auto header_path = output_dir_ / (sdfg.name() + "." + main_header_ext_);
+    return header_path;
+}
+
+std::shared_ptr<sdfg::codegen::CodeSnippetFactory> SrcFileCompiler::create_snippet_factory(const sdfg::StructuredSDFG&
+                                                                                               sdfg) const {
+    auto header_path = generate_header_path(sdfg);
+    std::pair<std::filesystem::path, std::filesystem::path> lib_config = std::make_pair(output_dir_, header_path);
+    return std::make_shared<sdfg::codegen::CodeSnippetFactory>(&lib_config);
+}
+
+/**
+ * this is to hide library snippet handling. In the future we want this to support asynchronously delivering finished
+ * snippets, so we can compile them as soon as possible. But right now, they are all available after the main code
+ * generation completed, so we do not need to do any of that.
+ */
+void SrcFileCompiler::for_each_file_snippet(
+    sdfg::codegen::CodeGenerator& generator, std::function<void(const sdfg::codegen::CodeSnippet&)> callback
+) {
+    for (auto& [id, snippet] : generator.library_snippets()) {
+        if (snippet.is_as_file()) {
+            callback(snippet);
+        }
+    }
+}
+
+std::filesystem::path SrcFileCompiler::
+    process(sdfg::codegen::CodeGenerator& generator, CompileExecutor& executor, const std::string& output_file_name) {
+    auto& sdfg = generator.sdfg();
+    auto header_path = emit_header(sdfg, generator);
+
+    auto mainCompile = create_compile(sdfg, nullptr, [&](std::ostream& out) {
+        generator.emit_main_source(out, header_path);
+    });
+
+    executor.add_compile_state(std::move(mainCompile));
+
+    for_each_file_snippet(generator, [&](const sdfg::codegen::CodeSnippet& snippet) {
+        auto compile_state = create_compile(sdfg, &snippet, [&](std::ostream& out) { out << snippet.stream().str(); });
+
+        executor.add_compile_state(std::move(compile_state));
+    });
+
+    executor.await_compiles_finished();
+
+    std::filesystem::path bin_file = output_dir_ / (output_file_name + "." + bin_ext_);
+
+    run_link(sdfg, executor, bin_file);
+
+    return bin_file;
+}
+
+bool SrcFileCompiler::run_compiler(const std::filesystem::path& src, const std::filesystem::path& obj) const {
+    std::stringstream cmd;
+
+    cmd << compiler_ << " " << COMPILE_ONLY_FLAG << " " << common_args_ << " " << compile_args_ << " " << src << " "
+        << OUTPUT_FILE_ARG << " " << obj;
+
+    DEBUG_PRINTLN("Compile: " << cmd.str());
+    int ret = std::system(cmd.str().c_str());
+    if (ret != 0) {
+        throw std::runtime_error("Compilation failed: " + cmd.str());
+    }
+    return true;
+}
+
+bool SrcFileCompiler::run_compile_and_link_single(const std::filesystem::path& src, const std::filesystem::path& bin)
+    const {
+    std::stringstream cmd;
+
+    cmd << compiler_ << " " << common_args_ << " " << compile_args_ << " ";
+    cmd << src << " -o " << bin << " ";
+    add_link_args(cmd);
+
+    DEBUG_PRINTLN("Build: " << cmd.str());
+    int ret = std::system(cmd.str().c_str());
+    if (ret != 0) {
+        throw std::runtime_error("Build failed: " + cmd.str());
+    }
+
+    return true;
+}
+
+void SrcFileCompiler::add_link_args(std::stringstream& cmd) const {
+    for (auto& ld : this->library_paths_) {
+        cmd << "-L " << ld << " ";
+    }
+    for (auto& option : this->link_options_) {
+        cmd << option << " ";
+    }
+}
+
+bool SrcFileCompiler::
+    run_link(const sdfg::StructuredSDFG& sdfg, CompileExecutor& executor, const std::filesystem::path& bin_file) const {
+    std::stringstream cmd;
+
+    cmd << linker_.value_or(compiler_) << " ";
+
+    cmd << common_args_ << " ";
+
+    executor.for_each_src([&](CompileState& state) {
+        auto& file_state = dynamic_cast<FileCompileState&>(state);
+        if (file_state.has_obj_to_link()) {
+            assert(file_state.obj_done_);
+            cmd << file_state.out_path_ << " ";
+        }
+    });
+
+    add_link_args(cmd);
+
+    cmd << "-o " << bin_file;
+
+    DEBUG_PRINTLN("Link: " << cmd.str());
+    int ret = std::system(cmd.str().c_str());
+    if (ret != 0) {
+        throw std::runtime_error("Link failed: " + cmd.str());
+    }
+
+    return true;
+}
+
+SrcFileCompilerBuilder::SrcFileCompilerBuilder() {}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_src_extension(const std::string& ext) {
+    main_src_ext_ = ext;
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_output_dir(const std::filesystem::path& out) {
+    output_dir_ = out;
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::add_compile_option(const std::string& opt) {
+    compile_options_.push_back(opt);
+    return *this;
+}
+
+bool SrcFileCompilerBuilder::remove_compile_option(const std::string& opt) {
+    auto it = std::find(compile_options_.begin(), compile_options_.end(), opt);
+    if (it != compile_options_.end()) {
+        compile_options_.erase(it);
+        return true;
+    }
+    return false;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_link_immediately(bool link_imm) {
+    link_immediately_ = link_imm;
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::add_link_option(const std::string& opt) {
+    link_options_.push_back(opt);
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::add_common_option(const std::string& opt) {
+    common_options_.push_back(opt);
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::add_include_path(const std::filesystem::path& path) {
+    include_paths_.push_back(path);
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::add_library_path(const std::filesystem::path& path) {
+    library_paths_.push_back(path);
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_compiler(const std::filesystem::path& compiler) {
+    compiler_ = compiler;
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_linker(const std::filesystem::path& linker) {
+    linker_ = linker;
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_from_paths(std::shared_ptr<util::DefaultDoccPaths> paths) {
+    auto incs = paths->get_default_include_paths();
+    include_paths_.insert(include_paths_.end(), incs.cbegin(), incs.cend());
+    auto libs = paths->get_default_library_paths();
+    library_paths_.insert(library_paths_.end(), libs.cbegin(), libs.cend());
+    return CodegenCompilerBuilderBase::set_from_paths(paths);
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::inherit(const SrcFileCompilerBuilder& builder, bool compile_options) {
+    output_dir_ = builder.output_dir_;
+    compiler_ = builder.compiler_;
+    docc_paths_ = builder.docc_paths_;
+
+    if (compile_options) {
+        main_src_ext_ = builder.main_src_ext_;
+        include_paths_.insert(include_paths_.end(), builder.include_paths_.cbegin(), builder.include_paths_.cend());
+        common_options_.insert(common_options_.end(), builder.common_options_.cbegin(), builder.common_options_.cend());
+        compile_options_
+            .insert(compile_options_.end(), builder.compile_options_.cbegin(), builder.compile_options_.cend());
+    }
+
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_bin_extension(const std::string& ext) {
+    bin_ext_ = ext;
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::contribute_parent_link_options(const std::vector<std::string>& opts) {
+    parent_link_options_.insert(parent_link_options_.end(), opts.cbegin(), opts.cend());
+    return *this;
+}
+
+std::unique_ptr<SrcFileCompiler> SrcFileCompilerBuilder::build() {
+    std::string compiler = this->compiler_.value();
+    std::stringstream compiler_args;
+    std::stringstream common_args;
+
+    for (auto& inc : this->include_paths_) {
+        compiler_args << "-I " << inc << " ";
+    }
+    for (auto& option : this->compile_options_) {
+        compiler_args << option << " ";
+    }
+    for (auto& option : this->common_options_) {
+        common_args << option << " ";
+    }
+
+    return std::make_unique<SrcFileCompiler>(
+        output_dir_.value(),
+        main_src_ext_.value(),
+        "h",
+        bin_ext_,
+        compiler,
+        this->linker_,
+        common_args.str(),
+        compiler_args.str(),
+        library_paths_,
+        link_options_,
+        link_immediately_,
+        std::move(this->redirects_)
+    );
+}
+
+
+} // namespace docc::compile

--- a/c-compile/src/compile/src_file_compiler.cpp
+++ b/c-compile/src/compile/src_file_compiler.cpp
@@ -1,4 +1,4 @@
-#include "docc/compile/file_compiler.h"
+#include "docc/compile/src_file_compiler.h"
 
 #include "docc/util/docc_paths.h"
 
@@ -69,12 +69,13 @@ SrcFileCompiler::SrcFileCompiler(
     const std::vector<std::filesystem::path>& library_paths,
     const std::vector<std::string>& link_options,
     bool link_immediately,
-    std::unordered_map<std::string, std::unique_ptr<CodegenCompiler>>&& redirects
+    std::unordered_map<std::string, std::unique_ptr<SrcFileCompiler>>&& redirects,
+    const std::vector<std::string>& parent_link_options
 )
-    : CodegenCompiler(std::move(redirects)), output_dir_(output_dir), main_src_ext_(main_src_ext),
-      main_header_ext_(main_header_ext), bin_ext_(bin_ext), compiler_(compiler), linker_(linker),
-      common_args_(common_args), compile_args_(compile_args), library_paths_(library_paths),
-      link_options_(link_options), link_immediately_(link_immediately) {
+    : output_dir_(output_dir), main_src_ext_(main_src_ext), main_header_ext_(main_header_ext), bin_ext_(bin_ext),
+      compiler_(compiler), linker_(linker), common_args_(common_args), compile_args_(compile_args),
+      library_paths_(library_paths), link_options_(link_options), link_immediately_(link_immediately),
+      redirects_(std::move(redirects)), parent_link_opts_(parent_link_options) {
     auto& codegen_statistics = sdfg::passes::CodegenStatistics::instance();
     if (codegen_statistics.enabled()) {
         stats_ = &codegen_statistics;
@@ -91,6 +92,22 @@ std::filesystem::path SrcFileCompiler::
     header_file.close();
 
     return p;
+}
+
+std::unique_ptr<CompileState> SrcFileCompiler::create_compile(
+    const sdfg::StructuredSDFG& sdfg,
+    const sdfg::codegen::CodeSnippet* snippet,
+    std::function<void(std::ostream&)> generator
+) {
+    if (snippet) {
+        auto& ext = snippet->extension();
+        auto it = redirects_.find(ext);
+        if (it != redirects_.end()) {
+            return it->second->do_create_compile(sdfg, snippet, generator);
+        }
+    }
+
+    return do_create_compile(sdfg, snippet, generator);
 }
 
 std::unique_ptr<CompileState> SrcFileCompiler::do_create_compile(
@@ -237,6 +254,9 @@ bool SrcFileCompiler::
 
     cmd << common_args_ << " ";
 
+    std::unordered_map<LinkOptContributor*, int> sub_counts;
+    std::vector<std::string> sub_opts;
+
     executor.for_each_src([&](CompileState& state) {
         auto& file_state = dynamic_cast<FileCompileState&>(state);
         if (file_state.has_obj_to_link()) {
@@ -245,10 +265,25 @@ bool SrcFileCompiler::
             }
             assert(file_state.obj_done_);
             cmd << file_state.out_path_ << " ";
+
+            auto* possible_contrib = dynamic_cast<LinkOptContributor*>(&file_state.creator());
+            if (possible_contrib) {
+                auto& count = sub_counts[possible_contrib];
+                if (count == 0) {
+                    auto* contrib_opts = possible_contrib->get_contributed_link_options();
+                    if (contrib_opts) {
+                        sub_opts.insert(sub_opts.end(), contrib_opts->cbegin(), contrib_opts->cend());
+                    }
+                }
+                ++count;
+            }
         }
     });
 
     add_link_args(cmd);
+    for (auto& opt : sub_opts) {
+        cmd << opt << " ";
+    }
 
     cmd << "-o " << bin_file;
 
@@ -268,131 +303,12 @@ bool SrcFileCompiler::
     return true;
 }
 
-SrcFileCompilerBuilder::SrcFileCompilerBuilder() {}
-
-SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_src_extension(const std::string& ext) {
-    main_src_ext_ = ext;
-    return *this;
-}
-
-SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_output_dir(const std::filesystem::path& out) {
-    output_dir_ = out;
-    return *this;
-}
-
-SrcFileCompilerBuilder& SrcFileCompilerBuilder::add_compile_option(const std::string& opt) {
-    compile_options_.push_back(opt);
-    return *this;
-}
-
-bool SrcFileCompilerBuilder::remove_compile_option(const std::string& opt) {
-    auto it = std::find(compile_options_.begin(), compile_options_.end(), opt);
-    if (it != compile_options_.end()) {
-        compile_options_.erase(it);
-        return true;
+const std::vector<std::string>* SrcFileCompiler::get_contributed_link_options() const {
+    if (parent_link_opts_.empty()) {
+        return nullptr;
+    } else {
+        return &parent_link_opts_;
     }
-    return false;
 }
-
-SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_link_immediately(bool link_imm) {
-    link_immediately_ = link_imm;
-    return *this;
-}
-
-SrcFileCompilerBuilder& SrcFileCompilerBuilder::add_link_option(const std::string& opt) {
-    link_options_.push_back(opt);
-    return *this;
-}
-
-SrcFileCompilerBuilder& SrcFileCompilerBuilder::add_common_option(const std::string& opt) {
-    common_options_.push_back(opt);
-    return *this;
-}
-
-SrcFileCompilerBuilder& SrcFileCompilerBuilder::add_include_path(const std::filesystem::path& path) {
-    include_paths_.push_back(path);
-    return *this;
-}
-
-SrcFileCompilerBuilder& SrcFileCompilerBuilder::add_library_path(const std::filesystem::path& path) {
-    library_paths_.push_back(path);
-    return *this;
-}
-
-SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_compiler(const std::filesystem::path& compiler) {
-    compiler_ = compiler;
-    return *this;
-}
-
-SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_linker(const std::filesystem::path& linker) {
-    linker_ = linker;
-    return *this;
-}
-
-SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_from_paths(std::shared_ptr<util::DefaultDoccPaths> paths) {
-    auto incs = paths->get_default_include_paths();
-    include_paths_.insert(include_paths_.end(), incs.cbegin(), incs.cend());
-    auto libs = paths->get_default_library_paths();
-    library_paths_.insert(library_paths_.end(), libs.cbegin(), libs.cend());
-    return CodegenCompilerBuilderBase::set_from_paths(paths);
-}
-
-SrcFileCompilerBuilder& SrcFileCompilerBuilder::inherit(const SrcFileCompilerBuilder& builder, bool compile_options) {
-    output_dir_ = builder.output_dir_;
-    compiler_ = builder.compiler_;
-    docc_paths_ = builder.docc_paths_;
-
-    if (compile_options) {
-        main_src_ext_ = builder.main_src_ext_;
-        include_paths_.insert(include_paths_.end(), builder.include_paths_.cbegin(), builder.include_paths_.cend());
-        common_options_.insert(common_options_.end(), builder.common_options_.cbegin(), builder.common_options_.cend());
-        compile_options_
-            .insert(compile_options_.end(), builder.compile_options_.cbegin(), builder.compile_options_.cend());
-    }
-
-    return *this;
-}
-
-SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_bin_extension(const std::string& ext) {
-    bin_ext_ = ext;
-    return *this;
-}
-
-SrcFileCompilerBuilder& SrcFileCompilerBuilder::contribute_parent_link_options(const std::vector<std::string>& opts) {
-    parent_link_options_.insert(parent_link_options_.end(), opts.cbegin(), opts.cend());
-    return *this;
-}
-
-std::unique_ptr<SrcFileCompiler> SrcFileCompilerBuilder::build() {
-    std::string compiler = this->compiler_.value();
-    std::stringstream compiler_args;
-    std::stringstream common_args;
-
-    for (auto& inc : this->include_paths_) {
-        compiler_args << "-I " << inc << " ";
-    }
-    for (auto& option : this->compile_options_) {
-        compiler_args << option << " ";
-    }
-    for (auto& option : this->common_options_) {
-        common_args << option << " ";
-    }
-
-    return std::make_unique<SrcFileCompiler>(
-        output_dir_.value(),
-        main_src_ext_.value(),
-        "h",
-        bin_ext_,
-        compiler,
-        this->linker_,
-        common_args.str(),
-        compiler_args.str(),
-        library_paths_,
-        link_options_,
-        link_immediately_,
-        std::move(this->redirects_)
-    );
-}
-
 
 } // namespace docc::compile

--- a/c-compile/src/compile/src_file_compiler_builder.cpp
+++ b/c-compile/src/compile/src_file_compiler_builder.cpp
@@ -1,0 +1,146 @@
+#include "docc/compile/src_file_compiler_builder.h"
+
+#include "docc/compile/src_file_compiler.h"
+
+namespace docc::compile {
+
+SrcFileCompilerBuilder::SrcFileCompilerBuilder() {}
+
+SrcFileCompilerBuilder::~SrcFileCompilerBuilder() = default;
+
+SrcFileCompilerBuilder::SrcFileCompilerBuilder(SrcFileCompilerBuilder&&) noexcept = default;
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::operator=(SrcFileCompilerBuilder&&) noexcept = default;
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_src_extension(const std::string& ext) {
+    main_src_ext_ = ext;
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_output_dir(const std::filesystem::path& out) {
+    output_dir_ = out;
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::add_compile_option(const std::string& opt) {
+    compile_options_.push_back(opt);
+    return *this;
+}
+
+bool SrcFileCompilerBuilder::remove_compile_option(const std::string& opt) {
+    auto it = std::find(compile_options_.begin(), compile_options_.end(), opt);
+    if (it != compile_options_.end()) {
+        compile_options_.erase(it);
+        return true;
+    }
+    return false;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_link_immediately(bool link_imm) {
+    link_immediately_ = link_imm;
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::add_link_option(const std::string& opt) {
+    link_options_.push_back(opt);
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::add_common_option(const std::string& opt) {
+    common_options_.push_back(opt);
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::add_include_path(const std::filesystem::path& path) {
+    include_paths_.push_back(path);
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::add_library_path(const std::filesystem::path& path) {
+    library_paths_.push_back(path);
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_compiler(const std::filesystem::path& compiler) {
+    compiler_ = compiler;
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_linker(const std::filesystem::path& linker) {
+    linker_ = linker;
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_from_paths(std::shared_ptr<util::DefaultDoccPaths> paths) {
+    auto incs = paths->get_default_include_paths();
+    include_paths_.insert(include_paths_.end(), incs.cbegin(), incs.cend());
+    auto libs = paths->get_default_library_paths();
+    library_paths_.insert(library_paths_.end(), libs.cbegin(), libs.cend());
+    return CodegenCompilerBuilderBase::set_from_paths(paths);
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::inherit(const SrcFileCompilerBuilder& builder, bool compile_options) {
+    output_dir_ = builder.output_dir_;
+    compiler_ = builder.compiler_;
+    docc_paths_ = builder.docc_paths_;
+
+    if (compile_options) {
+        main_src_ext_ = builder.main_src_ext_;
+        include_paths_.insert(include_paths_.end(), builder.include_paths_.cbegin(), builder.include_paths_.cend());
+        common_options_.insert(common_options_.end(), builder.common_options_.cbegin(), builder.common_options_.cend());
+        compile_options_
+            .insert(compile_options_.end(), builder.compile_options_.cbegin(), builder.compile_options_.cend());
+    }
+
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::set_bin_extension(const std::string& ext) {
+    bin_ext_ = ext;
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::contribute_parent_link_options(const std::vector<std::string>& opts) {
+    parent_link_options_.insert(parent_link_options_.end(), opts.cbegin(), opts.cend());
+    return *this;
+}
+
+SrcFileCompilerBuilder& SrcFileCompilerBuilder::
+    redirect_snippet(const std::string& ext, SrcFileCompilerBuilder sub_builder) {
+    redirects_[ext] = sub_builder.build();
+    return *this;
+}
+
+std::unique_ptr<SrcFileCompiler> SrcFileCompilerBuilder::build() {
+    std::string compiler = this->compiler_.value();
+    std::stringstream compiler_args;
+    std::stringstream common_args;
+
+    for (auto& inc : this->include_paths_) {
+        compiler_args << "-I " << inc << " ";
+    }
+    for (auto& option : this->compile_options_) {
+        compiler_args << option << " ";
+    }
+    for (auto& option : this->common_options_) {
+        common_args << option << " ";
+    }
+
+    return std::make_unique<SrcFileCompiler>(
+        output_dir_.value(),
+        main_src_ext_.value(),
+        "h",
+        bin_ext_,
+        compiler,
+        this->linker_,
+        common_args.str(),
+        compiler_args.str(),
+        library_paths_,
+        link_options_,
+        link_immediately_,
+        std::move(this->redirects_),
+        parent_link_options_
+    );
+}
+
+} // namespace docc::compile

--- a/c-compile/src/target/docc_target.cpp
+++ b/c-compile/src/target/docc_target.cpp
@@ -1,7 +1,8 @@
 #include "docc/target/docc_target.h"
 #include <filesystem>
+#include <sdfg/targets/highway/codegen/highway_map_dispatcher.h>
 
-#include "docc/compile/file_compiler.h"
+#include "docc/compile/src_file_compiler_builder.h"
 
 namespace docc::target {
 
@@ -18,7 +19,7 @@ static DoccTarget cuda_target = {
         b.add_compile_option("--cuda-gpu-arch=sm_70");
         b.add_compile_option("--cuda-path=/usr/local/cuda");
         b.set_bin_extension("cu");
-        builder.redirect_snippet("cu", b.build());
+        builder.redirect_snippet("cu", std::move(b));
         return true;
     }
 };
@@ -43,7 +44,7 @@ static DoccTarget rocm_target = {
         b.inherit(builder, true);
         b.remove_compile_option("--offload-host-only");
 
-        builder.redirect_snippet("rocm.cpp", b.build());
+        builder.redirect_snippet("rocm.cpp", std::move(b));
 
         return true;
     }
@@ -54,7 +55,7 @@ bool add_highway_build_support(compile::SrcFileCompilerBuilder& builder) {
     highway_builder.inherit(builder, true);
     highway_builder.contribute_parent_link_options({"-lhwy"});
 
-    builder.redirect_snippet("highway.cpp", highway_builder.build());
+    builder.redirect_snippet(sdfg::highway::HIGHWAY_SNIPPET_EXT, std::move(highway_builder));
     return true;
 }
 

--- a/c-compile/src/target/docc_target.cpp
+++ b/c-compile/src/target/docc_target.cpp
@@ -1,0 +1,72 @@
+#include "docc/target/docc_target.h"
+#include <filesystem>
+
+#include "docc/compile/file_compiler.h"
+
+namespace docc::target {
+
+static DoccTarget cuda_target = {
+    .short_name = "cuda",
+    .apply_additional_compile_options = [](compile::SrcFileCompilerBuilder& builder) -> bool {
+        builder.add_compile_option("-x cuda");
+        builder.add_link_option("-lcuda");
+        builder.add_link_option("/usr/local/cuda/lib64/libcudart.so");
+        builder.add_link_option("/usr/local/cuda/lib64/libcublas.so");
+
+        compile::SrcFileCompilerBuilder b;
+        b.inherit(builder, true);
+        b.add_compile_option("--cuda-gpu-arch=sm_70");
+        b.add_compile_option("--cuda-path=/usr/local/cuda");
+        b.set_bin_extension("cu");
+        builder.redirect_snippet("cu", b.build());
+        return true;
+    }
+};
+
+static DoccTarget rocm_target = {
+    .short_name = "rocm",
+    .apply_additional_compile_options = [](compile::SrcFileCompilerBuilder& builder) -> bool {
+        builder.add_compile_option("-x hip");
+        std::string rocm_dev = "gfx1201";
+        builder.add_compile_option("--offload-arch=" + rocm_dev);
+        std::filesystem::path rocm_path = "/opt/rocm";
+        builder.add_compile_option("--offload-host-only");
+        builder.add_compile_option("--rocm-path=" + rocm_path.string());
+        builder.add_include_path(rocm_path / "include");
+
+        auto lib_path = rocm_path / "lib";
+        builder.add_link_option(lib_path / "libamdhip64.so");
+        builder.add_link_option(lib_path / "libhiprtc.so");
+        builder.add_link_option(lib_path / "libhipblas.so");
+
+        compile::SrcFileCompilerBuilder b;
+        b.inherit(builder, true);
+        b.remove_compile_option("--offload-host-only");
+
+        builder.redirect_snippet("rocm.cpp", b.build());
+
+        return true;
+    }
+};
+
+bool add_highway_build_support(compile::SrcFileCompilerBuilder& builder) {
+    compile::SrcFileCompilerBuilder highway_builder;
+    highway_builder.inherit(builder, true);
+    highway_builder.contribute_parent_link_options({"-lhwy"});
+
+    builder.redirect_snippet("highway.cpp", highway_builder.build());
+    return true;
+}
+
+/**
+ * This exists as a workaround for current dependency hell. The builder is only defined in c-compile.
+ * But the plugins require at least the builder interface to operate on it.
+ * The c-compile library currently depends on the sdfgopt that contains these to plugins. We would need to place the
+ * compiler builder code into sdfglib to make this work
+ */
+void register_builtin_targets(sdfg::plugins::Context& context) {
+    context.add_target(&cuda_target);
+    context.add_target(&rocm_target);
+}
+
+} // namespace docc::target

--- a/c-compile/src/target/docc_target.cpp
+++ b/c-compile/src/target/docc_target.cpp
@@ -60,10 +60,9 @@ bool add_highway_build_support(compile::SrcFileCompilerBuilder& builder) {
 }
 
 /**
- * This exists as a workaround for current dependency hell. The builder is only defined in c-compile.
- * But the plugins require at least the builder interface to operate on it.
- * The c-compile library currently depends on the sdfgopt that contains these to plugins. We would need to place the
- * compiler builder code into sdfglib to make this work
+ * Temporary workaround. Ideally, these should live with the plugins themselves.
+ * But the plugins currently live in sdfgopt. We either need to split out the builder API
+ * so that sdfgopt can depend on it, or the plugins must be moved to a new library
  */
 void register_builtin_targets(sdfg::plugins::Context& context) {
     context.add_target(&cuda_target);

--- a/c-compile/src/util/docc_paths.cpp
+++ b/c-compile/src/util/docc_paths.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<DefaultDoccPaths> DefaultDoccPaths::from_lib_location(std::optio
     return std::make_unique<DefaultDoccPaths>("", "", DoccRootMode::None);
 }
 
-std::vector<std::filesystem::path> DefaultDoccPaths::get_default_include_paths() {
+std::vector<std::filesystem::path> DefaultDoccPaths::get_default_include_paths() const {
     switch (root_mode_) {
         case DoccRootMode::Pip:
             return {bin_root_ / "include"};
@@ -88,12 +88,64 @@ std::vector<std::filesystem::path> DefaultDoccPaths::get_default_include_paths()
     }
 }
 
-std::vector<std::filesystem::path> DefaultDoccPaths::get_default_library_paths() {
+std::vector<std::filesystem::path> DefaultDoccPaths::get_default_library_paths() const {
     switch (root_mode_) {
         case DoccRootMode::Pip:
             return {bin_root_ / "lib"};
         case DoccRootMode::CMake: // bin root must point to the cmake build dir of docc
             return {bin_root_ / "rtl", bin_root_ / "arg-capture-io"};
+        case DoccRootMode::None:
+        case DoccRootMode::GlobalDist:
+        default:
+            return {};
+    }
+}
+
+std::optional<std::filesystem::path> DefaultDoccPaths::get_builtin_target_plugin_src_path(const std::string& plugin
+) const {
+    switch (root_mode_) {
+        case DoccRootMode::CMake: // src root must point to the root of docc.git
+            return src_root_ / "targets" / plugin;
+        default:
+            return {};
+    }
+}
+
+std::optional<std::filesystem::path> DefaultDoccPaths::get_builtin_target_plugin_rt_lib_path(const std::string& plugin
+) const {
+    switch (root_mode_) {
+        case DoccRootMode::Pip:
+            return bin_root_ / "lib";
+        case DoccRootMode::CMake:
+            return bin_root_ / "targets" / plugin / "rt";
+        case DoccRootMode::None:
+        case DoccRootMode::GlobalDist:
+        default:
+            return {};
+    }
+}
+
+std::optional<std::filesystem::path> DefaultDoccPaths::get_builtin_target_plugin_rt_include_path(const std::string&
+                                                                                                     plugin) const {
+    switch (root_mode_) {
+        case DoccRootMode::Pip:
+            return bin_root_ / "lib";
+        case DoccRootMode::CMake:
+            return src_root_ / "targets" / plugin / "rt" / "include";
+        case DoccRootMode::None:
+        case DoccRootMode::GlobalDist:
+        default:
+            return {};
+    }
+}
+
+std::optional<std::filesystem::path> DefaultDoccPaths::
+    get_builtin_target_plugin_rt_libexec_src_path(const std::string& plugin, const std::string& rt_name) const {
+    switch (root_mode_) {
+        case DoccRootMode::Pip:
+            return bin_root_ / "libexec" / "docc" / plugin / rt_name;
+        case DoccRootMode::CMake:
+            return src_root_ / "targets" / plugin / "rt" / "libexec" / "docc" / plugin / rt_name;
         case DoccRootMode::None:
         case DoccRootMode::GlobalDist:
         default:

--- a/opt/CMakeLists.txt
+++ b/opt/CMakeLists.txt
@@ -42,15 +42,17 @@ set(SOURCE_FILES
     src/targets/cuda/blas/dot.cpp
     src/targets/cuda/blas/gemm.cpp
     src/targets/cuda/blas/utils.cpp
-    src/targets/cuda/stdlib/memset.cpp
     src/targets/cuda/cuda.cpp
     src/targets/cuda/cuda_data_offloading_node.cpp
     src/targets/cuda/cuda_map_dispatcher.cpp
+    src/targets/cuda/plugin.cpp
+    src/targets/cuda/stdlib/memset.cpp
     src/targets/rocm/blas/dot.cpp
     src/targets/rocm/blas/gemm.cpp
     src/targets/rocm/blas/gemm_handtuned.cpp
     src/targets/rocm/blas/utils.cpp
     src/targets/rocm/stdlib/memset.cpp
+    src/targets/rocm/plugin.cpp
     src/targets/rocm/rocm.cpp
     src/targets/rocm/rocm_data_offloading_node.cpp
     src/targets/rocm/rocm_map_dispatcher.cpp

--- a/opt/include/sdfg/targets/cuda/plugin.h
+++ b/opt/include/sdfg/targets/cuda/plugin.h
@@ -4,6 +4,7 @@
 #include <sdfg/data_flow/library_nodes/math/blas/dot_node.h>
 #include <sdfg/data_flow/library_nodes/math/blas/gemm_node.h>
 #include <sdfg/data_flow/library_nodes/stdlib/memset.h>
+#include <sdfg/plugins/plugins.h>
 #include <sdfg/serializer/json_serializer.h>
 
 #include "sdfg/codegen/language_extension.h"
@@ -19,117 +20,15 @@
 namespace sdfg {
 namespace cuda {
 
+
+void register_cuda_plugin(plugins::Context& context);
+
+/**
+ * @deprecated use the variant with explicit context
+ */
 inline void register_cuda_plugin() {
-    codegen::MapDispatcherRegistry::instance().register_map_dispatcher(
-        ScheduleType_CUDA::value(),
-        [](codegen::LanguageExtension& language_extension,
-           StructuredSDFG& sdfg,
-           analysis::AnalysisManager& analysis_manager,
-           structured_control_flow::Map& node,
-           codegen::InstrumentationPlan& instrumentation_plan,
-           codegen::ArgCapturePlan& arg_capture_plan) {
-            return std::make_unique<CUDAMapDispatcher>(
-                language_extension, sdfg, analysis_manager, node, instrumentation_plan, arg_capture_plan
-            );
-        }
-    );
-
-    codegen::LibraryNodeDispatcherRegistry::instance().register_library_node_dispatcher(
-        cuda::LibraryNodeType_CUDA_Offloading.value() + "::" + data_flow::ImplementationType_NONE.value(),
-        [](codegen::LanguageExtension& language_extension,
-           const Function& function,
-           const data_flow::DataFlowGraph& data_flow_graph,
-           const data_flow::LibraryNode& node) {
-            return std::make_unique<
-                cuda::CUDADataOffloadingNodeDispatcher>(language_extension, function, data_flow_graph, node);
-        }
-    );
-
-    serializer::LibraryNodeSerializerRegistry::instance()
-        .register_library_node_serializer(cuda::LibraryNodeType_CUDA_Offloading.value(), []() {
-            return std::make_unique<cuda::CUDADataOffloadingNodeSerializer>();
-        });
-
-
-    // Dot - CUBLAS with data transfers
-    codegen::LibraryNodeDispatcherRegistry::instance().register_library_node_dispatcher(
-        math::blas::LibraryNodeType_DOT.value() + "::" + cuda::ImplementationType_CUDAWithTransfers.value(),
-        [](codegen::LanguageExtension& language_extension,
-           const Function& function,
-           const data_flow::DataFlowGraph& data_flow_graph,
-           const data_flow::LibraryNode& node) {
-            return std::make_unique<blas::DotNodeDispatcher_CUBLASWithTransfers>(
-                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::DotNode&>(node)
-            );
-        }
-    );
-    // Dot - CUBLAS without data transfers
-    codegen::LibraryNodeDispatcherRegistry::instance().register_library_node_dispatcher(
-        math::blas::LibraryNodeType_DOT.value() + "::" + cuda::ImplementationType_CUDAWithoutTransfers.value(),
-        [](codegen::LanguageExtension& language_extension,
-           const Function& function,
-           const data_flow::DataFlowGraph& data_flow_graph,
-           const data_flow::LibraryNode& node) {
-            return std::make_unique<blas::DotNodeDispatcher_CUBLASWithoutTransfers>(
-                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::DotNode&>(node)
-            );
-        }
-    );
-
-    // GEMM - CUBLAS with data transfers
-    codegen::LibraryNodeDispatcherRegistry::instance().register_library_node_dispatcher(
-        math::blas::LibraryNodeType_GEMM.value() + "::" + cuda::ImplementationType_CUDAWithTransfers.value(),
-        [](codegen::LanguageExtension& language_extension,
-           const Function& function,
-           const data_flow::DataFlowGraph& data_flow_graph,
-           const data_flow::LibraryNode& node) {
-            return std::make_unique<blas::GEMMNodeDispatcher_CUBLASWithTransfers>(
-                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::GEMMNode&>(node)
-            );
-        }
-    );
-    // GEMM - CUBLAS without data transfers
-    codegen::LibraryNodeDispatcherRegistry::instance().register_library_node_dispatcher(
-        math::blas::LibraryNodeType_GEMM.value() + "::" + cuda::ImplementationType_CUDAWithoutTransfers.value(),
-        [](codegen::LanguageExtension& language_extension,
-           const Function& function,
-           const data_flow::DataFlowGraph& data_flow_graph,
-           const data_flow::LibraryNode& node) {
-            return std::make_unique<blas::GEMMNodeDispatcher_CUBLASWithoutTransfers>(
-                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::GEMMNode&>(node)
-            );
-        }
-    );
-
-
-    // Memset - CUDA with data transfers
-    codegen::LibraryNodeDispatcherRegistry::instance().register_library_node_dispatcher(
-        sdfg::stdlib::LibraryNodeType_Memset.value() + "::" + cuda::ImplementationType_CUDAWithTransfers.value(),
-        [](codegen::LanguageExtension& language_extension,
-           const Function& function,
-           const data_flow::DataFlowGraph& data_flow_graph,
-           const data_flow::LibraryNode& node) {
-            return std::make_unique<cuda::stdlib::MemsetNodeDispatcher_CUDAWithTransfers>(
-                language_extension, function, data_flow_graph, dynamic_cast<const sdfg::stdlib::MemsetNode&>(node)
-            );
-        }
-    );
-    // Memset - CUDA without data transfers
-    codegen::LibraryNodeDispatcherRegistry::instance().register_library_node_dispatcher(
-        sdfg::stdlib::LibraryNodeType_Memset.value() + "::" + cuda::ImplementationType_CUDAWithoutTransfers.value(),
-        [](codegen::LanguageExtension& language_extension,
-           const Function& function,
-           const data_flow::DataFlowGraph& data_flow_graph,
-           const data_flow::LibraryNode& node) {
-            return std::make_unique<cuda::stdlib::MemsetNodeDispatcher_CUDAWithoutTransfers>(
-                language_extension, function, data_flow_graph, dynamic_cast<const sdfg::stdlib::MemsetNode&>(node)
-            );
-        }
-    );
-
-
-    passes::scheduler::SchedulerRegistry::instance()
-        .register_loop_scheduler<passes::scheduler::CUDAScheduler>(passes::scheduler::CUDAScheduler::target());
+    auto ctx = sdfg::plugins::Context::global_context();
+    register_cuda_plugin(ctx);
 }
 
 } // namespace cuda

--- a/opt/include/sdfg/targets/highway/codegen/highway_map_dispatcher.h
+++ b/opt/include/sdfg/targets/highway/codegen/highway_map_dispatcher.h
@@ -11,6 +11,8 @@
 namespace sdfg {
 namespace highway {
 
+constexpr std::string HIGHWAY_SNIPPET_EXT = "highway.cpp";
+
 class HighwayMapDispatcher : public codegen::NodeDispatcher {
 private:
     structured_control_flow::Map& node_;

--- a/opt/include/sdfg/targets/rocm/plugin.h
+++ b/opt/include/sdfg/targets/rocm/plugin.h
@@ -4,6 +4,7 @@
 #include <sdfg/data_flow/library_nodes/math/blas/dot_node.h>
 #include <sdfg/data_flow/library_nodes/math/blas/gemm_node.h>
 #include <sdfg/data_flow/library_nodes/stdlib/memset.h>
+#include <sdfg/plugins/plugins.h>
 #include <sdfg/serializer/json_serializer.h>
 
 #include "sdfg/codegen/language_extension.h"
@@ -20,117 +21,14 @@
 namespace sdfg {
 namespace rocm {
 
+void register_rocm_plugin(plugins::Context& context);
+
+/**
+ * @deprecated use the variant with explicit context
+ */
 inline void register_rocm_plugin() {
-    codegen::MapDispatcherRegistry::instance().register_map_dispatcher(
-        ScheduleType_ROCM::value(),
-        [](codegen::LanguageExtension& language_extension,
-           StructuredSDFG& sdfg,
-           analysis::AnalysisManager& analysis_manager,
-           structured_control_flow::Map& node,
-           codegen::InstrumentationPlan& instrumentation_plan,
-           codegen::ArgCapturePlan& arg_capture_plan) {
-            return std::make_unique<ROCMMapDispatcher>(
-                language_extension, sdfg, analysis_manager, node, instrumentation_plan, arg_capture_plan
-            );
-        }
-    );
-
-    codegen::LibraryNodeDispatcherRegistry::instance().register_library_node_dispatcher(
-        rocm::LibraryNodeType_ROCM_Offloading.value() + "::" + data_flow::ImplementationType_NONE.value(),
-        [](codegen::LanguageExtension& language_extension,
-           const Function& function,
-           const data_flow::DataFlowGraph& data_flow_graph,
-           const data_flow::LibraryNode& node) {
-            return std::make_unique<
-                rocm::ROCMDataOffloadingNodeDispatcher>(language_extension, function, data_flow_graph, node);
-        }
-    );
-
-    serializer::LibraryNodeSerializerRegistry::instance()
-        .register_library_node_serializer(rocm::LibraryNodeType_ROCM_Offloading.value(), []() {
-            return std::make_unique<rocm::ROCMDataOffloadingNodeSerializer>();
-        });
-
-
-    // Dot - ROCMBLAS with data transfers
-    codegen::LibraryNodeDispatcherRegistry::instance().register_library_node_dispatcher(
-        math::blas::LibraryNodeType_DOT.value() + "::" + rocm::ImplementationType_ROCMWithTransfers.value(),
-        [](codegen::LanguageExtension& language_extension,
-           const Function& function,
-           const data_flow::DataFlowGraph& data_flow_graph,
-           const data_flow::LibraryNode& node) {
-            return std::make_unique<blas::DotNodeDispatcher_ROCMBLASWithTransfers>(
-                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::DotNode&>(node)
-            );
-        }
-    );
-    // Dot - ROCMBLAS without data transfers
-    codegen::LibraryNodeDispatcherRegistry::instance().register_library_node_dispatcher(
-        math::blas::LibraryNodeType_DOT.value() + "::" + rocm::ImplementationType_ROCMWithoutTransfers.value(),
-        [](codegen::LanguageExtension& language_extension,
-           const Function& function,
-           const data_flow::DataFlowGraph& data_flow_graph,
-           const data_flow::LibraryNode& node) {
-            return std::make_unique<blas::DotNodeDispatcher_ROCMBLASWithoutTransfers>(
-                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::DotNode&>(node)
-            );
-        }
-    );
-
-    // GEMM - ROCMBLAS with data transfers
-    codegen::LibraryNodeDispatcherRegistry::instance().register_library_node_dispatcher(
-        math::blas::LibraryNodeType_GEMM.value() + "::" + rocm::ImplementationType_ROCMWithTransfers.value(),
-        [](codegen::LanguageExtension& language_extension,
-           const Function& function,
-           const data_flow::DataFlowGraph& data_flow_graph,
-           const data_flow::LibraryNode& node) {
-            return std::make_unique<blas::GEMMNodeDispatcher_ROCMBLASWithTransfers>(
-                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::GEMMNode&>(node)
-            );
-        }
-    );
-
-    // GEMM - ROCM hand-tuned kernel (data already on GPU)
-    codegen::LibraryNodeDispatcherRegistry::instance().register_library_node_dispatcher(
-        math::blas::LibraryNodeType_GEMM.value() + "::" + rocm::ImplementationType_ROCMWithoutTransfers.value(),
-        [](codegen::LanguageExtension& language_extension,
-           const Function& function,
-           const data_flow::DataFlowGraph& data_flow_graph,
-           const data_flow::LibraryNode& node) {
-            return std::make_unique<blas::GEMMNodeDispatcher_ROCMHandTuned>(
-                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::GEMMNode&>(node)
-            );
-        }
-    );
-
-    // Memset - ROCM with data transfers
-    codegen::LibraryNodeDispatcherRegistry::instance().register_library_node_dispatcher(
-        sdfg::stdlib::LibraryNodeType_Memset.value() + "::" + rocm::ImplementationType_ROCMWithTransfers.value(),
-        [](codegen::LanguageExtension& language_extension,
-           const Function& function,
-           const data_flow::DataFlowGraph& data_flow_graph,
-           const data_flow::LibraryNode& node) {
-            return std::make_unique<rocm::stdlib::MemsetNodeDispatcher_ROCMWithTransfers>(
-                language_extension, function, data_flow_graph, dynamic_cast<const sdfg::stdlib::MemsetNode&>(node)
-            );
-        }
-    );
-    // Memset - ROCM without data transfers
-    codegen::LibraryNodeDispatcherRegistry::instance().register_library_node_dispatcher(
-        sdfg::stdlib::LibraryNodeType_Memset.value() + "::" + rocm::ImplementationType_ROCMWithoutTransfers.value(),
-        [](codegen::LanguageExtension& language_extension,
-           const Function& function,
-           const data_flow::DataFlowGraph& data_flow_graph,
-           const data_flow::LibraryNode& node) {
-            return std::make_unique<rocm::stdlib::MemsetNodeDispatcher_ROCMWithoutTransfers>(
-                language_extension, function, data_flow_graph, dynamic_cast<const sdfg::stdlib::MemsetNode&>(node)
-            );
-        }
-    );
-
-
-    passes::scheduler::SchedulerRegistry::instance()
-        .register_loop_scheduler<passes::scheduler::ROCMScheduler>(passes::scheduler::ROCMScheduler::target());
+    auto ctx = sdfg::plugins::Context::global_context();
+    register_rocm_plugin(ctx);
 }
 
 } // namespace rocm

--- a/opt/src/targets/cuda/plugin.cpp
+++ b/opt/src/targets/cuda/plugin.cpp
@@ -1,0 +1,122 @@
+#include "sdfg/targets/cuda/plugin.h"
+
+
+namespace sdfg::cuda {
+
+void register_cuda_plugin(plugins::Context& context) {
+    auto& libNodeDispatcherRegistry = context.library_node_dispatcher_registry;
+    auto& mapDispatcherRegistry = context.map_dispatcher_registry;
+    auto& libNodeSerRegistry = context.library_node_serializer_registry;
+
+    mapDispatcherRegistry.register_map_dispatcher(
+        ScheduleType_CUDA::value(),
+        [](codegen::LanguageExtension& language_extension,
+           StructuredSDFG& sdfg,
+           analysis::AnalysisManager& analysis_manager,
+           structured_control_flow::Map& node,
+           codegen::InstrumentationPlan& instrumentation_plan,
+           codegen::ArgCapturePlan& arg_capture_plan) {
+            return std::make_unique<CUDAMapDispatcher>(
+                language_extension, sdfg, analysis_manager, node, instrumentation_plan, arg_capture_plan
+            );
+        }
+    );
+
+    libNodeDispatcherRegistry.register_library_node_dispatcher(
+        cuda::LibraryNodeType_CUDA_Offloading.value() + "::" + data_flow::ImplementationType_NONE.value(),
+        [](codegen::LanguageExtension& language_extension,
+           const Function& function,
+           const data_flow::DataFlowGraph& data_flow_graph,
+           const data_flow::LibraryNode& node) {
+            return std::make_unique<
+                cuda::CUDADataOffloadingNodeDispatcher>(language_extension, function, data_flow_graph, node);
+        }
+    );
+
+    libNodeSerRegistry.register_library_node_serializer(cuda::LibraryNodeType_CUDA_Offloading.value(), []() {
+        return std::make_unique<cuda::CUDADataOffloadingNodeSerializer>();
+    });
+
+
+    // Dot - CUBLAS with data transfers
+    libNodeDispatcherRegistry.register_library_node_dispatcher(
+        math::blas::LibraryNodeType_DOT.value() + "::" + cuda::ImplementationType_CUDAWithTransfers.value(),
+        [](codegen::LanguageExtension& language_extension,
+           const Function& function,
+           const data_flow::DataFlowGraph& data_flow_graph,
+           const data_flow::LibraryNode& node) {
+            return std::make_unique<blas::DotNodeDispatcher_CUBLASWithTransfers>(
+                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::DotNode&>(node)
+            );
+        }
+    );
+    // Dot - CUBLAS without data transfers
+    libNodeDispatcherRegistry.register_library_node_dispatcher(
+        math::blas::LibraryNodeType_DOT.value() + "::" + cuda::ImplementationType_CUDAWithoutTransfers.value(),
+        [](codegen::LanguageExtension& language_extension,
+           const Function& function,
+           const data_flow::DataFlowGraph& data_flow_graph,
+           const data_flow::LibraryNode& node) {
+            return std::make_unique<blas::DotNodeDispatcher_CUBLASWithoutTransfers>(
+                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::DotNode&>(node)
+            );
+        }
+    );
+
+    // GEMM - CUBLAS with data transfers
+    libNodeDispatcherRegistry.register_library_node_dispatcher(
+        math::blas::LibraryNodeType_GEMM.value() + "::" + cuda::ImplementationType_CUDAWithTransfers.value(),
+        [](codegen::LanguageExtension& language_extension,
+           const Function& function,
+           const data_flow::DataFlowGraph& data_flow_graph,
+           const data_flow::LibraryNode& node) {
+            return std::make_unique<blas::GEMMNodeDispatcher_CUBLASWithTransfers>(
+                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::GEMMNode&>(node)
+            );
+        }
+    );
+    // GEMM - CUBLAS without data transfers
+    libNodeDispatcherRegistry.register_library_node_dispatcher(
+        math::blas::LibraryNodeType_GEMM.value() + "::" + cuda::ImplementationType_CUDAWithoutTransfers.value(),
+        [](codegen::LanguageExtension& language_extension,
+           const Function& function,
+           const data_flow::DataFlowGraph& data_flow_graph,
+           const data_flow::LibraryNode& node) {
+            return std::make_unique<blas::GEMMNodeDispatcher_CUBLASWithoutTransfers>(
+                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::GEMMNode&>(node)
+            );
+        }
+    );
+
+
+    // Memset - CUDA with data transfers
+    libNodeDispatcherRegistry.register_library_node_dispatcher(
+        sdfg::stdlib::LibraryNodeType_Memset.value() + "::" + cuda::ImplementationType_CUDAWithTransfers.value(),
+        [](codegen::LanguageExtension& language_extension,
+           const Function& function,
+           const data_flow::DataFlowGraph& data_flow_graph,
+           const data_flow::LibraryNode& node) {
+            return std::make_unique<cuda::stdlib::MemsetNodeDispatcher_CUDAWithTransfers>(
+                language_extension, function, data_flow_graph, dynamic_cast<const sdfg::stdlib::MemsetNode&>(node)
+            );
+        }
+    );
+    // Memset - CUDA without data transfers
+    libNodeDispatcherRegistry.register_library_node_dispatcher(
+        sdfg::stdlib::LibraryNodeType_Memset.value() + "::" + cuda::ImplementationType_CUDAWithoutTransfers.value(),
+        [](codegen::LanguageExtension& language_extension,
+           const Function& function,
+           const data_flow::DataFlowGraph& data_flow_graph,
+           const data_flow::LibraryNode& node) {
+            return std::make_unique<cuda::stdlib::MemsetNodeDispatcher_CUDAWithoutTransfers>(
+                language_extension, function, data_flow_graph, dynamic_cast<const sdfg::stdlib::MemsetNode&>(node)
+            );
+        }
+    );
+
+
+    context.scheduler_registry
+        .register_loop_scheduler<passes::scheduler::CUDAScheduler>(passes::scheduler::CUDAScheduler::target());
+}
+
+} // namespace sdfg::cuda

--- a/opt/src/targets/highway/codegen/highway_map_dispatcher.cpp
+++ b/opt/src/targets/highway/codegen/highway_map_dispatcher.cpp
@@ -216,7 +216,7 @@ void HighwayMapDispatcher::dispatch_node(
     codegen::PrettyPrinter& globals_stream,
     codegen::CodeSnippetFactory& library_snippet_factory
 ) {
-    std::string kernel_name = "highway_kernel_" + std::to_string(node_.element_id());
+    std::string kernel_name = "kernel_" + std::to_string(node_.element_id());
 
     // Kernel call and declaration in current file
     this->dispatch_kernel_call(main_stream, kernel_name);
@@ -225,7 +225,7 @@ void HighwayMapDispatcher::dispatch_node(
 
     // Kernel definition in separate file
 
-    auto& library_stream = library_snippet_factory.require(kernel_name, "cpp", true).stream();
+    auto& library_stream = library_snippet_factory.require(kernel_name, HIGHWAY_SNIPPET_EXT, true).stream();
 
     library_stream << "#include " << library_snippet_factory.header_path().filename() << std::endl;
     library_stream << "#include <hwy/highway.h>" << std::endl;

--- a/opt/src/targets/rocm/plugin.cpp
+++ b/opt/src/targets/rocm/plugin.cpp
@@ -1,0 +1,121 @@
+#include "sdfg/targets/rocm/plugin.h"
+
+namespace sdfg::rocm {
+
+void register_rocm_plugin(plugins::Context& context) {
+    auto& libNodeDispatcherRegistry = context.library_node_dispatcher_registry;
+    auto& mapDispatcherRegistry = context.map_dispatcher_registry;
+    auto& libNodeSerRegistry = context.library_node_serializer_registry;
+
+    mapDispatcherRegistry.register_map_dispatcher(
+        ScheduleType_ROCM::value(),
+        [](codegen::LanguageExtension& language_extension,
+           StructuredSDFG& sdfg,
+           analysis::AnalysisManager& analysis_manager,
+           structured_control_flow::Map& node,
+           codegen::InstrumentationPlan& instrumentation_plan,
+           codegen::ArgCapturePlan& arg_capture_plan) {
+            return std::make_unique<ROCMMapDispatcher>(
+                language_extension, sdfg, analysis_manager, node, instrumentation_plan, arg_capture_plan
+            );
+        }
+    );
+
+    libNodeDispatcherRegistry.register_library_node_dispatcher(
+        rocm::LibraryNodeType_ROCM_Offloading.value() + "::" + data_flow::ImplementationType_NONE.value(),
+        [](codegen::LanguageExtension& language_extension,
+           const Function& function,
+           const data_flow::DataFlowGraph& data_flow_graph,
+           const data_flow::LibraryNode& node) {
+            return std::make_unique<
+                rocm::ROCMDataOffloadingNodeDispatcher>(language_extension, function, data_flow_graph, node);
+        }
+    );
+
+    libNodeSerRegistry.register_library_node_serializer(rocm::LibraryNodeType_ROCM_Offloading.value(), []() {
+        return std::make_unique<rocm::ROCMDataOffloadingNodeSerializer>();
+    });
+
+
+    // Dot - ROCMBLAS with data transfers
+    libNodeDispatcherRegistry.register_library_node_dispatcher(
+        math::blas::LibraryNodeType_DOT.value() + "::" + rocm::ImplementationType_ROCMWithTransfers.value(),
+        [](codegen::LanguageExtension& language_extension,
+           const Function& function,
+           const data_flow::DataFlowGraph& data_flow_graph,
+           const data_flow::LibraryNode& node) {
+            return std::make_unique<blas::DotNodeDispatcher_ROCMBLASWithTransfers>(
+                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::DotNode&>(node)
+            );
+        }
+    );
+    // Dot - ROCMBLAS without data transfers
+    libNodeDispatcherRegistry.register_library_node_dispatcher(
+        math::blas::LibraryNodeType_DOT.value() + "::" + rocm::ImplementationType_ROCMWithoutTransfers.value(),
+        [](codegen::LanguageExtension& language_extension,
+           const Function& function,
+           const data_flow::DataFlowGraph& data_flow_graph,
+           const data_flow::LibraryNode& node) {
+            return std::make_unique<blas::DotNodeDispatcher_ROCMBLASWithoutTransfers>(
+                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::DotNode&>(node)
+            );
+        }
+    );
+
+    // GEMM - ROCMBLAS with data transfers
+    libNodeDispatcherRegistry.register_library_node_dispatcher(
+        math::blas::LibraryNodeType_GEMM.value() + "::" + rocm::ImplementationType_ROCMWithTransfers.value(),
+        [](codegen::LanguageExtension& language_extension,
+           const Function& function,
+           const data_flow::DataFlowGraph& data_flow_graph,
+           const data_flow::LibraryNode& node) {
+            return std::make_unique<blas::GEMMNodeDispatcher_ROCMBLASWithTransfers>(
+                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::GEMMNode&>(node)
+            );
+        }
+    );
+
+    // GEMM - ROCM hand-tuned kernel (data already on GPU)
+    libNodeDispatcherRegistry.register_library_node_dispatcher(
+        math::blas::LibraryNodeType_GEMM.value() + "::" + rocm::ImplementationType_ROCMWithoutTransfers.value(),
+        [](codegen::LanguageExtension& language_extension,
+           const Function& function,
+           const data_flow::DataFlowGraph& data_flow_graph,
+           const data_flow::LibraryNode& node) {
+            return std::make_unique<blas::GEMMNodeDispatcher_ROCMHandTuned>(
+                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::GEMMNode&>(node)
+            );
+        }
+    );
+
+    // Memset - ROCM with data transfers
+    libNodeDispatcherRegistry.register_library_node_dispatcher(
+        sdfg::stdlib::LibraryNodeType_Memset.value() + "::" + rocm::ImplementationType_ROCMWithTransfers.value(),
+        [](codegen::LanguageExtension& language_extension,
+           const Function& function,
+           const data_flow::DataFlowGraph& data_flow_graph,
+           const data_flow::LibraryNode& node) {
+            return std::make_unique<rocm::stdlib::MemsetNodeDispatcher_ROCMWithTransfers>(
+                language_extension, function, data_flow_graph, dynamic_cast<const sdfg::stdlib::MemsetNode&>(node)
+            );
+        }
+    );
+    // Memset - ROCM without data transfers
+    libNodeDispatcherRegistry.register_library_node_dispatcher(
+        sdfg::stdlib::LibraryNodeType_Memset.value() + "::" + rocm::ImplementationType_ROCMWithoutTransfers.value(),
+        [](codegen::LanguageExtension& language_extension,
+           const Function& function,
+           const data_flow::DataFlowGraph& data_flow_graph,
+           const data_flow::LibraryNode& node) {
+            return std::make_unique<rocm::stdlib::MemsetNodeDispatcher_ROCMWithoutTransfers>(
+                language_extension, function, data_flow_graph, dynamic_cast<const sdfg::stdlib::MemsetNode&>(node)
+            );
+        }
+    );
+
+
+    context.scheduler_registry
+        .register_loop_scheduler<passes::scheduler::ROCMScheduler>(passes::scheduler::ROCMScheduler::target());
+}
+
+} // namespace sdfg::rocm

--- a/opt/tests/test.cpp
+++ b/opt/tests/test.cpp
@@ -12,9 +12,10 @@ static std::optional<std::filesystem::path> test_output_dir;
 
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
+    auto context = sdfg::plugins::Context::global_context();
     sdfg::codegen::register_default_dispatchers();
-    sdfg::cuda::register_cuda_plugin();
-    sdfg::rocm::register_rocm_plugin();
+    sdfg::cuda::register_cuda_plugin(context);
+    sdfg::rocm::register_rocm_plugin(context);
     sdfg::serializer::register_default_serializers();
     sdfg::highway::register_highway_plugin();
     sdfg::omp::register_omp_plugin();

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -213,7 +213,8 @@ PYBIND11_MODULE(_sdfg, m) {
             py::arg("target"),
             py::arg("instrumentation_mode") = "",
             py::arg("capture_args") = false,
-            py::arg("debug_build") = false
+            py::arg("debug_build") = false,
+            py::arg("threads") = 0 // means hardware-threads
         )
         .def("metadata", &PyStructuredSDFG::metadata, py::arg("key"), "Get metadata value")
         .def("loop_report", &PyStructuredSDFG::loop_report, "Get loop statistics from the SDFG")

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -45,6 +45,8 @@
 #include <sdfg/targets/rocm/plugin.h>
 
 #include <sdfg/passes/statistics.h>
+
+#include "docc/target/docc_target.h"
 #include "sdfg/passes/rpc/rpc_scheduler.h"
 #include "sdfg/passes/scheduler/cuda_scheduler.h"
 
@@ -63,8 +65,9 @@ PYBIND11_MODULE(_sdfg, m) {
     sdfg::serializer::register_default_serializers();
     sdfg::omp::register_omp_plugin();
     sdfg::highway::register_highway_plugin();
-    sdfg::cuda::register_cuda_plugin();
-    sdfg::rocm::register_rocm_plugin();
+    sdfg::cuda::register_cuda_plugin(docc_context);
+    sdfg::rocm::register_rocm_plugin(docc_context);
+    docc::target::register_builtin_targets(docc_context);
 #ifdef DOCC_HAS_TARGET_ET
     docc::target::et::register_plugin(docc_context);
 #endif
@@ -151,8 +154,18 @@ PYBIND11_MODULE(_sdfg, m) {
 
     // Register SDFG class
     py::class_<PyStructuredSDFG>(m, "StructuredSDFG")
-        .def_static("from_file", &PyStructuredSDFG::from_file, py::arg("file_path"), "Load a StructuredSDFG from file")
-        .def_static("parse", &PyStructuredSDFG::parse, py::arg("sdfg_text"), "Parse a StructuredSDFG from text")
+        .def_static(
+            "from_file",
+            [&](const std::string& file_path) { return PyStructuredSDFG::from_file(docc_context, file_path); },
+            py::arg("file_path"),
+            "Load a StructuredSDFG from file"
+        )
+        .def_static(
+            "parse",
+            [&](const std::string& sdfg_text) { return PyStructuredSDFG::parse(docc_context, sdfg_text); },
+            py::arg("sdfg_text"),
+            "Parse a StructuredSDFG from text"
+        )
         .def_property_readonly("name", &PyStructuredSDFG::name)
         .def_property_readonly(
             "_ptr",
@@ -199,7 +212,8 @@ PYBIND11_MODULE(_sdfg, m) {
             py::arg("output_folder"),
             py::arg("target"),
             py::arg("instrumentation_mode") = "",
-            py::arg("capture_args") = false
+            py::arg("capture_args") = false,
+            py::arg("debug_build") = false
         )
         .def("metadata", &PyStructuredSDFG::metadata, py::arg("key"), "Get metadata value")
         .def("loop_report", &PyStructuredSDFG::loop_report, "Get loop statistics from the SDFG")
@@ -209,9 +223,17 @@ PYBIND11_MODULE(_sdfg, m) {
 
     // Register StructuredSDFGBuilder class
     py::class_<PyStructuredSDFGBuilder>(m, "StructuredSDFGBuilder")
-        .def(py::init<const std::string&>(), py::arg("name"), "Create a StructuredSDFGBuilder with the given name")
         .def(
-            py::init<const std::string&, const IType&>(),
+            py::init([](const std::string& name) {
+                return std::make_unique<PyStructuredSDFGBuilder>(docc_context, name);
+            }),
+            py::arg("name"),
+            "Create a StructuredSDFGBuilder with the given name"
+        )
+        .def(
+            py::init([](const std::string& name, const IType& return_type) {
+                return std::make_unique<PyStructuredSDFGBuilder>(docc_context, name, return_type);
+            }),
             py::arg("name"),
             py::arg("return_type"),
             "Create a StructuredSDFGBuilder with the given name and return type"

--- a/python/bindings/builder/py_structured_sdfg_builder.cpp
+++ b/python/bindings/builder/py_structured_sdfg_builder.cpp
@@ -32,19 +32,24 @@ sdfg::symbolic::Expression parse_and_expand(const std::string& expr_str) {
     return expr;
 }
 
-PyStructuredSDFGBuilder::PyStructuredSDFGBuilder(const std::string& name)
-    : builder_(name, sdfg::FunctionType_CPU, sdfg::types::Scalar(sdfg::types::PrimitiveType::Void)) {
+PyStructuredSDFGBuilder::PyStructuredSDFGBuilder(sdfg::plugins::Context& ctx, const std::string& name)
+    : docc_context_(ctx),
+      builder_(name, sdfg::FunctionType_CPU, sdfg::types::Scalar(sdfg::types::PrimitiveType::Void)) {
     scope_stack.push_back({&builder_.subject().root(), nullptr, -1});
 }
 
-PyStructuredSDFGBuilder::PyStructuredSDFGBuilder(const std::string& name, const sdfg::types::IType& return_type)
-    : builder_(name, sdfg::FunctionType_CPU, return_type) {
+PyStructuredSDFGBuilder::
+    PyStructuredSDFGBuilder(sdfg::plugins::Context& ctx, const std::string& name, const sdfg::types::IType& return_type)
+    : docc_context_(ctx), builder_(name, sdfg::FunctionType_CPU, return_type) {
     scope_stack.push_back({&builder_.subject().root(), nullptr, -1});
 }
 
-PyStructuredSDFGBuilder::PyStructuredSDFGBuilder(PyStructuredSDFG& sdfg) : builder_(sdfg.sdfg()) {
+PyStructuredSDFGBuilder::PyStructuredSDFGBuilder(PyStructuredSDFG& sdfg)
+    : docc_context_(sdfg.docc_context_), builder_(sdfg.sdfg()) {
     scope_stack.push_back({&builder_.subject().root(), nullptr, -1});
 }
+
+sdfg::plugins::Context& PyStructuredSDFGBuilder::docc_context() const { return docc_context_; }
 
 PyStructuredSDFG PyStructuredSDFGBuilder::move() {
     sdfg::analysis::AnalysisManager analysis_manager(builder_.subject());
@@ -52,7 +57,7 @@ PyStructuredSDFG PyStructuredSDFGBuilder::move() {
     debug_info_propagation_pass.run(builder_, analysis_manager);
 
     auto sdfg = builder_.move();
-    return PyStructuredSDFG(sdfg);
+    return PyStructuredSDFG(docc_context_, sdfg);
 }
 
 void PyStructuredSDFGBuilder::add_container(const std::string& name, const sdfg::types::IType& type, bool is_argument) {

--- a/python/bindings/builder/py_structured_sdfg_builder.h
+++ b/python/bindings/builder/py_structured_sdfg_builder.h
@@ -25,17 +25,20 @@ struct Scope {
 
 class PyStructuredSDFGBuilder {
 private:
+    sdfg::plugins::Context& docc_context_;
     sdfg::builder::StructuredSDFGBuilder builder_;
     std::vector<Scope> scope_stack;
 
     sdfg::structured_control_flow::Sequence& current_sequence();
 
 public:
-    PyStructuredSDFGBuilder(const std::string& name);
-    PyStructuredSDFGBuilder(const std::string& name, const sdfg::types::IType& return_type);
+    PyStructuredSDFGBuilder(sdfg::plugins::Context& ctx, const std::string& name);
+    PyStructuredSDFGBuilder(sdfg::plugins::Context& ctx, const std::string& name, const sdfg::types::IType& return_type);
     PyStructuredSDFGBuilder(PyStructuredSDFG& sdfg);
 
     sdfg::builder::StructuredSDFGBuilder& builder() { return builder_; }
+
+    sdfg::plugins::Context& docc_context() const;
 
     PyStructuredSDFG move();
 

--- a/python/bindings/cutouts/py_cutout.h
+++ b/python/bindings/cutouts/py_cutout.h
@@ -29,7 +29,7 @@ inline PyStructuredSDFG cutout(
     sdfg::structured_control_flow::ControlFlowNode& node
 ) {
     auto result = sdfg::util::cutout(builder.builder(), analysis_manager.manager(), node);
-    return PyStructuredSDFG::from_sdfg(std::move(result));
+    return PyStructuredSDFG::from_sdfg(builder.docc_context(), std::move(result));
 }
 
 /**

--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -52,7 +52,9 @@
 #include <sdfg/visualizer/dot_visualizer.h>
 
 #include <chrono>
+#include <docc/target/docc_target.h>
 
+#include "docc/compile/file_compiler.h"
 #include "docc/util/docc_paths.h"
 #include "sdfg/passes/offloading/code_motion/block_hoisting.h"
 #include "sdfg/passes/offloading/code_motion/block_sorting.h"
@@ -80,17 +82,18 @@
 namespace fs = std::filesystem;
 using json = nlohmann::json;
 
-PyStructuredSDFG::PyStructuredSDFG(std::unique_ptr<sdfg::StructuredSDFG>& sdfg) : sdfg_(std::move(sdfg)) {}
+PyStructuredSDFG::PyStructuredSDFG(sdfg::plugins::Context& ctx, std::unique_ptr<sdfg::StructuredSDFG>& sdfg)
+    : docc_context_(ctx), sdfg_(std::move(sdfg)) {}
 
-PyStructuredSDFG PyStructuredSDFG::parse(const std::string& sdfg_text) {
+PyStructuredSDFG PyStructuredSDFG::parse(sdfg::plugins::Context& ctx, const std::string& sdfg_text) {
     json j = json::parse(sdfg_text);
     sdfg::serializer::JSONSerializer serializer;
     auto sdfg = serializer.deserialize(j);
 
-    return PyStructuredSDFG(sdfg);
+    return PyStructuredSDFG(ctx, sdfg);
 }
 
-PyStructuredSDFG PyStructuredSDFG::from_file(const std::string& file_path) {
+PyStructuredSDFG PyStructuredSDFG::from_file(sdfg::plugins::Context& ctx, const std::string& file_path) {
     std::ifstream sdfg_file(file_path);
     if (!sdfg_file.is_open()) {
         throw std::runtime_error("Failed to open SDFG file: " + file_path);
@@ -101,14 +104,16 @@ PyStructuredSDFG PyStructuredSDFG::from_file(const std::string& file_path) {
     sdfg::serializer::JSONSerializer serializer;
     auto sdfg = serializer.deserialize(j);
 
-    return PyStructuredSDFG(sdfg);
+    return PyStructuredSDFG(ctx, sdfg);
 }
 
-PyStructuredSDFG PyStructuredSDFG::from_sdfg(std::unique_ptr<sdfg::StructuredSDFG> sdfg) {
-    return PyStructuredSDFG(sdfg);
+PyStructuredSDFG PyStructuredSDFG::from_sdfg(sdfg::plugins::Context& ctx, std::unique_ptr<sdfg::StructuredSDFG> sdfg) {
+    return PyStructuredSDFG(ctx, sdfg);
 }
 
 std::string PyStructuredSDFG::name() const { return sdfg_->name(); }
+
+sdfg::plugins::Context& PyStructuredSDFG::docc_context() const { return docc_context_; }
 
 const sdfg::types::IType& PyStructuredSDFG::return_type() const { return sdfg_->return_type(); }
 
@@ -417,7 +422,8 @@ std::string PyStructuredSDFG::compile(
     const std::string& output_folder,
     const std::string& target,
     const std::string& instrumentation_mode,
-    bool capture_args
+    bool capture_args,
+    bool debug_build
 ) const {
     fs::path build_path(output_folder);
     if (!fs::exists(build_path)) {
@@ -452,236 +458,58 @@ std::string PyStructuredSDFG::compile(
         arg_capture_plan = sdfg::codegen::ArgCapturePlan::none(*sdfg_);
     }
 
-    std::pair<std::filesystem::path, std::filesystem::path> lib_config = std::make_pair(build_path, header_path);
-    std::shared_ptr<sdfg::codegen::CodeSnippetFactory> snippet_factory =
-        std::make_shared<sdfg::codegen::CodeSnippetFactory>(&lib_config);
+    // Find libraries relative to the module location
+    std::shared_ptr<docc::util::DefaultDoccPaths> paths =
+        docc::util::DefaultDoccPaths::from_lib_location(docc::util::find_lib_location());
 
-    // Code generation
-    std::chrono::high_resolution_clock::time_point codegen_start;
-    if (sdfg::passes::CodegenStatistics::instance().enabled()) {
-        codegen_start = std::chrono::high_resolution_clock::now();
+    docc::compile::SrcFileCompilerBuilder compile_builder;
+    compile_builder.set_compiler(DOCC_CXX_COMPILER)
+        .set_from_paths(paths)
+        .set_src_extension("cpp")
+        .set_bin_extension("so")
+        .set_output_dir(build_path)
+        .add_common_option("-fPIC")
+        .add_common_option("-O3")
+        .add_common_option("-fopenmp")
+        .add_common_option("-march=native")
+        .add_common_option("-mtune=native")
+        .add_compile_option("-funroll-loops")
+        .add_link_option("-shared")
+        .add_link_option("-ldaisy_rtl")
+        .add_link_option("-larg_capture_io")
+        .add_link_option("-lm")
+        .add_link_option("-lstdc++");
+
+    if (debug_build) {
+        compile_builder.add_common_option("-g");
     }
 
+#if defined(__APPLE__)
+    compile_builder.add_common_option("-Xpreprocessor");
+    compile_builder.add_include_path("/opt/homebrew/include");
+    compile_builder.add_library_path("/opt/homebrew/opt/libomp/lib")
+        .add_library_path("/opt/homebrew/opt/libomp/include")
+        .add_library_path("/opt/homebrew/lib");
+    compile_builder.add_link_option("-lomp");
+    compile_builder.add_link_option("-framework Accelerate");
+#else
+    compile_builder.add_link_option("-lblas");
+#endif
+
+    auto* target_handler = docc_context_.get_target_handler(target);
+    if (target_handler) {
+        target_handler->apply_additional_compile_options(compile_builder);
+    }
+    docc::target::add_highway_build_support(compile_builder);
+
+    auto fcomp_handler = compile_builder.build();
+    docc::compile::CodegenBuildPool pool(1);
+
+    std::shared_ptr<sdfg::codegen::CodeSnippetFactory> snippet_factory = fcomp_handler->create_snippet_factory(*sdfg_);
     sdfg::codegen::CPPCodeGenerator
         generator(*sdfg_, analysis_manager, *instrumentation_plan, *arg_capture_plan, snippet_factory);
-    generator.generate();
 
-    generator.as_source(header_path, source_path);
-
-    if (sdfg::passes::CodegenStatistics::instance().enabled()) {
-        auto codegen_end = std::chrono::high_resolution_clock::now();
-        auto codegen_duration =
-            std::chrono::duration_cast<std::chrono::milliseconds>(codegen_end - codegen_start).count();
-        sdfg::passes::CodegenStatistics::instance().add_codegen("code_generation", codegen_duration);
-    }
-
-    // Write library snippets
-    std::unordered_map<std::string, SnippetMetadata> lib_files;
-    for (auto& [name, snippet] : snippet_factory->snippets()) {
-        std::chrono::high_resolution_clock::time_point snipped_gen_start;
-        if (sdfg::passes::CodegenStatistics::instance().enabled()) {
-            snipped_gen_start = std::chrono::high_resolution_clock::now();
-        }
-        if (snippet.is_as_file()) {
-            auto p = build_path / (name + "." + snippet.extension());
-            std::ofstream outfile_lib;
-            if (!lib_files.contains(p.string())) {
-                outfile_lib.open(p, std::ios_base::out);
-                lib_files[p.string()] = {.name = name, .extension = snippet.extension()};
-            } else {
-                outfile_lib.open(p, std::ios_base::app);
-            }
-            if (!outfile_lib.is_open()) {
-                throw std::runtime_error("Failed to open library file: " + p.string());
-            }
-            outfile_lib << snippet.stream().str() << std::endl;
-            outfile_lib.close();
-        }
-
-        if (sdfg::passes::CodegenStatistics::instance().enabled()) {
-            auto snippet_gen_end = std::chrono::high_resolution_clock::now();
-            auto snippet_gen_duration =
-                std::chrono::duration_cast<std::chrono::milliseconds>(snippet_gen_end - snipped_gen_start).count();
-            sdfg::passes::CodegenStatistics::instance().add_codegen("snippet_generation", snippet_gen_duration);
-        }
-    }
-
-    // Find libraries relative to the module location
-    auto paths = docc::util::DefaultDoccPaths::from_lib_location(docc::util::find_lib_location());
-
-    bool has_highway = false;
-    std::unordered_set<std::string> object_files;
-    for (const auto& [lib_file, meta] : lib_files) {
-        std::chrono::high_resolution_clock::time_point snippet_compile_start;
-        if (sdfg::passes::CodegenStatistics::instance().enabled()) {
-            snippet_compile_start = std::chrono::high_resolution_clock::now();
-        }
-
-        std::filesystem::path lib_path(lib_file);
-        auto& [snippet_name, extension] = meta;
-        if (extension == "json") {
-            continue;
-        }
-
-#ifdef DOCC_HAS_TARGET_ET
-        if (extension == docc::target::et::ETSOC_KERNEL_FILE_EXT) {
-            docc::target::et::EtBuildArgs args{.build_dir = build_path, .plugin_rt_dir = paths->bin_root()};
-            auto et_k_file = docc::target::et::et_build_kernel(*sdfg_, *snippet_factory, lib_file, args);
-            DEBUG_PRINTLN("Generated ET Kernel to: " << et_k_file);
-            continue;
-        }
-#endif
-        std::string name = lib_path.stem().string();
-        std::string object_file = build_path.string() + "/" + name + ".o";
-        std::stringstream cmd;
-#if defined(__APPLE__)
-        cmd << DOCC_CXX_COMPILER << " -c -fPIC -O3 -Xpreprocessor -fopenmp -march=native -mtune=native -funroll-loops";
-#else
-        cmd << DOCC_CXX_COMPILER << " -c -fPIC -O3 -fopenmp -march=native -mtune=native -funroll-loops";
-#endif
-        for (auto& inc_path : paths->get_default_include_paths()) {
-            cmd << " -I" << inc_path;
-        }
-        for (auto& ld_path : paths->get_default_library_paths()) {
-            cmd << " -L" << ld_path;
-        }
-
-#if defined(__APPLE__)
-        cmd << " -I/opt/homebrew/include";
-#endif
-        if (target == "cuda") { // should use .cu to detect
-            cmd << " -x cuda --cuda-gpu-arch=sm_70 --cuda-path=/usr/local/cuda";
-        } else if (target == "rocm" && extension == "rocm.cpp") {
-            cmd << " -x hip --offload-arch=gfx1201 --rocm-path=/opt/rocm -I/opt/rocm/include";
-        }
-
-        cmd << " " << lib_file;
-        cmd << " -o " << object_file;
-        if (name.starts_with("highway_")) {
-            cmd << " -lhwy";
-            has_highway = true;
-        }
-        cmd << " -lm";
-        int ret = std::system(cmd.str().c_str());
-        if (ret != 0) {
-            throw std::runtime_error("Compilation failed: " + cmd.str());
-        }
-        object_files.insert(object_file);
-
-        if (sdfg::passes::CodegenStatistics::instance().enabled()) {
-            auto snippet_compile_end = std::chrono::high_resolution_clock::now();
-            auto snippet_compile_duration =
-                std::chrono::duration_cast<std::chrono::milliseconds>(snippet_compile_end - snippet_compile_start)
-                    .count();
-            sdfg::passes::CodegenStatistics::instance().add_codegen("snippet_compilation", snippet_compile_duration);
-        }
-    }
-
-    std::chrono::high_resolution_clock::time_point compile_start;
-    if (sdfg::passes::CodegenStatistics::instance().enabled()) {
-        compile_start = std::chrono::high_resolution_clock::now();
-    }
-
-    // Compile
-    {
-        std::stringstream cmd;
-#if defined(__APPLE__)
-        cmd << DOCC_CXX_COMPILER << " -c -fPIC -O3 -Xpreprocessor -fopenmp -march=native -mtune=native -funroll-loops";
-#else
-        cmd << DOCC_CXX_COMPILER << " -c -fPIC -O3 -fopenmp -march=native -mtune=native -funroll-loops";
-#endif
-        for (auto& inc_path : paths->get_default_include_paths()) {
-            cmd << " -I" << inc_path;
-        }
-        if (target == "cuda") {
-            cmd << " -x cuda -lcuda";
-        } else if (target == "rocm") {
-            cmd << " -x hip --offload-arch=gfx1201 --offload-host-only --rocm-path=/opt/rocm -I/opt/rocm/include";
-        } else if (target == "etsoc") {
-#ifdef DOCC_HAS_TARGET_ET
-            cmd << " " << docc::target::et::et_get_host_additional_compile_args(*sdfg_, *snippet_factory);
-#endif
-        }
-        cmd << " " << source_path.string();
-        cmd << " -g -o " << (build_path / (sdfg_->name() + ".o")).string();
-        DEBUG_PRINTLN("Compile: " << cmd.str());
-        int ret = std::system(cmd.str().c_str());
-        if (ret != 0) {
-            throw std::runtime_error("Compilation failed: " + cmd.str());
-        }
-        object_files.insert((build_path / (sdfg_->name() + ".o")).string());
-    }
-
-    if (sdfg::passes::CodegenStatistics::instance().enabled()) {
-        auto compile_end = std::chrono::high_resolution_clock::now();
-        auto compile_duration =
-            std::chrono::duration_cast<std::chrono::milliseconds>(compile_end - compile_start).count();
-        sdfg::passes::CodegenStatistics::instance().add_codegen("compilation", compile_duration);
-    }
-
-    // Link into shared library
-    fs::path lib_path = build_path / ("lib" + sdfg_->name() + ".so");
-
-    std::stringstream cmd;
-#if defined(__APPLE__)
-    cmd << DOCC_CXX_COMPILER << " -shared -Xpreprocessor -fopenmp -fPIC -O3";
-    cmd << " -L/opt/homebrew/opt/libomp/lib -I/opt/homebrew/opt/libomp/include";
-    cmd << " -L/opt/homebrew/lib";
-#else
-    cmd << DOCC_CXX_COMPILER << " -shared -fopenmp -fPIC -O3";
-#endif
-    for (auto& ld_path : paths->get_default_library_paths()) {
-        cmd << " -L" << ld_path;
-    }
-    // cmd << " " << source_path.string();
-    for (const auto& object_file : object_files) {
-        cmd << " " << object_file;
-    }
-    if (has_highway) {
-        cmd << " -lhwy";
-    }
-    cmd << " -ldaisy_rtl";
-    cmd << " -larg_capture_io";
-#if defined(__APPLE__)
-    cmd << " -lomp";
-    cmd << " -framework Accelerate";
-#else
-    cmd << " -lblas";
-#endif
-    cmd << " -lm -g";
-    cmd << " -lstdc++";
-    if (target == "cuda") {
-        cmd << " /usr/local/cuda/lib64/libcudart.so";
-        cmd << " /usr/local/cuda/lib64/libcublas.so";
-    } else if (target == "rocm") {
-        cmd << " /opt/rocm/lib/libamdhip64.so";
-        cmd << " /opt/rocm/lib/libhiprtc.so";
-        cmd << " /opt/rocm/lib/libhipblas.so";
-    } else if (target == "etsoc") {
-#ifdef DOCC_HAS_TARGET_ET
-        cmd << " " << docc::target::et::et_get_host_additional_link_args(*sdfg_, *snippet_factory);
-#endif
-    }
-    cmd << " -o " << lib_path.string();
-
-    std::chrono::high_resolution_clock::time_point link_start;
-    if (sdfg::passes::CodegenStatistics::instance().enabled()) {
-        link_start = std::chrono::high_resolution_clock::now();
-    }
-
-    DEBUG_PRINTLN("Link: " << cmd.str());
-    int ret = std::system(cmd.str().c_str());
-    if (ret != 0) {
-        throw std::runtime_error("Compilation failed: " + cmd.str());
-    }
-
-    if (sdfg::passes::CodegenStatistics::instance().enabled()) {
-        auto link_end = std::chrono::high_resolution_clock::now();
-        auto link_duration = std::chrono::duration_cast<std::chrono::milliseconds>(link_end - link_start).count();
-        sdfg::passes::CodegenStatistics::instance().add_codegen("linking", link_duration);
-    }
-
-    return lib_path.string();
+    return fcomp_handler->process(generator, pool, "lib" + sdfg_->name());
 }
 
 std::string PyStructuredSDFG::metadata(const std::string& key) const {

--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -54,7 +54,8 @@
 #include <chrono>
 #include <docc/target/docc_target.h>
 
-#include "docc/compile/file_compiler.h"
+#include "docc/compile/src_file_compiler.h"
+#include "docc/compile/src_file_compiler_builder.h"
 #include "docc/util/docc_paths.h"
 #include "sdfg/passes/offloading/code_motion/block_hoisting.h"
 #include "sdfg/passes/offloading/code_motion/block_sorting.h"

--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -472,7 +472,6 @@ std::string PyStructuredSDFG::compile(
         .set_output_dir(build_path)
         .add_common_option("-fPIC")
         .add_common_option("-O3")
-        .add_common_option("-fopenmp")
         .add_common_option("-march=native")
         .add_common_option("-mtune=native")
         .add_compile_option("-funroll-loops")
@@ -487,7 +486,7 @@ std::string PyStructuredSDFG::compile(
     }
 
 #if defined(__APPLE__)
-    compile_builder.add_common_option("-Xpreprocessor");
+    compile_builder.add_common_option("-Xpreprocessor -fopenmp");
     compile_builder.add_include_path("/opt/homebrew/include");
     compile_builder.add_library_path("/opt/homebrew/opt/libomp/lib")
         .add_library_path("/opt/homebrew/opt/libomp/include")
@@ -495,6 +494,7 @@ std::string PyStructuredSDFG::compile(
     compile_builder.add_link_option("-lomp");
     compile_builder.add_link_option("-framework Accelerate");
 #else
+    compile_builder.add_common_option("-fopenmp");
     compile_builder.add_link_option("-lblas");
 #endif
 

--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -423,7 +423,8 @@ std::string PyStructuredSDFG::compile(
     const std::string& target,
     const std::string& instrumentation_mode,
     bool capture_args,
-    bool debug_build
+    bool debug_build,
+    int threads
 ) const {
     fs::path build_path(output_folder);
     if (!fs::exists(build_path)) {
@@ -503,7 +504,7 @@ std::string PyStructuredSDFG::compile(
     docc::target::add_highway_build_support(compile_builder);
 
     auto fcomp_handler = compile_builder.build();
-    docc::compile::CodegenBuildPool pool(1);
+    docc::compile::CodegenBuildPool pool((threads > 0) ? threads : std::thread::hardware_concurrency());
 
     std::shared_ptr<sdfg::codegen::CodeSnippetFactory> snippet_factory = fcomp_handler->create_snippet_factory(*sdfg_);
     sdfg::codegen::CPPCodeGenerator

--- a/python/bindings/py_structured_sdfg.h
+++ b/python/bindings/py_structured_sdfg.h
@@ -72,12 +72,23 @@ public:
 
     void schedule(const std::string& target, const std::string& category, bool remote_tuning = false);
 
+    /**
+     * Build the shared library containing the SDFG
+     * @param output_folder will contain src and binary files
+     * @param target
+     * @param instrumentation_mode
+     * @param capture_args
+     * @param debug_build build with debug info
+     * @param threads number of threads to use for the compile. 0 or negative means auto (max. hardware threads)
+     * @return
+     */
     std::string compile(
         const std::string& output_folder,
         const std::string& target,
         const std::string& instrumentation_mode = "",
         bool capture_args = false,
-        bool debug_build = false
+        bool debug_build = false,
+        int threads = 0
     ) const;
 
     std::string metadata(const std::string& key) const;

--- a/python/bindings/py_structured_sdfg.h
+++ b/python/bindings/py_structured_sdfg.h
@@ -6,20 +6,23 @@
 #include <sdfg/structured_control_flow/sequence.h>
 #include <sdfg/structured_sdfg.h>
 
+#include "sdfg/plugins/plugins.h"
+
 class PyStructuredSDFGBuilder;
 
 class PyStructuredSDFG {
     friend class PyStructuredSDFGBuilder;
 
 private:
+    sdfg::plugins::Context& docc_context_;
     std::unique_ptr<sdfg::StructuredSDFG> sdfg_;
 
-    PyStructuredSDFG(std::unique_ptr<sdfg::StructuredSDFG>& sdfg);
+    PyStructuredSDFG(sdfg::plugins::Context& ctx, std::unique_ptr<sdfg::StructuredSDFG>& sdfg);
 
 public:
-    static PyStructuredSDFG parse(const std::string& sdfg_text);
+    static PyStructuredSDFG parse(sdfg::plugins::Context& ctx, const std::string& sdfg_text);
 
-    static PyStructuredSDFG from_file(const std::string& file_path);
+    static PyStructuredSDFG from_file(sdfg::plugins::Context& ctx, const std::string& file_path);
 
     /**
      * @brief Create a PyStructuredSDFG from a unique_ptr
@@ -27,9 +30,11 @@ public:
      * This factory method is used internally for operations like cutout
      * that create new SDFGs.
      */
-    static PyStructuredSDFG from_sdfg(std::unique_ptr<sdfg::StructuredSDFG> sdfg);
+    static PyStructuredSDFG from_sdfg(sdfg::plugins::Context& ctx, std::unique_ptr<sdfg::StructuredSDFG> sdfg);
 
     std::string name() const;
+
+    sdfg::plugins::Context& docc_context() const;
 
     sdfg::StructuredSDFG& sdfg() { return *sdfg_; }
 
@@ -71,7 +76,8 @@ public:
         const std::string& output_folder,
         const std::string& target,
         const std::string& instrumentation_mode = "",
-        bool capture_args = false
+        bool capture_args = false,
+        bool debug_build = false
     ) const;
 
     std::string metadata(const std::string& key) const;

--- a/python/docc/compiler/docc_program.py
+++ b/python/docc/compiler/docc_program.py
@@ -17,8 +17,26 @@ from docc.compiler.target_registry import (
 )
 
 
-def _is_debug_dump() -> bool:
-    return bool(os.environ.get("DOCC_DEBUG"))
+def _parse_docc_debug() -> dict[str, str]:
+    debug_env = os.environ.get("DOCC_DEBUG", "")
+    debug_dict = {}
+    if debug_env:
+        for entry in debug_env.split(";"):
+            if not entry:
+                continue
+            parts = entry.split("=", 1)
+            key = parts[0].strip()
+            value = parts[1].strip() if len(parts) > 1 else ""
+            debug_dict[key] = value
+    return debug_dict
+
+
+def _is_debug_dump(flags: dict[str, str]) -> bool:
+    return "dump" in flags
+
+
+def _is_debug_compile(flags: dict[str, str]) -> bool:
+    return "build" in flags
 
 
 class DoccProgram(ABC):
@@ -38,7 +56,9 @@ class DoccProgram(ABC):
         self.remote_tuning = remote_tuning
         self.last_sdfg: Optional[StructuredSDFG] = None
         self.cache: dict = {}
-        self.debug_dump: bool = _is_debug_dump()
+        debug_flags = _parse_docc_debug()
+        self.debug_dump: bool = _is_debug_dump(debug_flags)
+        self.debug_build: bool = _is_debug_compile(debug_flags)
 
         # Check environment variable DOCC_CI
         docc_ci = os.environ.get("DOCC_CI", "")
@@ -131,7 +151,11 @@ class DoccProgram(ABC):
         custom_compile_fn = get_target_compile_fn(self.target)
         if custom_compile_fn is not None:
             lib_path = custom_compile_fn(
-                sdfg, output_folder, instrumentation_mode, capture_args, {}
+                sdfg,
+                output_folder,
+                instrumentation_mode,
+                capture_args,
+                {"debug_build": self.debug_build},
             )
         else:
             lib_path = sdfg._compile(
@@ -139,6 +163,7 @@ class DoccProgram(ABC):
                 target=self.target,
                 instrumentation_mode=instrumentation_mode,
                 capture_args=capture_args,
+                debug_build=self.debug_build,
             )
 
         # Dump statistics after compile

--- a/python/docc/compiler/docc_program.py
+++ b/python/docc/compiler/docc_program.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 import sys
 from typing import Any, Optional
 import os
+import re
 
 from docc.sdfg import StructuredSDFG
 from docc.sdfg._sdfg import (
@@ -21,7 +22,7 @@ def _parse_docc_debug() -> dict[str, str]:
     debug_env = os.environ.get("DOCC_DEBUG", "")
     debug_dict = {}
     if debug_env:
-        for entry in debug_env.split(";"):
+        for entry in re.split(r"[;:]", debug_env):
             if not entry:
                 continue
             parts = entry.split("=", 1)
@@ -37,6 +38,10 @@ def _is_debug_dump(flags: dict[str, str]) -> bool:
 
 def _is_debug_compile(flags: dict[str, str]) -> bool:
     return "build" in flags
+
+
+def _get_build_thread_count(flags: dict[str, str]) -> int:
+    return int(flags.get("build_threads", "0"))
 
 
 class DoccProgram(ABC):
@@ -59,6 +64,7 @@ class DoccProgram(ABC):
         debug_flags = _parse_docc_debug()
         self.debug_dump: bool = _is_debug_dump(debug_flags)
         self.debug_build: bool = _is_debug_compile(debug_flags)
+        self.build_thread_count: int = _get_build_thread_count(debug_flags)
 
         # Check environment variable DOCC_CI
         docc_ci = os.environ.get("DOCC_CI", "")
@@ -155,7 +161,7 @@ class DoccProgram(ABC):
                 output_folder,
                 instrumentation_mode,
                 capture_args,
-                {"debug_build": self.debug_build},
+                {"debug_build": self.debug_build, "threads": self.build_thread_count},
             )
         else:
             lib_path = sdfg._compile(
@@ -164,6 +170,7 @@ class DoccProgram(ABC):
                 instrumentation_mode=instrumentation_mode,
                 capture_args=capture_args,
                 debug_build=self.debug_build,
+                threads=self.build_thread_count,
             )
 
         # Dump statistics after compile

--- a/sdfg/include/sdfg/codegen/code_generator.h
+++ b/sdfg/include/sdfg/codegen/code_generator.h
@@ -67,6 +67,8 @@ public:
 
     virtual ~CodeGenerator() = default;
 
+    [[nodiscard]] const StructuredSDFG& sdfg() const { return this->sdfg_; };
+
     /**
      * @brief Generate the code
      *
@@ -77,12 +79,19 @@ public:
     /// @brief Generate a function definition for the SDFG
     virtual std::string function_definition() = 0;
 
+    /// @brief write the contents of the main header into out
+    virtual bool emit_header(PrettyPrinter& out) = 0;
+
+    /// @brief write the contents of the main source file into out. Can also generate additional source files (snippets)
+    /// that also depend on the header
+    virtual bool emit_main_source(std::ostream& out, const std::filesystem::path& header_path) = 0;
+
     /// @brief Generate the SDFG's code into source files
     virtual bool as_source(const std::filesystem::path& header_path, const std::filesystem::path& source_path) = 0;
 
     /// @brief Generate only the function source code and append it to the source file. @ref as_source generates this
     /// into `source_path` after includes, globals and structs
-    virtual void append_function_source(std::ofstream& ofs_source) = 0;
+    virtual void append_function_source(std::ostream& ofs_source) = 0;
 
     /// @brief Get the includes
     const PrettyPrinter& includes() const { return this->includes_stream_; };

--- a/sdfg/include/sdfg/codegen/code_generators/c_code_generator.h
+++ b/sdfg/include/sdfg/codegen/code_generators/c_code_generator.h
@@ -11,9 +11,9 @@ private:
     CLanguageExtension language_extension_;
 
 protected:
-    void dispatch_includes() override;
+    void dispatch_header_includes(PrettyPrinter& out) override;
 
-    void dispatch_structures() override;
+    void dispatch_header_structures(PrettyPrinter& out) override;
 
     void dispatch_globals() override;
 

--- a/sdfg/include/sdfg/codegen/code_generators/c_style_base_code_generator.h
+++ b/sdfg/include/sdfg/codegen/code_generators/c_style_base_code_generator.h
@@ -12,9 +12,13 @@ class CStyleBaseCodeGenerator : public CodeGenerator {
 protected:
     virtual LanguageExtension& language_extension() = 0;
 
-    virtual void dispatch_includes() = 0;
+    void dispatch_header(PrettyPrinter& out);
 
-    virtual void dispatch_structures() = 0;
+    void dispatch_includes();
+    virtual void dispatch_header_includes(PrettyPrinter& out) = 0;
+
+    void dispatch_structures();
+    virtual void dispatch_header_structures(PrettyPrinter& out) = 0;
 
     virtual void dispatch_globals() = 0;
 
@@ -32,9 +36,13 @@ public:
 
     bool generate() override;
 
+    bool emit_header(PrettyPrinter& out) override;
+
+    bool emit_main_source(std::ostream& out, const std::filesystem::path& header_path) override;
+
     bool as_source(const std::filesystem::path& header_path, const std::filesystem::path& source_path) override;
 
-    void append_function_source(std::ofstream& ofs_source) override;
+    void append_function_source(std::ostream& ofs_source) override;
 
     virtual void emit_capture_context_init(std::ostream& ofs_source) const = 0;
 };

--- a/sdfg/include/sdfg/codegen/code_generators/cpp_code_generator.h
+++ b/sdfg/include/sdfg/codegen/code_generators/cpp_code_generator.h
@@ -12,9 +12,9 @@ private:
     CPPLanguageExtension language_extension_;
 
 protected:
-    void dispatch_includes() override;
+    void dispatch_header_includes(PrettyPrinter& out) override;
 
-    void dispatch_structures() override;
+    void dispatch_header_structures(PrettyPrinter& out) override;
 
     void dispatch_globals() override;
 

--- a/sdfg/include/sdfg/codegen/code_generators/cuda_code_generator.h
+++ b/sdfg/include/sdfg/codegen/code_generators/cuda_code_generator.h
@@ -13,8 +13,9 @@ private:
 
 protected:
     void dispatch_includes();
-
+    void dispatch_header_includes(PrettyPrinter& out);
     void dispatch_structures();
+    void dispatch_header_structures(PrettyPrinter& out);
 
     void dispatch_globals();
 
@@ -33,9 +34,12 @@ public:
 
     std::string function_definition() override;
 
+    bool emit_header(PrettyPrinter& out) override;
+    bool emit_main_source(std::ostream& out, const std::filesystem::path& header_path) override;
+
     bool as_source(const std::filesystem::path& header_path, const std::filesystem::path& source_path) override;
 
-    void append_function_source(std::ofstream& ofs_source) override;
+    void append_function_source(std::ostream& ofs_source) override;
 };
 
 } // namespace codegen

--- a/sdfg/include/sdfg/codegen/utils.h
+++ b/sdfg/include/sdfg/codegen/utils.h
@@ -13,6 +13,7 @@ class PrettyPrinter {
 public:
     // Constructor
     PrettyPrinter(int indent = 0, bool frozen = false);
+    PrettyPrinter(std::ostream& stream, int indent = 0, bool frozen = false);
 
     // Set the indentation level
     void setIndent(int indent);
@@ -42,7 +43,8 @@ public:
     PrettyPrinter& operator<<(std::ostream& (*manip)(std::ostream&) );
 
 private:
-    std::stringstream stream;
+    std::unique_ptr<std::stringstream> owned_stream;
+    std::ostream& stream;
     int indentSize;
     bool isNewLine = true;
     bool frozen_;

--- a/sdfg/include/sdfg/data_flow/pointer_metadata.h
+++ b/sdfg/include/sdfg/data_flow/pointer_metadata.h
@@ -44,7 +44,7 @@ public:
     /**
      * Despite this being a leak of the pointer,
      * the user will only use it for blocking accesses to the underlying data and not keep a reference to the data in
-     * any way Like a Rust temporary borrow for the duration for the LibNode and no more.
+     * any way. Like a Rust temporary borrow for the duration of the LibNode and no more.
      */
     bool no_ptr_escape() const { return no_ptr_escape_; }
 

--- a/sdfg/include/sdfg/plugins/plugins.h
+++ b/sdfg/include/sdfg/plugins/plugins.h
@@ -7,6 +7,7 @@
 #include "sdfg/codegen/dispatchers/map_dispatcher.h"
 #include "sdfg/codegen/dispatchers/node_dispatcher_registry.h"
 #include "sdfg/passes/scheduler/scheduler_registry.h"
+#include "sdfg/plugins/targets.h"
 #include "sdfg/serializer/json_serializer.h"
 #include "sdfg/structured_sdfg.h"
 
@@ -25,6 +26,8 @@ struct Context {
     // Schedulers
     passes::scheduler::SchedulerRegistry& scheduler_registry;
 
+    std::unordered_map<std::string, docc::target::DoccTarget*> available_targets;
+
     static Context global_context() {
         return Context{
             serializer::LibraryNodeSerializerRegistry::instance(),
@@ -33,6 +36,19 @@ struct Context {
             codegen::LibraryNodeDispatcherRegistry::instance(),
             passes::scheduler::SchedulerRegistry::instance()
         };
+    }
+
+    bool add_target(docc::target::DoccTarget* target) {
+        auto res = available_targets.insert_or_assign(target->short_name, target);
+        return res.second;
+    }
+
+    docc::target::DoccTarget* get_target_handler(const std::string& target) const {
+        auto it = available_targets.find(target);
+        if (it != available_targets.end()) {
+            return it->second;
+        }
+        return nullptr;
     }
 };
 

--- a/sdfg/include/sdfg/plugins/targets.h
+++ b/sdfg/include/sdfg/plugins/targets.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace docc::compile {
+class SrcFileCompilerBuilder;
+}
+
+namespace docc::target {
+
+struct DoccTarget {
+    std::string short_name;
+
+    bool (*apply_additional_compile_options)(docc::compile::SrcFileCompilerBuilder& src_compile_builder);
+};
+
+} // namespace docc::target

--- a/sdfg/src/codegen/code_generators/c_code_generator.cpp
+++ b/sdfg/src/codegen/code_generators/c_code_generator.cpp
@@ -35,32 +35,32 @@ void CCodeGenerator::emit_capture_context_init(std::ostream& ofs_source) const {
     ofs_source << std::endl;
 }
 
-void CCodeGenerator::dispatch_includes() {
+void CCodeGenerator::dispatch_header_includes(PrettyPrinter& out) {
 #if defined(__linux__)
-    this->includes_stream_ << "#include <alloca.h>" << std::endl;
-    this->includes_stream_ << "#include <malloc.h>" << std::endl;
+    out << "#include <alloca.h>" << std::endl;
+    out << "#include <malloc.h>" << std::endl;
 #endif
 
-    this->includes_stream_ << "#include <math.h>" << std::endl;
-    this->includes_stream_ << "#include <stdbool.h>" << std::endl;
-    this->includes_stream_ << "#include <stdio.h>" << std::endl;
-    this->includes_stream_ << "#include <stdlib.h>" << std::endl;
-    this->includes_stream_ << "#include <string.h>" << std::endl;
-    this->includes_stream_ << "#include <stdint.h>" << std::endl;
+    out << "#include <math.h>" << std::endl;
+    out << "#include <stdbool.h>" << std::endl;
+    out << "#include <stdio.h>" << std::endl;
+    out << "#include <stdlib.h>" << std::endl;
+    out << "#include <string.h>" << std::endl;
+    out << "#include <stdint.h>" << std::endl;
 
 #if defined(__APPLE__)
-    this->includes_stream_ << "#include <Accelerate/Accelerate.h>" << std::endl;
+    out << "#include <Accelerate/Accelerate.h>" << std::endl;
 #else
-    this->includes_stream_ << "#include <cblas.h>" << std::endl;
+    out << "#include <cblas.h>" << std::endl;
 #endif
 
-    this->includes_stream_ << "#include <daisy_rtl/daisy_rtl.h>" << std::endl;
+    out << "#include <daisy_rtl/daisy_rtl.h>" << std::endl;
 };
 
-void CCodeGenerator::dispatch_structures() {
+void CCodeGenerator::dispatch_header_structures(PrettyPrinter& out) {
     // Forward declarations
     for (auto& structure : sdfg_.structures()) {
-        this->classes_stream_ << "typedef struct " << structure << " " << structure << ";" << std::endl;
+        out << "typedef struct " << structure << " " << structure << ";" << std::endl;
     }
 
     // Generate topology-sorted structure definitions
@@ -101,27 +101,26 @@ void CCodeGenerator::dispatch_structures() {
     for (auto& structure_index : order) {
         std::string structure = names.at(structure_index);
         auto& definition = sdfg_.structure(structure);
-        this->classes_stream_ << "typedef struct ";
+        out << "typedef struct ";
         if (definition.is_packed()) {
-            this->classes_stream_ << "__attribute__((packed)) ";
+            out << "__attribute__((packed)) ";
         }
-        this->classes_stream_ << structure << std::endl;
-        this->classes_stream_ << "{\n";
+        out << structure << std::endl;
+        out << "{\n";
 
         for (size_t i = 0; i < definition.num_members(); i++) {
             auto& member_type = definition.member_type(symbolic::integer(i));
             if (auto pointer_type = dynamic_cast<const sdfg::types::Pointer*>(&member_type)) {
                 if (pointer_type->has_pointee_type() &&
                     dynamic_cast<const sdfg::types::Structure*>(&pointer_type->pointee_type())) {
-                    this->classes_stream_ << "struct ";
+                    out << "struct ";
                 }
             }
-            this->classes_stream_
-                << language_extension_.declaration("member_" + std::to_string(i), member_type, false, true);
-            this->classes_stream_ << ";" << std::endl;
+            out << language_extension_.declaration("member_" + std::to_string(i), member_type, false, true);
+            out << ";" << std::endl;
         }
 
-        this->classes_stream_ << "} " << structure << ";" << std::endl;
+        out << "} " << structure << ";" << std::endl;
     }
 };
 

--- a/sdfg/src/codegen/code_generators/c_style_base_code_generator.cpp
+++ b/sdfg/src/codegen/code_generators/c_style_base_code_generator.cpp
@@ -32,7 +32,38 @@ bool CStyleBaseCodeGenerator::generate() {
     this->dispatch_globals();
     this->dispatch_schedule();
     return true;
-};
+}
+
+bool CStyleBaseCodeGenerator::emit_header(PrettyPrinter& out) {
+    out << "#pragma once" << std::endl;
+
+    dispatch_header(out);
+    return true;
+}
+
+void CStyleBaseCodeGenerator::dispatch_header(PrettyPrinter& out) {
+    dispatch_header_includes(out);
+    dispatch_header_structures(out);
+}
+
+void CStyleBaseCodeGenerator::dispatch_includes() { dispatch_header_includes(this->includes_stream_); }
+
+void CStyleBaseCodeGenerator::dispatch_structures() { dispatch_header_structures(this->classes_stream_); }
+
+bool CStyleBaseCodeGenerator::emit_main_source(std::ostream& out, const std::filesystem::path& header_path) {
+    out << "#include \"" << header_path.filename().string() << "\"" << std::endl;
+    dispatch_globals();
+    dispatch_schedule();
+
+    for (auto& snippet : library_snippet_factory_->globals_snippets()) {
+        out << snippet << std::endl;
+    }
+
+    out << this->globals_stream_.str() << std::endl;
+
+    append_function_source(out);
+    return true;
+}
 
 bool CStyleBaseCodeGenerator::as_source(const std::filesystem::path& header_path, const std::filesystem::path& source_path) {
     std::ofstream ofs_header(header_path, std::ofstream::out | std::ofstream::trunc);
@@ -63,7 +94,7 @@ bool CStyleBaseCodeGenerator::as_source(const std::filesystem::path& header_path
     return true;
 }
 
-void CStyleBaseCodeGenerator::append_function_source(std::ofstream& ofs_source) {
+void CStyleBaseCodeGenerator::append_function_source(std::ostream& ofs_source) {
     std::unique_ptr<std::vector<CaptureVarPlan>> capturePlan;
     if (!arg_capture_plan_.is_empty()) {
         this->emit_capture_context_init(ofs_source);

--- a/sdfg/src/codegen/code_generators/cpp_code_generator.cpp
+++ b/sdfg/src/codegen/code_generators/cpp_code_generator.cpp
@@ -35,31 +35,31 @@ void CPPCodeGenerator::emit_capture_context_init(std::ostream& ofs_source) const
     ofs_source << std::endl;
 }
 
-void CPPCodeGenerator::dispatch_includes() {
+void CPPCodeGenerator::dispatch_header_includes(PrettyPrinter& out) {
 #if defined(__linux__)
-    this->includes_stream_ << "#include <alloca.h>" << std::endl;
-    this->includes_stream_ << "#include <malloc.h>" << std::endl;
+    out << "#include <alloca.h>" << std::endl;
+    out << "#include <malloc.h>" << std::endl;
 #endif
 
-    this->includes_stream_ << "#include <cmath>" << std::endl;
-    this->includes_stream_ << "#include <cstdio>" << std::endl;
-    this->includes_stream_ << "#include <cstdlib>" << std::endl;
-    this->includes_stream_ << "#include <cstring>" << std::endl;
-    this->includes_stream_ << "#include <cstdint>" << std::endl;
+    out << "#include <cmath>" << std::endl;
+    out << "#include <cstdio>" << std::endl;
+    out << "#include <cstdlib>" << std::endl;
+    out << "#include <cstring>" << std::endl;
+    out << "#include <cstdint>" << std::endl;
 
 #if defined(__APPLE__)
-    this->includes_stream_ << "#include <Accelerate/Accelerate.h>" << std::endl;
+    out << "#include <Accelerate/Accelerate.h>" << std::endl;
 #else
-    this->includes_stream_ << "#include <cblas.h>" << std::endl;
+    out << "#include <cblas.h>" << std::endl;
 #endif
 
-    this->includes_stream_ << "#include <daisy_rtl/daisy_rtl.h>" << std::endl;
-};
+    out << "#include <daisy_rtl/daisy_rtl.h>" << std::endl;
+}
 
-void CPPCodeGenerator::dispatch_structures() {
+void CPPCodeGenerator::dispatch_header_structures(PrettyPrinter& out) {
     // Forward declarations
     for (auto& structure : sdfg_.structures()) {
-        this->classes_stream_ << "struct " << structure << ";" << std::endl;
+        out << "struct " << structure << ";" << std::endl;
     }
 
     // Generate topology-sorted structure definitions
@@ -100,26 +100,25 @@ void CPPCodeGenerator::dispatch_structures() {
     for (auto& structure_index : order) {
         std::string structure = names.at(structure_index);
         auto& definition = sdfg_.structure(structure);
-        this->classes_stream_ << "struct ";
+        out << "struct ";
         if (definition.is_packed()) {
-            this->classes_stream_ << "__attribute__((packed)) ";
+            out << "__attribute__((packed)) ";
         }
-        this->classes_stream_ << structure << std::endl;
-        this->classes_stream_ << "{\n";
+        out << structure << std::endl;
+        out << "{\n";
 
         for (size_t i = 0; i < definition.num_members(); i++) {
             auto& member_type = definition.member_type(symbolic::integer(i));
             if (dynamic_cast<const sdfg::types::Structure*>(&member_type)) {
-                this->classes_stream_ << "struct ";
+                out << "struct ";
             }
-            this->classes_stream_
-                << language_extension_.declaration("member_" + std::to_string(i), member_type, false, true);
-            this->classes_stream_ << ";" << std::endl;
+            out << language_extension_.declaration("member_" + std::to_string(i), member_type, false, true);
+            out << ";" << std::endl;
         }
 
-        this->classes_stream_ << "};" << std::endl;
+        out << "};" << std::endl;
     }
-};
+}
 
 void CPPCodeGenerator::dispatch_globals() {
     // Declare globals

--- a/sdfg/src/codegen/code_generators/cuda_code_generator.cpp
+++ b/sdfg/src/codegen/code_generators/cuda_code_generator.cpp
@@ -44,6 +44,25 @@ std::string CUDACodeGenerator::function_definition() {
     return "extern \"C\" __global__ void " + sdfg_.name() + "(" + arglist.str() + ")";
 };
 
+bool CUDACodeGenerator::emit_header(PrettyPrinter& out) {
+    out << "#pragma once" << std::endl;
+    dispatch_header_includes(out);
+    dispatch_header_structures(out);
+    return true;
+}
+
+bool CUDACodeGenerator::emit_main_source(std::ostream& out, const std::filesystem::path& header_path) {
+    out << "#include \"" << header_path.filename().string() << "\"" << std::endl;
+    dispatch_globals();
+    dispatch_schedule();
+
+    out << this->globals_stream_.str() << std::endl;
+
+    append_function_source(out);
+
+    return true;
+}
+
 bool CUDACodeGenerator::as_source(const std::filesystem::path& header_path, const std::filesystem::path& source_path) {
     std::ofstream ofs_header(header_path, std::ofstream::out);
     if (!ofs_header.is_open()) {
@@ -71,24 +90,28 @@ bool CUDACodeGenerator::as_source(const std::filesystem::path& header_path, cons
     return true;
 };
 
-void CUDACodeGenerator::append_function_source(std::ofstream& ofs_source) {
+void CUDACodeGenerator::append_function_source(std::ostream& ofs_source) {
     ofs_source << this->function_definition() << std::endl;
     ofs_source << "{" << std::endl;
     ofs_source << this->main_stream_.str() << std::endl;
     ofs_source << "}" << std::endl;
 }
 
-void CUDACodeGenerator::dispatch_includes() {
-    this->includes_stream_ << "#define "
-                           << "__DAISY_NVVM__" << std::endl;
-    this->includes_stream_ << "#include <cstdint>" << std::endl;
-    this->includes_stream_ << "#include <daisy_rtl/daisy_rtl.h>" << std::endl;
+void CUDACodeGenerator::dispatch_includes() { this->dispatch_header_includes(this->includes_stream_); }
+
+void CUDACodeGenerator::dispatch_header_includes(PrettyPrinter& out) {
+    out << "#define "
+        << "__DAISY_NVVM__" << std::endl;
+    out << "#include <cstdint>" << std::endl;
+    out << "#include <daisy_rtl/daisy_rtl.h>" << std::endl;
 };
 
-void CUDACodeGenerator::dispatch_structures() {
+void CUDACodeGenerator::dispatch_structures() { this->dispatch_header_structures(this->classes_stream_); }
+
+void CUDACodeGenerator::dispatch_header_structures(PrettyPrinter& out) {
     // Forward declarations
     for (auto& structure : sdfg_.structures()) {
-        this->classes_stream_ << "struct " << structure << ";" << std::endl;
+        out << "struct " << structure << ";" << std::endl;
     }
 
     // Generate topology-sorted structure definitions
@@ -129,24 +152,23 @@ void CUDACodeGenerator::dispatch_structures() {
     for (auto& structure_index : order) {
         std::string structure = names.at(structure_index);
         auto& definition = sdfg_.structure(structure);
-        this->classes_stream_ << "struct ";
+        out << "struct ";
         if (definition.is_packed()) {
-            this->classes_stream_ << "__attribute__((packed)) ";
+            out << "__attribute__((packed)) ";
         }
-        this->classes_stream_ << structure << std::endl;
-        this->classes_stream_ << "{\n";
+        out << structure << std::endl;
+        out << "{\n";
 
         for (size_t i = 0; i < definition.num_members(); i++) {
             auto& member_type = definition.member_type(symbolic::integer(i));
             if (dynamic_cast<const sdfg::types::Structure*>(&member_type)) {
-                this->classes_stream_ << "struct ";
+                out << "struct ";
             }
-            this->classes_stream_
-                << language_extension_.declaration("member_" + std::to_string(i), member_type, false, true);
-            this->classes_stream_ << ";" << std::endl;
+            out << language_extension_.declaration("member_" + std::to_string(i), member_type, false, true);
+            out << ";" << std::endl;
         }
 
-        this->classes_stream_ << "};" << std::endl;
+        out << "};" << std::endl;
     }
 };
 

--- a/sdfg/src/codegen/utils.cpp
+++ b/sdfg/src/codegen/utils.cpp
@@ -5,9 +5,11 @@ namespace codegen {
 
 // Constructor
 PrettyPrinter::PrettyPrinter(int indent, bool frozen)
-    : indentSize(indent), frozen_(frozen) {
+    : owned_stream(std::make_unique<std::stringstream>()), stream(*owned_stream.get()), indentSize(indent),
+      frozen_(frozen) {}
 
-      };
+PrettyPrinter::PrettyPrinter(std::ostream& stream, int indent, bool frozen)
+    : stream(stream), indentSize(indent), frozen_(frozen) {}
 
 // Set the indentation level
 void PrettyPrinter::setIndent(int indent) { indentSize = indent; };
@@ -17,13 +19,13 @@ int PrettyPrinter::indent() const { return indentSize; };
 int PrettyPrinter::changeIndent(int delta) { return indentSize += delta; };
 
 // Get the underlying string
-std::string PrettyPrinter::str() const { return stream.str(); };
+std::string PrettyPrinter::str() const { return owned_stream->str(); };
 
 // Clear the stringstream content
 void PrettyPrinter::clear() {
-    stream.str("");
-    stream.clear();
-};
+    owned_stream->str("");
+    owned_stream->clear();
+}
 
 // Overload for manipulators (like std::endl)
 PrettyPrinter& PrettyPrinter::operator<<(std::ostream& (*manip)(std::ostream&) ) {

--- a/sdfg/src/passes/dataflow/dead_data_elimination.cpp
+++ b/sdfg/src/passes/dataflow/dead_data_elimination.cpp
@@ -363,7 +363,7 @@ void IndirectMemoryAccessFinder::use_as_src_node(
         }
         // Library nodes may get a pointer as input. But some of them we know enough about,
         // to know they are only borrowing the pointer for read access during their execution, not representing an
-        // actual leak these we can instead cound as indirect readse
+        // actual leak. These we can instead count as indirect reads
         if (edge.is_src_read()) {
             if (auto* libNode = dynamic_cast<const data_flow::LibraryNode*>(&edge.dst())) {
                 auto conns = libNode->inputs();
@@ -387,8 +387,8 @@ void IndirectMemoryAccessFinder::use_as_dst_node(
         }
         // hack to classify Offload nodes with D2H correctly. For historic reasons they use a direct output edge
         // to the host ptr, even though they will never write the pointer, but only write the memory the pointer points
-        // to as that edge is destructive to many optimizations and scheduled to be removed, cuhere custom handleing per
-        // node
+        // to. As that edge is destructive to many optimizations and scheduled to be removed, use custom handling here
+        // to classify it correctly
         if (edge.is_dst_write()) {
             if (auto* offload = dynamic_cast<const offloading::DataOffloadingNode*>(&edge.src())) {
                 if (offload->transfer_direction() != offloading::DataTransferDirection::NONE) {

--- a/targets/et/CMakeLists.txt
+++ b/targets/et/CMakeLists.txt
@@ -14,6 +14,12 @@ target_include_directories(docc-target-et
         $<INSTALL_INTERFACE:${PARENT_PROJECT_INSTALL_PREFIX}include>
 )
 
+target_include_directories(docc-target-et
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../c-compile/include
+) # very hacky to get access to the SrcFileCompilerBuilder interface. Needs better lib structure
+
+
 target_compile_definitions(docc-target-et PUBLIC
     DOCC_HAS_TARGET_ET
 )

--- a/targets/et/include/docc/target/et/target.h
+++ b/targets/et/include/docc/target/et/target.h
@@ -4,8 +4,11 @@
 #include <sdfg/analysis/analysis.h>
 #include <sdfg/builder/structured_sdfg_builder.h>
 #include <sdfg/plugins/plugins.h>
+#include <sdfg/plugins/targets.h>
 
 namespace docc::target::et {
+
+extern DoccTarget et_target;
 
 inline sdfg::data_flow::ImplementationType ImplementationType_ETSOC_WithTransfers{"ETSOC_WithTransfers"};
 inline sdfg::data_flow::ImplementationType ImplementationType_ETSOC_WithoutTransfers{"ETSOC_WithoutTransfers"};

--- a/targets/et/src/et/target.cpp
+++ b/targets/et/src/et/target.cpp
@@ -8,6 +8,7 @@
 
 #include "docc/target/et/target.h"
 
+#include "docc/compile/file_compiler.h"
 #include "docc/target/et/blas/gemm.h"
 
 namespace docc::target::et {
@@ -15,6 +16,86 @@ namespace docc::target::et {
 using namespace sdfg;
 
 static std::filesystem::path ET_INSTALL_PATH = "/opt/et";
+
+DoccTarget et_target = {
+    .short_name = "etsoc",
+    .apply_additional_compile_options = [](compile::SrcFileCompilerBuilder& builder) -> bool {
+        builder.add_include_path(ET_INSTALL_PATH / "include");
+        builder.add_include_path(ET_INSTALL_PATH / "include/esperanto");
+        builder.add_library_path(ET_INSTALL_PATH / "lib");
+        builder.add_link_option(" -Wl,-rpath," + (ET_INSTALL_PATH / "lib").string());
+        builder.add_link_option("-ldocc-rt-et");
+        builder.add_link_option("-ldebug");
+        builder.add_link_option("-llogging");
+        builder.add_link_option("-lg3log");
+        builder.add_link_option("-letrt");
+        builder.add_link_option("-ldeviceLayer");
+        builder.add_link_option("-lsw-sysemu");
+        builder.add_link_option("-lglog");
+
+        auto& docc_paths = builder.docc_paths();
+        if (auto rt_inc_dir = docc_paths.get_builtin_target_plugin_rt_include_path("et")) {
+            builder.add_include_path(rt_inc_dir.value());
+        }
+        if (auto rt_lib_dir = docc_paths.get_builtin_target_plugin_rt_lib_path("et")) {
+            builder.add_library_path(rt_lib_dir.value());
+        }
+
+        compile::SrcFileCompilerBuilder etBuilder;
+        etBuilder.inherit(builder, false);
+        etBuilder.set_src_extension(ETSOC_KERNEL_FILE_EXT);
+        etBuilder.set_bin_extension("elf");
+        etBuilder.set_compiler(ET_INSTALL_PATH / "bin" / "riscv64-unknown-elf-g++");
+        etBuilder.set_link_immediately(true);
+        etBuilder.add_common_option("--specs=nano.specs");
+        etBuilder.add_common_option("-mcmodel=medany");
+        etBuilder.add_common_option("-march=rv64imfc");
+        etBuilder.add_common_option("-mabi=lp64f");
+        etBuilder.add_common_option("-mno-strict-align");
+        etBuilder.add_common_option("-mno-riscv-attribute");
+        etBuilder.add_common_option("-fstack-usage");
+        etBuilder.add_compile_option("-Wall");
+        etBuilder.add_compile_option("-Wextra");
+        etBuilder.add_compile_option("-Wdouble-promotion");
+        etBuilder.add_compile_option("-Wformat");
+        etBuilder.add_compile_option("-Wnull-dereference");
+        etBuilder.add_compile_option("-Wswitch-enum");
+        etBuilder.add_compile_option("-Wshadow");
+        etBuilder.add_compile_option("-Wstack-protector");
+        etBuilder.add_compile_option("-Wpointer-arith");
+        etBuilder.add_compile_option("-Wundef");
+        etBuilder.add_compile_option("-Wcast-qual");
+        etBuilder.add_compile_option("-Wcast-align");
+        etBuilder.add_compile_option("-Wconversion");
+        etBuilder.add_compile_option("-Wlogical-op");
+        etBuilder.add_compile_option("-Wmissing-declarations");
+        etBuilder.add_compile_option("-Wno-main");
+
+        if (auto libexec_src_dir = docc_paths.get_builtin_target_plugin_rt_libexec_src_path("et", "etsoc1-dev")) {
+            auto dir = libexec_src_dir.value();
+            etBuilder.add_include_path(dir / "include");
+            etBuilder.add_link_option(dir / "crt.S");
+            etBuilder.add_link_option("-T " + (dir / "sections.ld").string());
+        }
+
+        etBuilder.add_include_path(ET_INSTALL_PATH / "cm-umode" / "include"); // was -isystem
+        etBuilder.add_include_path(ET_INSTALL_PATH / "include" / "esperanto"); // was -isystem
+        etBuilder.add_compile_option("-O3");
+        etBuilder.add_compile_option("-DNDEBUG");
+        etBuilder.add_compile_option("-flto=auto");
+        etBuilder.add_compile_option("-fno-fat-lto-objects");
+        etBuilder.add_link_option("-nostdlib");
+        etBuilder.add_link_option("-nostartfiles");
+        etBuilder.add_link_option("-Wl,--gc-sections");
+        etBuilder.add_link_option("-lc");
+        etBuilder.add_link_option("-lm");
+        etBuilder.add_link_option("-lgcc");
+        etBuilder.add_link_option(ET_INSTALL_PATH / "cm-umode/lib/libcm-umode.a");
+
+        builder.redirect_snippet(ETSOC_KERNEL_FILE_EXT, etBuilder.build());
+        return true;
+    }
+};
 
 void register_plugin(plugins::Context& context) {
     auto& libNodeDispatcherRegistry = context.library_node_dispatcher_registry;
@@ -31,6 +112,8 @@ void register_plugin(plugins::Context& context) {
             );
         }
     );
+
+    context.add_target(&et_target);
 }
 
 void et_scheduling_passes(

--- a/targets/et/src/et/target.cpp
+++ b/targets/et/src/et/target.cpp
@@ -8,7 +8,7 @@
 
 #include "docc/target/et/target.h"
 
-#include "docc/compile/file_compiler.h"
+#include "docc/compile/src_file_compiler_builder.h"
 #include "docc/target/et/blas/gemm.h"
 
 namespace docc::target::et {
@@ -92,7 +92,7 @@ DoccTarget et_target = {
         etBuilder.add_link_option("-lgcc");
         etBuilder.add_link_option(ET_INSTALL_PATH / "cm-umode/lib/libcm-umode.a");
 
-        builder.redirect_snippet(ETSOC_KERNEL_FILE_EXT, etBuilder.build());
+        builder.redirect_snippet(ETSOC_KERNEL_FILE_EXT, std::move(etBuilder));
         return true;
     }
 };


### PR DESCRIPTION
 + DoccTarget to allow modularly adding support for snippets that need to be compiled differently (standalone, cross-compiled kernels or just with special compilers)
 + Builder infrastructure to define C/C++ build options with inheritance, overrides and ability to modify by plugins, extensions and targets as needed
 + The redirected handling of snippets based on the extension can contribute link-options when they have been used (the generic solution to highway support)
 + Model to handle any parallism for compile in its own class without having to touch the definitions and compile options
 + DoccPaths extended to resolve default plugin dirs (as used by et-plugin)
 + PrettyPrinter can write directly to another (file) stream instead of a local buffer
 * extended CodeGenerator to allow generating the header first and direct-to-file (its needed for all snippet & main compile, which could be parallel otherwise)
 + Defaults to parallel builds with as many cores as present
 + DOCC_DEBUG is more defined. A list of key-value pairs separated by ; or : Supported options: "dump" dump sdfgs, "build" add debug symbols, "build_threads=x" override thread count. less then 1 is the default auto-selection.
 + CodegenStats is integrated into the new Compiler concept. To reduce the impact of the asynchronicity, times are always measured, but only recored with the CodegenStats if enabled and later, in sequential places. The items recorded now include the sdfg & snippet names to identify slow parts