### PR TITLE
Suppress SymEngine compilation warnings when building for MLIR

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -5,6 +5,11 @@ project(mlir-sdfg VERSION 0.0.1 DESCRIPTION "MLIR to SDFG Conversion Library")
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Suppress SymEngine compilation warnings
+add_compile_options(-Wno-suggest-override)
+add_compile_options(-Wno-non-virtual-dtor)
+add_compile_options(-Wno-ignored-qualifiers)
+
 # This project is not built by default
 # Enable with: cmake -DDOCC_BUILD_MLIR=ON
 

--- a/mlir/lib/Target/SDFG/CMakeLists.txt
+++ b/mlir/lib/Target/SDFG/CMakeLists.txt
@@ -11,7 +11,7 @@ set(TARGET_SDFG_FILES
     TranslateToSDFG.cpp
 )
 
-set_source_files_properties(${TARGET_SDFG_FILES} PROPERTIES COMPILE_FLAGS "-fexceptions -Wno-suggest-override -Wno-non-virtual-dtor -Wno-ignored-qualifiers")
+set_source_files_properties(${TARGET_SDFG_FILES} PROPERTIES COMPILE_FLAGS -fexceptions)
 add_mlir_translation_library(MLIRTargetSDFG
     ${TARGET_SDFG_FILES}
 

--- a/mlir/lib/Target/SDFG/CMakeLists.txt
+++ b/mlir/lib/Target/SDFG/CMakeLists.txt
@@ -11,7 +11,7 @@ set(TARGET_SDFG_FILES
     TranslateToSDFG.cpp
 )
 
-set_source_files_properties(${TARGET_SDFG_FILES} PROPERTIES COMPILE_FLAGS -fexceptions)
+set_source_files_properties(${TARGET_SDFG_FILES} PROPERTIES COMPILE_FLAGS "-fexceptions -Wno-suggest-override -Wno-non-virtual-dtor -Wno-ignored-qualifiers")
 add_mlir_translation_library(MLIRTargetSDFG
     ${TARGET_SDFG_FILES}
 


### PR DESCRIPTION
When building the MLIR frontend, 250k lines of warnings are generated. We cannot fix them because they come from the SymEngine submodule repository. With this PR they are at least suppressed.