### PR TITLE
Enable transfer tuning for stencils

### DIFF
--- a/.github/workflows/unit_tests_linux.yml
+++ b/.github/workflows/unit_tests_linux.yml
@@ -114,6 +114,7 @@ jobs:
         env:
           SDFG_TEST_SDFG_PATH: ${{ github.workspace }}/examples/input/transfertuning/matmul_sdfg.json
           SDFG_TEST_SEQUENCE_PATH: ${{ github.workspace }}/examples/input/transfertuning/matmul_sequence.json
+          DOCC_ACCESS_TOKEN: ${{ secrets.DOCC_CI_TOKEN }}
         shell: bash
         run: |
           set -e
@@ -132,6 +133,10 @@ jobs:
 
           # Shut down the server
           kill "$SERVER_PID" || true
+
+          # Run production server transfer-tuning tests
+          cd "$GITHUB_WORKSPACE/build"
+          ./rpc/tests/sdfgrpc_daisytuner_rpc_test
 
   python-tests-linux:
     runs-on:

--- a/opt/src/passes/scheduler/loop_scheduling_pass.cpp
+++ b/opt/src/passes/scheduler/loop_scheduling_pass.cpp
@@ -92,13 +92,17 @@ bool LoopSchedulingPass::run_pass_target(
                 break;
             }
             case SchedulerAction::CHILDREN: {
-                auto children = loop_analysis.children(loop);
+                // Re-acquire analyses: find() may call cutout() which modifies
+                // the SDFG and invalidates all cached analyses.
+                auto& loop_analysis_fresh = analysis_manager.get<analysis::LoopAnalysis>();
+                auto& flop_analysis_fresh = analysis_manager.get<analysis::FlopAnalysis>();
+                auto children = loop_analysis_fresh.children(loop);
                 for (auto& child : children) {
                     queue.push_front(child);
 
                     SchedulerLoopInfo info;
-                    info.loop_info = loop_analysis.loop_info(child);
-                    info.flop = flop_analysis.get(child);
+                    info.loop_info = loop_analysis_fresh.loop_info(child);
+                    info.flop = flop_analysis_fresh.get(child);
                     scheduling_info_map[child] = info;
                 }
                 break;

--- a/rpc/tests/CMakeLists.txt
+++ b/rpc/tests/CMakeLists.txt
@@ -14,8 +14,18 @@ set(TEST_FILES
 
 # Now simply link against gtest or gtest_main as needed. Eg
 add_executable(sdfgrpc_test ${TEST_FILES})
-target_include_directories(sdfgrpc_test PRIVATE ./)
+target_include_directories(sdfgrpc_test PRIVATE ./ ${CMAKE_CURRENT_SOURCE_DIR}/../../opt/tests)
 target_link_libraries(sdfgrpc_test gtest_main sdfgrpc)
+
+# Daisytuner RPC tests (polybench transfer tuning regression tests)
+set(DAISYTUNER_RPC_TEST_FILES
+    passes/rpc/polybench_transfertuning_test.cpp
+    test_daisytuner_rpc.cpp
+)
+
+add_executable(sdfgrpc_daisytuner_rpc_test ${DAISYTUNER_RPC_TEST_FILES})
+target_include_directories(sdfgrpc_daisytuner_rpc_test PRIVATE ./ ${CMAKE_CURRENT_SOURCE_DIR}/../../opt/tests)
+target_link_libraries(sdfgrpc_daisytuner_rpc_test gtest_main sdfgrpc)
 if(SDFG_ENABLE_COVERAGE)
   target_compile_options(sdfgrpc_test PRIVATE
     -fprofile-instr-generate
@@ -24,9 +34,17 @@ if(SDFG_ENABLE_COVERAGE)
   target_link_options(sdfgrpc_test PRIVATE
     -fprofile-instr-generate
   )
+  target_compile_options(sdfgrpc_daisytuner_rpc_test PRIVATE
+    -fprofile-instr-generate
+    -fcoverage-mapping
+  )
+  target_link_options(sdfgrpc_daisytuner_rpc_test PRIVATE
+    -fprofile-instr-generate
+  )
 endif()
 
 add_test(NAME sdfgrpc_test_test COMMAND rpc_test)
 
 include(GoogleTest)
 gtest_discover_tests(sdfgrpc_test)
+gtest_discover_tests(sdfgrpc_daisytuner_rpc_test)

--- a/rpc/tests/passes/rpc/polybench_transfertuning_test.cpp
+++ b/rpc/tests/passes/rpc/polybench_transfertuning_test.cpp
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "sdfg/analysis/loop_analysis.h"
+#include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/passes/normalization/normalization.h"
+#include "sdfg/passes/pipeline.h"
+#include "sdfg/passes/rpc/rpc_scheduler.h"
+#include "sdfg/passes/scheduler/loop_scheduling_pass.h"
+#include "sdfg/structured_sdfg.h"
+
+#include "fixtures/polybench.h"
+
+using namespace sdfg;
+
+// Runs the RPC scheduling pass on a polybench SDFG after normalizing loops
+// (data parallelism + loop normalization), matching the real compiler pipeline.
+// This exercises the full LoopSchedulingPass traversal including the CHILDREN
+// descent path, catching regressions like use-after-free when find()
+// invalidates the analysis cache via cutout().
+static bool run_rpc_scheduling(std::unique_ptr<StructuredSDFG> init_sdfg) {
+    builder::StructuredSDFGBuilder builder(init_sdfg);
+    analysis::AnalysisManager analysis_manager(builder.subject());
+
+    passes::Pipeline data_parallelism = passes::Pipeline::data_parallelism();
+    data_parallelism.run(builder, analysis_manager);
+
+    passes::Pipeline lp_pipeline = passes::normalization::loop_normalization();
+    lp_pipeline.run(builder, analysis_manager);
+
+    analysis_manager.invalidate_all();
+
+    passes::scheduler::LoopSchedulingPass loop_scheduling_pass({"rpc"}, nullptr);
+    return loop_scheduling_pass.run(builder, analysis_manager);
+}
+
+// Tests with multiple loop nests where the scheduler must descend (CHILDREN)
+// into children because the outermost loop can't be directly transformed.
+
+TEST(PolybenchRPCSchedulerTest, Correlation) {
+    EXPECT_TRUE(run_rpc_scheduling(correlation()));
+}
+
+TEST(PolybenchRPCSchedulerTest, Covariance) {
+    EXPECT_TRUE(run_rpc_scheduling(covariance()));
+}
+
+TEST(PolybenchRPCSchedulerTest, Gemm) {
+    EXPECT_TRUE(run_rpc_scheduling(gemm()));
+}
+
+TEST(PolybenchRPCSchedulerTest, Gemver) {
+    EXPECT_TRUE(run_rpc_scheduling(gemver()));
+}
+
+TEST(PolybenchRPCSchedulerTest, Gesummv) {
+    EXPECT_TRUE(run_rpc_scheduling(gesummv()));
+}
+
+TEST(PolybenchRPCSchedulerTest, Symm) {
+    EXPECT_TRUE(run_rpc_scheduling(symm()));
+}
+
+TEST(PolybenchRPCSchedulerTest, Syr2k) {
+    EXPECT_TRUE(run_rpc_scheduling(syr2k()));
+}
+
+TEST(PolybenchRPCSchedulerTest, Syrk) {
+    EXPECT_TRUE(run_rpc_scheduling(syrk()));
+}
+
+TEST(PolybenchRPCSchedulerTest, Atax) {
+    EXPECT_TRUE(run_rpc_scheduling(atax()));
+}
+
+TEST(PolybenchRPCSchedulerTest, Bicg) {
+    EXPECT_TRUE(run_rpc_scheduling(bicg()));
+}
+
+TEST(PolybenchRPCSchedulerTest, Mvt) {
+    EXPECT_TRUE(run_rpc_scheduling(mvt()));
+}
+
+TEST(PolybenchRPCSchedulerTest, Cholesky) {
+    EXPECT_TRUE(run_rpc_scheduling(cholesky()));
+}
+
+TEST(PolybenchRPCSchedulerTest, Trmm) {
+    EXPECT_TRUE(run_rpc_scheduling(trmm()));
+}
+
+TEST(PolybenchRPCSchedulerTest, Doitgen) {
+    EXPECT_NO_THROW(run_rpc_scheduling(doitgen()));
+}
+
+TEST(PolybenchRPCSchedulerTest, Jacobi2d) {
+    EXPECT_NO_THROW(run_rpc_scheduling(jacobi_2d()));
+}
+
+TEST(PolybenchRPCSchedulerTest, Fdtd2d) {
+    EXPECT_TRUE(run_rpc_scheduling(fdtd_2d()));
+}

--- a/rpc/tests/test_daisytuner_rpc.cpp
+++ b/rpc/tests/test_daisytuner_rpc.cpp
@@ -1,0 +1,27 @@
+#include <gtest/gtest.h>
+
+#include "sdfg/codegen/dispatchers/node_dispatcher_registry.h"
+#include "sdfg/passes/rpc/daisytuner_rpc_context.h"
+#include "sdfg/passes/rpc/rpc_scheduler.h"
+#include "sdfg/serializer/json_serializer.h"
+
+
+class DaisytunerRpcTestEnvironment : public ::testing::Environment {
+public:
+    void SetUp() override {
+        try {
+            auto ctx = sdfg::passes::rpc::DaisytunerRpcContext::from_docc_config();
+            sdfg::passes::rpc::register_rpc_loop_opt(ctx, "sequential", "server", true);
+        } catch (const std::exception& e) {
+            // Optionally print a warning or skip tests
+        }
+    }
+};
+
+int main(int argc, char **argv) {
+    testing::InitGoogleTest(&argc, argv);
+    sdfg::codegen::register_default_dispatchers();
+    sdfg::serializer::register_default_serializers();
+    ::testing::AddGlobalTestEnvironment(new DaisytunerRpcTestEnvironment);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- Adds unit test for transfer tuning (using the production database for now)
- Enables the narrow case of stencils by creating a local loop analysis when stepping into a loop nest. I have an idea how to avoid the costly rebuild going forward, but I would prefer a working version before changing the cutout functionality, as auto-tuning and transfer tuning heavily rely on it.