### PR TITLE
Fixed LLVM frontend bugs

### DIFF
--- a/.github/workflows/unit_tests_linux.yml
+++ b/.github/workflows/unit_tests_linux.yml
@@ -61,13 +61,14 @@ jobs:
           LLVM_PROFILE_FILE="sdfglib_test.profraw" ./sdfg/tests/sdfglib_test
           LLVM_PROFILE_FILE="sdfgopt_test.profraw" ./opt/tests/sdfgopt_test
           LLVM_PROFILE_FILE="docc-target-et_test.profraw" ./targets/et/tests/docc-target-et_test
+          LLVM_PROFILE_FILE="c-compile_test.profraw" ./c-compile/tests/c-compile_test
           ./tutorial/printf_target/tests/printf_target_test
 
           # Run coverage
-          llvm-profdata-19 merge -sparse sdfglib_test.profraw sdfgopt_test.profraw docc-target-et_test.profraw -o default.profdata
+          llvm-profdata-19 merge -sparse sdfglib_test.profraw sdfgopt_test.profraw docc-target-et_test.profraw c-compile_test.profraw -o default.profdata
           cd ../
-          llvm-cov-19 export ./build/sdfg/tests/sdfglib_test -object ./build/opt/tests/sdfgopt_test -object ./build/targets/et/tests/docc-target-et_test -instr-profile=build/default.profdata -format=lcov > build/coverage_full.lcov
-          lcov --ignore-errors unused --extract build/coverage_full.lcov '*/sdfg/src/*' '*/sdfg/include/*' '*/opt/src/*' '*/opt/include/*' '*/targets/et/src/*' '*/targets/et/include/*' --output-file build/coverage.lcov
+          llvm-cov-19 export ./build/sdfg/tests/sdfglib_test -object ./build/opt/tests/sdfgopt_test -object ./build/targets/et/tests/docc-target-et_test -object ./c-compile/tests/c-compile_test -instr-profile=build/default.profdata -format=lcov > build/coverage_full.lcov
+          lcov --ignore-errors unused --extract build/coverage_full.lcov '*/sdfg/src/*' '*/sdfg/include/*' '*/opt/src/*' '*/opt/include/*' '*/targets/et/src/*' '*/targets/et/include/*' '*/c-compile/src/*' '*/c-compile/include/*' --output-file build/coverage.lcov
 
       - name: Test Arg-Capture-IO
         run: |

--- a/.github/workflows/unit_tests_linux.yml
+++ b/.github/workflows/unit_tests_linux.yml
@@ -67,7 +67,7 @@ jobs:
           # Run coverage
           llvm-profdata-19 merge -sparse sdfglib_test.profraw sdfgopt_test.profraw docc-target-et_test.profraw c-compile_test.profraw -o default.profdata
           cd ../
-          llvm-cov-19 export ./build/sdfg/tests/sdfglib_test -object ./build/opt/tests/sdfgopt_test -object ./build/targets/et/tests/docc-target-et_test -object ./c-compile/tests/c-compile_test -instr-profile=build/default.profdata -format=lcov > build/coverage_full.lcov
+          llvm-cov-19 export ./build/sdfg/tests/sdfglib_test -object ./build/opt/tests/sdfgopt_test -object ./build/targets/et/tests/docc-target-et_test -object ./build/c-compile/tests/c-compile_test -instr-profile=build/default.profdata -format=lcov > build/coverage_full.lcov
           lcov --ignore-errors unused --extract build/coverage_full.lcov '*/sdfg/src/*' '*/sdfg/include/*' '*/opt/src/*' '*/opt/include/*' '*/targets/et/src/*' '*/targets/et/include/*' '*/c-compile/src/*' '*/c-compile/include/*' --output-file build/coverage.lcov
 
       - name: Test Arg-Capture-IO

--- a/c-compile/tests/util/docc_paths_test.cpp
+++ b/c-compile/tests/util/docc_paths_test.cpp
@@ -4,19 +4,36 @@
 
 using namespace docc;
 
+void EXPECT_EQ_PATHS(std::string path1, std::string path2) {
+    if (path1.back() == '/') {
+        path1.pop_back();
+    }
+    if (path2.back() == '/') {
+        path2.pop_back();
+    }
+    EXPECT_EQ(path1, path2);
+}
+
+void EXPECT_EQ_PATHS(std::vector<std::filesystem::path> paths1, std::vector<std::filesystem::path> paths2) {
+    ASSERT_EQ(paths1.size(), paths2.size());
+    for (size_t i = 0; i < paths1.size(); i++) {
+        EXPECT_EQ_PATHS(paths1.at(i), paths2.at(i));
+    }
+}
+
 TEST(DoccPathsTest, ResolveCmakeSuffixRoot) {
     std::string root = "CMake:/home/daisy/docc-llvm/cmake-build-debug/docc:/home/daisy/docc-llvm/docc";
 
     auto p = util::DefaultDoccPaths::from_root(root);
 
-    EXPECT_EQ(p->bin_root(), "/home/daisy/docc-llvm/cmake-build-debug/docc");
-    EXPECT_EQ(p->src_root(), "/home/daisy/docc-llvm/docc");
+    EXPECT_EQ_PATHS(p->bin_root(), "/home/daisy/docc-llvm/cmake-build-debug/docc");
+    EXPECT_EQ_PATHS(p->src_root(), "/home/daisy/docc-llvm/docc");
     EXPECT_EQ(p->root_mode(), util::DefaultDoccPaths::DoccRootMode::CMake);
     std::vector<std::filesystem::path> expected_inc_paths = {
         "/home/daisy/docc-llvm/docc/rtl/include",
         "/home/daisy/docc-llvm/docc/arg-capture-io/include",
     };
-    EXPECT_EQ(p->get_default_include_paths(), expected_inc_paths);
+    EXPECT_EQ_PATHS(p->get_default_include_paths(), expected_inc_paths);
 }
 
 TEST(DoccPathsTest, FromLibraryLocation) {
@@ -25,8 +42,8 @@ TEST(DoccPathsTest, FromLibraryLocation) {
     std::filesystem::path ref_bin_root = std::filesystem::path(DOCC_BIN_ROOT).lexically_normal();
     std::filesystem::path ref_src_root = std::filesystem::path(DOCC_SRC_ROOT).lexically_normal();
 
-    EXPECT_EQ(p->bin_root().lexically_normal(), ref_bin_root);
-    EXPECT_EQ(p->src_root().lexically_normal(), ref_src_root);
+    EXPECT_EQ_PATHS(p->bin_root().lexically_normal(), ref_bin_root);
+    EXPECT_EQ_PATHS(p->src_root().lexically_normal(), ref_src_root);
     EXPECT_EQ(p->root_mode(), util::DefaultDoccPaths::DoccRootMode::CMake);
     std::vector<std::filesystem::path> expected_inc_paths = {
         ref_src_root / "rtl" / "include",
@@ -34,7 +51,7 @@ TEST(DoccPathsTest, FromLibraryLocation) {
     };
     auto inc_paths = p->get_default_include_paths();
     for (int i = 0; i < expected_inc_paths.size(); i++) {
-        EXPECT_EQ(inc_paths.at(i).lexically_normal(), expected_inc_paths.at(i).lexically_normal());
+        EXPECT_EQ_PATHS(inc_paths.at(i).lexically_normal(), expected_inc_paths.at(i).lexically_normal());
     }
 }
 
@@ -43,14 +60,14 @@ TEST(DoccPathsTest, ResolveCmakeDirectRoot) {
 
     auto p = util::DefaultDoccPaths::from_root(root);
 
-    EXPECT_EQ(p->bin_root(), "/home/daisy/docc/cmake-build-debug");
-    EXPECT_EQ(p->src_root(), "/home/daisy/docc");
+    EXPECT_EQ_PATHS(p->bin_root(), "/home/daisy/docc/cmake-build-debug");
+    EXPECT_EQ_PATHS(p->src_root(), "/home/daisy/docc");
     EXPECT_EQ(p->root_mode(), util::DefaultDoccPaths::DoccRootMode::CMake);
     std::vector<std::filesystem::path> expected_inc_paths = {
         "/home/daisy/docc/rtl/include",
         "/home/daisy/docc/arg-capture-io/include",
     };
-    EXPECT_EQ(p->get_default_include_paths(), expected_inc_paths);
+    EXPECT_EQ_PATHS(p->get_default_include_paths(), expected_inc_paths);
 }
 
 TEST(DoccPathsTest, ResolveDistRoot) {
@@ -58,13 +75,13 @@ TEST(DoccPathsTest, ResolveDistRoot) {
 
     auto p = util::DefaultDoccPaths::from_root(root);
 
-    EXPECT_EQ(p->bin_root(), "/usr/lib/docc-0.1.6/bin");
-    EXPECT_EQ(p->src_root(), "/usr/lib/docc-0.1.6");
+    EXPECT_EQ_PATHS(p->bin_root(), "/usr/lib/docc-0.1.6/bin");
+    EXPECT_EQ_PATHS(p->src_root(), "/usr/lib/docc-0.1.6");
     EXPECT_EQ(p->root_mode(), util::DefaultDoccPaths::DoccRootMode::Dist);
     std::vector<std::filesystem::path> expected_inc_paths = {
         "/usr/lib/docc-0.1.6/include",
     };
-    EXPECT_EQ(p->get_default_include_paths(), expected_inc_paths);
+    EXPECT_EQ_PATHS(p->get_default_include_paths(), expected_inc_paths);
 }
 
 TEST(DoccPathsTest, ResolveNoneRoot) {
@@ -74,11 +91,11 @@ TEST(DoccPathsTest, ResolveNoneRoot) {
 
     EXPECT_EQ(p->root_mode(), util::DefaultDoccPaths::DoccRootMode::None);
     std::vector<std::filesystem::path> expected_inc_paths = {};
-    EXPECT_EQ(p->get_default_include_paths(), expected_inc_paths);
+    EXPECT_EQ_PATHS(p->get_default_include_paths(), expected_inc_paths);
 
     root = "";
     p = util::DefaultDoccPaths::from_root(root);
 
     EXPECT_EQ(p->root_mode(), util::DefaultDoccPaths::DoccRootMode::None);
-    EXPECT_EQ(p->get_default_include_paths(), expected_inc_paths);
+    EXPECT_EQ_PATHS(p->get_default_include_paths(), expected_inc_paths);
 }

--- a/llvm/include/docc/cmd_args.h
+++ b/llvm/include/docc/cmd_args.h
@@ -31,6 +31,8 @@ namespace args {
 
 extern llvm::cl::opt<bool> DOCC_DOT_DUMP_SCHEDULED;
 
+extern llvm::cl::opt<bool> DOCC_DUMP_SDFG;
+
 /**
  * Only needed in linker right now, only here so that it can pass arg-validation.
  */

--- a/llvm/include/docc/lifting/function_to_sdfg.h
+++ b/llvm/include/docc/lifting/function_to_sdfg.h
@@ -21,8 +21,6 @@ private:
 
     size_t sdfg_counter;
 
-    bool dump_passes = false;
-
     std::unique_ptr<llvm::Region> expand_region(std::unique_ptr<llvm::Region>& R);
 
     // Entire function
@@ -39,7 +37,9 @@ private:
 
     std::unique_ptr<sdfg::StructuredSDFG> simplify(std::unique_ptr<sdfg::StructuredSDFG>& sdfg);
 
-    void dump_sdfg(const sdfg::StructuredSDFG& sdfg, const std::string& step) const;
+    void dump_sdfg(const sdfg::SDFG& sdfg, const std::string& step) const;
+
+    void dump_structured_sdfg(const sdfg::StructuredSDFG& sdfg, const std::string& step) const;
 
 public:
     FunctionToSDFG(llvm::Function& function, llvm::FunctionAnalysisManager& FAM, bool apply_on_linkonce_odr);

--- a/llvm/src/cmd_args.cpp
+++ b/llvm/src/cmd_args.cpp
@@ -69,6 +69,8 @@ llvm::cl::opt<bool> DOCC_DOT_DUMP_SCHEDULED(
     "docc-dot-scheduled", llvm::cl::desc("Dumps the scheduled graph to a DOT file"), llvm::cl::init(false)
 );
 
+llvm::cl::opt<bool> DOCC_DUMP_SDFG("docc-dump-sdfg", llvm::cl::desc("Enables Output of sdfgs"), llvm::cl::init(false));
+
 llvm::cl::opt<std::string> DOCC_LINK_MODE(
     "docc-link", llvm::cl::desc("Sets special options for how to link. Experimental"), llvm::cl::init("")
 );

--- a/llvm/src/lifting/function_to_sdfg.cpp
+++ b/llvm/src/lifting/function_to_sdfg.cpp
@@ -25,6 +25,7 @@
 #include <sdfg/passes/symbolic/type_minimization.h>
 
 #include "docc/analysis/sdfg_registry.h"
+#include "docc/cmd_args.h"
 #include "docc/lifting/functions/function_lifting.h"
 #include "docc/lifting/lift_report.h"
 #include "docc/lifting/lifting.h"
@@ -542,13 +543,17 @@ std::unique_ptr<sdfg::StructuredSDFG> FunctionToSDFG::apply(llvm::Region& region
     auto& TLI = this->FAM_.getResult<llvm::TargetLibraryAnalysis>(this->function_);
     Lifting lifting(TLI, *external_function, sdfg::FunctionType_CPU);
     std::unique_ptr<sdfg::SDFG> sdfg = lifting.run();
+    dump_sdfg(*sdfg, "0");
     sdfg->validate();
 
     sdfg::builder::SDFGBuilder builder_canon(sdfg);
     sdfg::passes::UnifyLoopExits unify_loop_exits_pass;
     unify_loop_exits_pass.run(builder_canon);
+    dump_sdfg(builder_canon.subject(), "1");
     unify_loop_exits_pass.run(builder_canon);
+    dump_sdfg(builder_canon.subject(), "2");
     unify_loop_exits_pass.run(builder_canon);
+    dump_sdfg(builder_canon.subject(), "3");
     sdfg = builder_canon.move();
 
     // Build StructuredSDFG
@@ -584,14 +589,18 @@ std::unique_ptr<sdfg::StructuredSDFG> FunctionToSDFG::apply() {
     auto& TLI = this->FAM_.getResult<llvm::TargetLibraryAnalysis>(this->function_);
     Lifting lifting(TLI, this->function_, sdfg::FunctionType_CPU);
     std::unique_ptr<sdfg::SDFG> sdfg = lifting.run();
+    dump_sdfg(*sdfg, "0");
     sdfg->validate();
 
     // Increase of graph complexity
     sdfg::builder::SDFGBuilder builder_canon(sdfg);
     sdfg::passes::UnifyLoopExits unify_loop_exits_pass;
     unify_loop_exits_pass.run(builder_canon);
+    dump_sdfg(builder_canon.subject(), "1");
     unify_loop_exits_pass.run(builder_canon);
+    dump_sdfg(builder_canon.subject(), "2");
     unify_loop_exits_pass.run(builder_canon);
+    dump_sdfg(builder_canon.subject(), "3");
     sdfg = builder_canon.move();
 
     // Build StructuredSDFG
@@ -675,7 +684,7 @@ std::unique_ptr<sdfg::StructuredSDFG> FunctionToSDFG::simplify(std::unique_ptr<s
     sdfg::builder::StructuredSDFGBuilder builder_opt(sdfg);
     sdfg::analysis::AnalysisManager analysis_manager(builder_opt.subject());
 
-    dump_sdfg(builder_opt.subject(), "0.init");
+    dump_structured_sdfg(builder_opt.subject(), "0.init");
 
     // Optimization Pipelines
     sdfg::passes::Pipeline dataflow_simplification = sdfg::passes::Pipeline::dataflow_simplification();
@@ -712,7 +721,7 @@ std::unique_ptr<sdfg::StructuredSDFG> FunctionToSDFG::simplify(std::unique_ptr<s
     dde.run(builder_opt, analysis_manager);
     dce.run(builder_opt, analysis_manager);
 
-    dump_sdfg(builder_opt.subject(), "1.dde");
+    dump_structured_sdfg(builder_opt.subject(), "1.dde");
 
     /***** Structured Loops *****/
 
@@ -729,7 +738,7 @@ std::unique_ptr<sdfg::StructuredSDFG> FunctionToSDFG::simplify(std::unique_ptr<s
         symbolic_simplification.run(builder_opt, analysis_manager);
     }
 
-    dump_sdfg(builder_opt.subject(), "2.cae");
+    dump_structured_sdfg(builder_opt.subject(), "2.cae");
 
     // Convert loops into structured loops
     sdfg::passes::WhileToForConversion for_conversion_pass;
@@ -738,7 +747,7 @@ std::unique_ptr<sdfg::StructuredSDFG> FunctionToSDFG::simplify(std::unique_ptr<s
     // Propagate for simpler indvar usage
     symbol_propagation_pass.run(builder_opt, analysis_manager);
 
-    dump_sdfg(builder_opt.subject(), "4.symprop");
+    dump_structured_sdfg(builder_opt.subject(), "4.symprop");
 
     // Eliminate redundant branches
     {
@@ -750,7 +759,7 @@ std::unique_ptr<sdfg::StructuredSDFG> FunctionToSDFG::simplify(std::unique_ptr<s
         } while (applies);
     }
 
-    dump_sdfg(builder_opt.subject(), "5.condelim");
+    dump_structured_sdfg(builder_opt.subject(), "5.condelim");
 
     // Normalize loop condition and update (run twice)
     sdfg::passes::normalization::LoopNormalFormPass loop_normalization_pass;
@@ -759,83 +768,94 @@ std::unique_ptr<sdfg::StructuredSDFG> FunctionToSDFG::simplify(std::unique_ptr<s
     dde.run(builder_opt, analysis_manager);
     dce.run(builder_opt, analysis_manager);
 
-    dump_sdfg(builder_opt.subject(), "6.loopnorm");
+    dump_structured_sdfg(builder_opt.subject(), "6.loopnorm");
 
     // Eliminate symbols correlated to loop iterators
     sdfg::passes::SymbolEvolution symbol_evolution_pass;
     symbol_evolution_pass.run(builder_opt, analysis_manager);
 
-    dump_sdfg(builder_opt.subject(), "7.symbevo");
+    dump_structured_sdfg(builder_opt.subject(), "7.symbevo");
 
     // Dead code elimination
     symbol_propagation_pass.run(builder_opt, analysis_manager);
     dde.run(builder_opt, analysis_manager);
     dce.run(builder_opt, analysis_manager);
 
-    dump_sdfg(builder_opt.subject(), "8.dde");
+    dump_structured_sdfg(builder_opt.subject(), "8.dde");
 
     /***** Data Parallelism *****/
 
     // Combine address calculations in memlets
     memlet_combine.run(builder_opt, analysis_manager);
 
-    dump_sdfg(builder_opt.subject(), "9.memletcomb");
+    dump_structured_sdfg(builder_opt.subject(), "9.memletcomb");
 
     // Move code out of loops where possible
     sdfg::passes::Pipeline code_motion = sdfg::passes::code_motion();
     code_motion.run(builder_opt, analysis_manager);
 
-    dump_sdfg(builder_opt.subject(), "10.codemotion");
+    dump_structured_sdfg(builder_opt.subject(), "10.codemotion");
 
     // Convert pointer-based iterators to indvar usage
     sdfg::passes::PointerEvolution pointer_evolution_pass;
     pointer_evolution_pass.run(builder_opt, analysis_manager);
     loop_normalization_pass.run(builder_opt, analysis_manager);
 
-    dump_sdfg(builder_opt.subject(), "11.pointerevo");
+    dump_structured_sdfg(builder_opt.subject(), "11.pointerevo");
 
     // Convert lib-calls into managed memory
     sdfg::passes::Pipeline memory = sdfg::passes::Pipeline::memory();
     memory.run(builder_opt, analysis_manager);
 
-    dump_sdfg(builder_opt.subject(), "12.memorymgmt");
+    dump_structured_sdfg(builder_opt.subject(), "12.memorymgmt");
 
     sdfg::passes::TypeMinimizationPass type_minimization_pass;
     type_minimization_pass.run(builder_opt, analysis_manager);
     type_minimization_pass.run(builder_opt, analysis_manager);
 
-    dump_sdfg(builder_opt.subject(), "13.typemin");
+    dump_structured_sdfg(builder_opt.subject(), "13.typemin");
 
     // Dead code elimination
     symbol_propagation_pass.run(builder_opt, analysis_manager);
     dce.run(builder_opt, analysis_manager);
     dde.run(builder_opt, analysis_manager);
 
-    dump_sdfg(builder_opt.subject(), "14.dde");
+    dump_structured_sdfg(builder_opt.subject(), "14.dde");
 
     // Convert for loops into maps
     sdfg::passes::For2MapPass map_conversion_pass;
     map_conversion_pass.run(builder_opt, analysis_manager);
 
-    dump_sdfg(builder_opt.subject(), "15.for2map");
+    dump_structured_sdfg(builder_opt.subject(), "15.for2map");
 
     // Move code out of maps where possible
     code_motion.run(builder_opt, analysis_manager);
 
-    dump_sdfg(builder_opt.subject(), "16.codemotion");
+    dump_structured_sdfg(builder_opt.subject(), "16.codemotion");
 
     // Dead code elimination
     dde.run(builder_opt, analysis_manager);
     dce.run(builder_opt, analysis_manager);
     dataflow_simplification.run(builder_opt, analysis_manager);
 
-    dump_sdfg(builder_opt.subject(), "17.dde");
+    dump_structured_sdfg(builder_opt.subject(), "17.dde");
 
     return builder_opt.move();
 }
 
-void FunctionToSDFG::dump_sdfg(const sdfg::StructuredSDFG& sdfg, const std::string& step) const {
-    if (dump_passes) {
+void FunctionToSDFG::dump_sdfg(const sdfg::SDFG& sdfg, const std::string& step) const {
+    if (args::DOCC_DUMP_SDFG) {
+        auto mod = function_.getParent();
+
+        auto out_dir = analysis::SDFGRegistry::docc_extract_dir(*mod);
+
+        std::filesystem::create_directories(out_dir);
+        sdfg::visualizer::DotVisualizer::writeToFile(sdfg, out_dir / (sdfg.name() + ".lifting." + step + ".dot"));
+    }
+}
+
+void FunctionToSDFG::dump_structured_sdfg(const sdfg::StructuredSDFG& sdfg, const std::string& step) const {
+    if (args::DOCC_DUMP_SDFG) {
         auto mod = function_.getParent();
 
         auto out_dir = analysis::SDFGRegistry::docc_extract_dir(*mod);

--- a/llvm/src/lifting/functions/libfunc_lifting.cpp
+++ b/llvm/src/lifting/functions/libfunc_lifting.cpp
@@ -380,14 +380,12 @@ sdfg::control_flow::State& LibFuncLifting::visit_free(
     llvm::Value* pointer_operand = instruction->getArgOperand(0);
     std::string input = utils::find_const_name_to_sdfg_name(this->constants_mapping_, pointer_operand);
     auto& input_node = this->builder_.add_access(current_state, input, dbg_info);
-    auto& output_node = this->builder_.add_access(current_state, input, dbg_info);
 
     // Define library node
     auto& lib_node = this->builder_.add_library_node<sdfg::stdlib::FreeNode>(current_state, dbg_info);
 
     sdfg::types::Pointer opaque_ptr;
     this->builder_.add_computational_memlet(current_state, input_node, lib_node, "_ptr", {}, opaque_ptr, dbg_info);
-    this->builder_.add_computational_memlet(current_state, lib_node, "_ptr", output_node, {}, opaque_ptr, dbg_info);
 
     return current_state;
 }

--- a/llvm/src/plugin.cpp
+++ b/llvm/src/plugin.cpp
@@ -62,13 +62,6 @@ llvm::cl::opt<bool> DOCC_LowerInvoke(
 
 llvm::cl::opt<bool> DOCC_Einsum("docc-einsum", llvm::cl::desc("Enables lifting Einstein notation."), llvm::cl::init(false));
 
-llvm::cl::opt<std::string> DOCC_DUMP_SDFG(
-    "docc-dump-sdfg",
-    llvm::cl::desc("Enables Output of sdfgs"),
-    llvm::cl::init("none"),
-    llvm::cl::value_desc("none|normalization")
-);
-
 static docc::analysis::AnalysisManager AM;
 
 #ifdef NDEBUG

--- a/llvm/tests/lifting/libfunc_lifting_test.cpp
+++ b/llvm/tests/lifting/libfunc_lifting_test.cpp
@@ -63,7 +63,7 @@ entry:
         EXPECT_NE(free_node, nullptr);
 
         EXPECT_EQ(state.dataflow().in_degree(*free_node), 1);
-        EXPECT_EQ(state.dataflow().out_degree(*free_node), 1);
+        EXPECT_EQ(state.dataflow().out_degree(*free_node), 0);
 
         auto& iedge = *state.dataflow().in_edges(*free_node).begin();
         EXPECT_EQ(iedge.dst_conn(), "_ptr");
@@ -73,15 +73,6 @@ entry:
 
         auto& src = static_cast<const sdfg::data_flow::AccessNode&>(iedge.src());
         EXPECT_EQ(src.data(), "a");
-
-        auto& oedge = *state.dataflow().out_edges(*free_node).begin();
-        EXPECT_EQ(oedge.src_conn(), "_ptr");
-        EXPECT_EQ(oedge.dst_conn(), "void");
-        EXPECT_EQ(oedge.subset().size(), 0);
-        EXPECT_EQ(oedge.base_type(), sdfg::types::Pointer());
-
-        auto& dst = static_cast<const sdfg::data_flow::AccessNode&>(oedge.dst());
-        EXPECT_EQ(dst.data(), "a");
     }
     EXPECT_TRUE(found_free);
 }

--- a/sdfg/include/sdfg/visualizer/dot_visualizer.h
+++ b/sdfg/include/sdfg/visualizer/dot_visualizer.h
@@ -20,6 +20,9 @@ private:
     std::string last_comp_name_cluster_;
     bool show_block_ids = false;
 
+    virtual void visualizeSDFG(const SDFG& sdfg) override;
+
+    virtual void visualizeStructuredSDFG(const StructuredSDFG& sdfg) override;
     virtual void visualizeBlock(const StructuredSDFG& sdfg, const structured_control_flow::Block& block) override;
     virtual void visualizeSequence(const StructuredSDFG& sdfg, const structured_control_flow::Sequence& sequence)
         override;
@@ -33,13 +36,13 @@ private:
         override;
     virtual void visualizeMap(const StructuredSDFG& sdfg, const structured_control_flow::Map& map_node) override;
 
+    virtual void visualizeDataFlowGraph(const std::string& id, const data_flow::DataFlowGraph& dfg) override;
+
 public:
     using Visualizer::Visualizer;
 
-    virtual void visualize() override;
-
-    static void writeToFile(const StructuredSDFG& sdfg, const std::filesystem::path& file);
-    static void writeToFile(const StructuredSDFG& sdfg, const std::filesystem::path* file = nullptr);
+    static void writeToFile(const Function& sdfg, const std::filesystem::path& file);
+    static void writeToFile(const Function& sdfg, const std::filesystem::path* file = nullptr);
 };
 
 } // namespace visualizer

--- a/sdfg/include/sdfg/visualizer/visualizer.h
+++ b/sdfg/include/sdfg/visualizer/visualizer.h
@@ -8,6 +8,7 @@
 #include "sdfg/data_flow/memlet.h"
 #include "sdfg/data_flow/tasklet.h"
 #include "sdfg/function.h"
+#include "sdfg/sdfg.h"
 #include "sdfg/structured_control_flow/block.h"
 #include "sdfg/structured_control_flow/control_flow_node.h"
 #include "sdfg/structured_control_flow/for.h"
@@ -25,11 +26,16 @@ namespace visualizer {
 class Visualizer {
 protected:
     codegen::PrettyPrinter stream_;
-    const StructuredSDFG& sdfg_;
+    const Function& sdfg_;
     std::vector<std::pair<const std::string, const std::string>> replacements_;
 
     virtual std::string expression(const std::string expr);
 
+    // SDFG nodes
+    virtual void visualizeSDFG(const SDFG& sdfg) = 0;
+
+    // Structured SDFG nodes
+    virtual void visualizeStructuredSDFG(const StructuredSDFG& sdfg) = 0;
     virtual void visualizeNode(const StructuredSDFG& sdfg, const structured_control_flow::ControlFlowNode& node);
     virtual void visualizeBlock(const StructuredSDFG& sdfg, const structured_control_flow::Block& block) = 0;
     virtual void visualizeSequence(const StructuredSDFG& sdfg, const structured_control_flow::Sequence& sequence) = 0;
@@ -41,6 +47,8 @@ protected:
     virtual void visualizeContinue(const StructuredSDFG& sdfg, const structured_control_flow::Continue& continue_node) = 0;
     virtual void visualizeMap(const StructuredSDFG& sdfg, const structured_control_flow::Map& map_node) = 0;
 
+    // Data Flow Graph
+    virtual void visualizeDataFlowGraph(const std::string& id, const data_flow::DataFlowGraph& dfg) = 0;
     virtual void visualizeTasklet(data_flow::Tasklet const& tasklet);
     virtual void visualizeForBounds(
         symbolic::Symbol const& indvar,
@@ -52,15 +60,13 @@ protected:
     std::string subsetRangeString(data_flow::Subset const& subset, int subIdx);
 
 public:
-    Visualizer(const StructuredSDFG& sdfg) : stream_{}, sdfg_{sdfg}, replacements_{} {};
+    Visualizer(const Function& sdfg) : stream_{}, sdfg_{sdfg}, replacements_{} {};
 
-    virtual void visualize() = 0;
+    virtual void visualize();
 
     codegen::PrettyPrinter const& getStream() const { return this->stream_; }
 
-    virtual void visualizeSubset(
-        Function const& function, data_flow::Subset const& begin_sub, types::IType const* type = nullptr, int subIdx = 0
-    );
+    virtual void visualizeSubset(data_flow::Subset const& begin_sub, types::IType const* type = nullptr, int subIdx = 0);
 };
 
 } // namespace visualizer

--- a/sdfg/src/codegen/code_generators/c_style_base_code_generator.cpp
+++ b/sdfg/src/codegen/code_generators/c_style_base_code_generator.cpp
@@ -92,6 +92,13 @@ bool CStyleBaseCodeGenerator::as_source(const std::filesystem::path& header_path
     for (auto& snippet : library_snippet_factory_->globals_snippets()) {
         ofs_source << snippet << std::endl;
     }
+    std::vector<std::string> includes;
+    for (auto* dep : library_snippet_factory_->get_used_lib_dependencies()) {
+        dep->enumerate_includes(includes);
+    }
+    for (auto& include : includes) {
+        ofs_source << "#include <" << include << ">" << std::endl;
+    }
     ofs_source << this->globals_stream_.str() << std::endl;
 
     append_function_source(ofs_source);

--- a/sdfg/src/visualizer/dot_visualizer.cpp
+++ b/sdfg/src/visualizer/dot_visualizer.cpp
@@ -10,6 +10,7 @@
 #include "sdfg/structured_control_flow/control_flow_node.h"
 #include "sdfg/structured_control_flow/sequence.h"
 #include "sdfg/structured_sdfg.h"
+#include "sdfg/symbolic/symbolic.h"
 
 namespace sdfg {
 namespace visualizer {
@@ -22,6 +23,81 @@ static std::string escapeDotId(const std::string& id, const std::string& prefix 
     return prefix + std::regex_replace(id, dotIdBadChars, "_");
 }
 
+void DotVisualizer::visualizeSDFG(const SDFG& sdfg) {
+    this->stream_.clear();
+    this->stream_ << "digraph SDFG {\n";
+    this->stream_.setIndent(4);
+    this->stream_ << "graph [compound=true];" << std::endl << "node [style=filled,fillcolor=white];" << std::endl;
+
+    // State identifier in DOT
+    std::unordered_map<size_t, std::string> node_ids;
+
+    // States as nodes
+    for (auto& state : sdfg.states()) {
+        auto id = escapeDotId(state.element_id(), "state_");
+        this->stream_ << "subgraph cluster_" << id << " {" << std::endl;
+        this->stream_.setIndent(this->stream_.indent() + 4);
+        this->stream_ << "style=filled;fillcolor=white;color=black;label=\"State " << state.element_id() << "\";"
+                      << std::endl
+                      << id << " [shape=point,style=invis;label=\"\"];" << std::endl;
+        this->visualizeDataFlowGraph(id, state.dataflow());
+        this->stream_.setIndent(this->stream_.indent() - 4);
+        this->stream_ << "}" << std::endl;
+        node_ids.insert({state.element_id(), id});
+    }
+
+    // Edges
+    for (auto& edge : sdfg.edges()) {
+        auto& src_id = node_ids.at(edge.src().element_id());
+        auto& dst_id = node_ids.at(edge.dst().element_id());
+        this->stream_ << src_id << " -> " << dst_id << " [ltail=cluster_" << src_id << ",lhead=cluster_" << dst_id
+                      << ",label=\"";
+
+        // Condition
+        bool print_condition = !symbolic::eq(edge.condition(), symbolic::__true__());
+        if (print_condition) {
+            this->stream_ << edge.condition()->__str__();
+        }
+
+        // Assignments
+        if (!edge.assignments().empty()) {
+            if (print_condition) {
+                this->stream_ << ",\\n";
+            }
+            this->stream_ << "{";
+            bool first = true;
+            for (auto& [var, expr] : edge.assignments()) {
+                if (!first) {
+                    this->stream_ << "; ";
+                }
+                this->stream_ << var->get_name() << " = " << expr->__str__();
+                first = false;
+            }
+            this->stream_ << "}";
+        }
+        this->stream_ << "\"];" << std::endl;
+    }
+
+    this->stream_.setIndent(0);
+    this->stream_ << "}" << std::endl;
+}
+
+void DotVisualizer::visualizeStructuredSDFG(const StructuredSDFG& sdfg) {
+    this->stream_.clear();
+    this->stream_ << "digraph " << escapeDotId(sdfg.name()) << " {" << std::endl;
+    this->stream_.setIndent(4);
+    this->stream_ << "graph [compound=true];" << std::endl;
+    this->stream_ << "subgraph cluster_" << escapeDotId(sdfg.name()) << " {" << std::endl;
+    this->stream_.setIndent(8);
+    this->stream_ << "node [style=filled,fillcolor=white];" << std::endl
+                  << "style=filled;color=lightblue;label=\"\";" << std::endl;
+    this->visualizeSequence(sdfg, sdfg.root());
+    this->stream_.setIndent(4);
+    this->stream_ << "}" << std::endl;
+    this->stream_.setIndent(0);
+    this->stream_ << "}" << std::endl;
+}
+
 void DotVisualizer::visualizeBlock(const StructuredSDFG& sdfg, const structured_control_flow::Block& block) {
     auto id = escapeDotId(block.element_id(), "block_");
     this->stream_ << "subgraph cluster_" << id << " {" << std::endl;
@@ -31,139 +107,7 @@ void DotVisualizer::visualizeBlock(const StructuredSDFG& sdfg, const structured_
         this->stream_ << "#" << block.element_id() << " ";
     }
     this->stream_ << "\";" << std::endl;
-    this->last_comp_name_cluster_ = "cluster_" + id;
-    if (block.dataflow().nodes().empty()) {
-        this->stream_ << id << " [shape=point,style=invis,label=\"\"];" << std::endl;
-        this->stream_.setIndent(this->stream_.indent() - 4);
-        this->stream_ << "}" << std::endl;
-        this->last_comp_name_ = id;
-        return;
-    }
-    this->last_comp_name_.clear();
-    std::list<const data_flow::DataFlowNode*> nodes = block.dataflow().topological_sort();
-    for (const data_flow::DataFlowNode* node : nodes) {
-        std::vector<std::string> in_connectors;
-        bool is_access_node = false;
-        bool node_will_show_literal_connectors = false;
-        auto nodeId = escapeDotId(node->element_id(), "id");
-        if (this->last_comp_name_.empty()) this->last_comp_name_ = nodeId;
-        if (const data_flow::Tasklet* tasklet = dynamic_cast<const data_flow::Tasklet*>(node)) {
-            this->stream_ << nodeId << " [shape=octagon,label=\"" << tasklet->output() << " = ";
-            this->visualizeTasklet(*tasklet);
-            this->stream_ << "\"];" << std::endl;
-
-            in_connectors = tasklet->inputs();
-            node_will_show_literal_connectors = true;
-        } else if (const data_flow::ConstantNode* constant_node = dynamic_cast<const data_flow::ConstantNode*>(node)) {
-            this->stream_ << nodeId << " [";
-            this->stream_ << "penwidth=3.0,";
-            if (sdfg.is_transient(constant_node->data())) this->stream_ << "style=\"dashed,filled\",";
-            this->stream_ << "label=\"" << constant_node->data() << "\"];" << std::endl;
-            is_access_node = true;
-        } else if (const data_flow::AccessNode* access_node = dynamic_cast<const data_flow::AccessNode*>(node)) {
-            this->stream_ << nodeId << " [";
-            this->stream_ << "penwidth=3.0,";
-            if (sdfg.is_transient(access_node->data())) this->stream_ << "style=\"dashed,filled\",";
-            this->stream_ << "label=\"" << access_node->data() << "\"];" << std::endl;
-            is_access_node = true;
-        } else if (const data_flow::LibraryNode* libnode = dynamic_cast<const data_flow::LibraryNode*>(node)) {
-            this->stream_ << nodeId << " [shape=doubleoctagon,label=\"" << libnode->toStr() << "\"];" << std::endl;
-            in_connectors = libnode->inputs();
-        }
-
-        std::unordered_set<std::string> unused_connectors(in_connectors.begin(), in_connectors.end());
-        for (const data_flow::Memlet& iedge : block.dataflow().in_edges(*node)) {
-            auto& src = iedge.src();
-            auto& dst_conn = iedge.dst_conn();
-            bool nonexistent_conn = false;
-
-            if (!is_access_node) {
-                auto it = unused_connectors.find(dst_conn);
-                if (it != unused_connectors.end()) {
-                    unused_connectors.erase(it); // remove connector from in_connectors, so it is not used again
-                } else {
-                    nonexistent_conn = true;
-                }
-            }
-
-            this->stream_ << escapeDotId(src.element_id(), "id") << " -> " << nodeId << " [label=\"   ";
-            bool dstIsVoid = dst_conn == "void";
-            bool dstIsRef = dst_conn == "ref";
-            bool dstIsDeref = dst_conn == "deref";
-            auto& src_conn = iedge.src_conn();
-            bool srcIsVoid = src_conn == "void";
-            bool srcIsDeref = src_conn == "deref";
-
-            if (nonexistent_conn) {
-                this->stream_ << "!!"; // this should not happen, but if it does, we can still visualize the memlet
-            }
-
-            if (dstIsVoid || dstIsRef || dstIsDeref) { // subset applies to dst
-                auto& dstVar = dynamic_cast<data_flow::AccessNode const&>(iedge.dst()).data();
-                bool subsetOnDst = false;
-                if (srcIsDeref && dstIsVoid) { // Pure Store by Memlet definition (Dereference Memlet Store)
-                    auto& subset = iedge.subset();
-                    if (subset.size() == 1 && symbolic::eq(subset[0], symbolic::integer(0))) {
-                        this->stream_ << "*" << dstVar; // store to pointer without further address calc
-                    } else { // fallback, this should not be allowed to happen
-                        this->stream_ << dstVar; // use access node name instead of connector-name
-                        subsetOnDst = true;
-                    }
-                } else if (dstIsVoid) { // computational memlet / output from tasklet / memory store
-                    this->stream_ << dstVar; // use access node name instead of connector-name
-                    subsetOnDst = true;
-                } else {
-                    this->stream_ << dstVar; // use access node name instead of connector-name
-                }
-                if (subsetOnDst) {
-                    this->visualizeSubset(sdfg, iedge.subset(), &iedge.base_type());
-                }
-            } else { // dst is a tasklet/library node
-                this->stream_ << dst_conn;
-            }
-
-            this->stream_ << " = ";
-
-            if (srcIsVoid || srcIsDeref) { // subset applies to src, could be computational, reference or dereference
-                                           // memlet
-                auto& srcVar = dynamic_cast<data_flow::AccessNode const&>(src).data();
-                bool subsetOnSrc = false;
-                if (srcIsVoid && dstIsRef) { // reference memlet / address-of / get-element-ptr equivalent
-                    this->stream_ << "&";
-                    subsetOnSrc = true;
-                } else if (srcIsVoid && dstIsDeref) { // Dereference memlet / load from address
-                    this->stream_ << "*";
-                    auto& subset = iedge.subset();
-                    if (subset.size() != 1 && symbolic::eq(subset[0], symbolic::integer(0))) { // does not match memlet
-                                                                                               // definition -> fallback
-                        subsetOnSrc = true;
-                    }
-                } else if (srcIsVoid) {
-                    subsetOnSrc = true;
-                }
-                this->stream_ << srcVar;
-                if (subsetOnSrc) {
-                    this->visualizeSubset(sdfg, iedge.subset(), &iedge.base_type());
-                }
-            } else {
-                this->stream_ << src_conn;
-            }
-            this->stream_ << "   \"];" << std::endl;
-        }
-
-        if (!node_will_show_literal_connectors) {
-            for (uint64_t i = 0; i < in_connectors.size(); ++i) {
-                auto& in_conn = in_connectors[i];
-                auto it = unused_connectors.find(in_conn);
-                if (it != unused_connectors.end()) {
-                    auto literal_id = escapeDotId(node->element_id(), "id") + "_" + escapeDotId(i, "in");
-                    this->stream_ << literal_id << " [style=\"invis\", label=\"\"];" << std::endl;
-                    this->stream_ << literal_id << " -> " << nodeId << " [style=\"dotted\", label=\"" << i << ":"
-                                  << in_conn << "\"]" << ";" << std::endl;
-                }
-            }
-        }
-    }
+    this->visualizeDataFlowGraph(id, block.dataflow());
     this->stream_.setIndent(this->stream_.indent() - 4);
     this->stream_ << "}" << std::endl;
 }
@@ -285,27 +229,145 @@ void DotVisualizer::visualizeMap(const StructuredSDFG& sdfg, const structured_co
     this->last_comp_name_cluster_ = "cluster_" + id;
 }
 
-void DotVisualizer::visualize() {
-    this->stream_.clear();
-    this->stream_ << "digraph " << escapeDotId(this->sdfg_.name()) << " {" << std::endl;
-    this->stream_.setIndent(4);
-    this->stream_ << "graph [compound=true];" << std::endl;
-    this->stream_ << "subgraph cluster_" << escapeDotId(this->sdfg_.name()) << " {" << std::endl;
-    this->stream_.setIndent(8);
-    this->stream_ << "node [style=filled,fillcolor=white];" << std::endl
-                  << "style=filled;color=lightblue;label=\"\";" << std::endl;
-    this->visualizeSequence(this->sdfg_, this->sdfg_.root());
-    this->stream_.setIndent(4);
-    this->stream_ << "}" << std::endl;
-    this->stream_.setIndent(0);
-    this->stream_ << "}" << std::endl;
+void DotVisualizer::visualizeDataFlowGraph(const std::string& id, const data_flow::DataFlowGraph& dfg) {
+    this->last_comp_name_cluster_ = "cluster_" + id;
+    if (dfg.nodes().empty()) {
+        this->stream_ << id << " [shape=point,style=invis,label=\"\"];" << std::endl;
+        this->last_comp_name_ = id;
+        return;
+    }
+    this->last_comp_name_.clear();
+    std::list<const data_flow::DataFlowNode*> nodes = dfg.topological_sort();
+    for (const data_flow::DataFlowNode* node : nodes) {
+        std::vector<std::string> in_connectors;
+        bool is_access_node = false;
+        bool node_will_show_literal_connectors = false;
+        auto nodeId = escapeDotId(node->element_id(), "id");
+        if (this->last_comp_name_.empty()) {
+            this->last_comp_name_ = nodeId;
+        }
+        if (const data_flow::Tasklet* tasklet = dynamic_cast<const data_flow::Tasklet*>(node)) {
+            this->stream_ << nodeId << " [shape=octagon,label=\"" << tasklet->output() << " = ";
+            this->visualizeTasklet(*tasklet);
+            this->stream_ << "\"];" << std::endl;
+
+            in_connectors = tasklet->inputs();
+            node_will_show_literal_connectors = true;
+        } else if (const data_flow::ConstantNode* constant_node = dynamic_cast<const data_flow::ConstantNode*>(node)) {
+            this->stream_ << nodeId << " [";
+            this->stream_ << "penwidth=3.0,";
+            if (this->sdfg_.is_transient(constant_node->data())) this->stream_ << "style=\"dashed,filled\",";
+            this->stream_ << "label=\"" << constant_node->data() << "\"];" << std::endl;
+            is_access_node = true;
+        } else if (const data_flow::AccessNode* access_node = dynamic_cast<const data_flow::AccessNode*>(node)) {
+            this->stream_ << nodeId << " [";
+            this->stream_ << "penwidth=3.0,";
+            if (this->sdfg_.is_transient(access_node->data())) this->stream_ << "style=\"dashed,filled\",";
+            this->stream_ << "label=\"" << access_node->data() << "\"];" << std::endl;
+            is_access_node = true;
+        } else if (const data_flow::LibraryNode* libnode = dynamic_cast<const data_flow::LibraryNode*>(node)) {
+            this->stream_ << nodeId << " [shape=doubleoctagon,label=\"" << libnode->toStr() << "\"];" << std::endl;
+            in_connectors = libnode->inputs();
+        }
+
+        std::unordered_set<std::string> unused_connectors(in_connectors.begin(), in_connectors.end());
+        for (const data_flow::Memlet& iedge : dfg.in_edges(*node)) {
+            auto& src = iedge.src();
+            auto& dst_conn = iedge.dst_conn();
+            bool nonexistent_conn = false;
+
+            if (!is_access_node) {
+                auto it = unused_connectors.find(dst_conn);
+                if (it != unused_connectors.end()) {
+                    unused_connectors.erase(it); // remove connector from in_connectors, so it is not used again
+                } else {
+                    nonexistent_conn = true;
+                }
+            }
+
+            this->stream_ << escapeDotId(src.element_id(), "id") << " -> " << nodeId << " [label=\"   ";
+            bool dstIsVoid = dst_conn == "void";
+            bool dstIsRef = dst_conn == "ref";
+            bool dstIsDeref = dst_conn == "deref";
+            auto& src_conn = iedge.src_conn();
+            bool srcIsVoid = src_conn == "void";
+            bool srcIsDeref = src_conn == "deref";
+
+            if (nonexistent_conn) {
+                this->stream_ << "!!"; // this should not happen, but if it does, we can still visualize the memlet
+            }
+
+            if (dstIsVoid || dstIsRef || dstIsDeref) { // subset applies to dst
+                auto& dstVar = dynamic_cast<data_flow::AccessNode const&>(iedge.dst()).data();
+                bool subsetOnDst = false;
+                if (srcIsDeref && dstIsVoid) { // Pure Store by Memlet definition (Dereference Memlet Store)
+                    auto& subset = iedge.subset();
+                    if (subset.size() == 1 && symbolic::eq(subset[0], symbolic::integer(0))) {
+                        this->stream_ << "*" << dstVar; // store to pointer without further address calc
+                    } else { // fallback, this should not be allowed to happen
+                        this->stream_ << dstVar; // use access node name instead of connector-name
+                        subsetOnDst = true;
+                    }
+                } else if (dstIsVoid) { // computational memlet / output from tasklet / memory store
+                    this->stream_ << dstVar; // use access node name instead of connector-name
+                    subsetOnDst = true;
+                } else {
+                    this->stream_ << dstVar; // use access node name instead of connector-name
+                }
+                if (subsetOnDst) {
+                    this->visualizeSubset(iedge.subset(), &iedge.base_type());
+                }
+            } else { // dst is a tasklet/library node
+                this->stream_ << dst_conn;
+            }
+
+            this->stream_ << " = ";
+
+            if (srcIsVoid || srcIsDeref) { // subset applies to src, could be computational, reference or dereference
+                                           // memlet
+                auto& srcVar = dynamic_cast<data_flow::AccessNode const&>(src).data();
+                bool subsetOnSrc = false;
+                if (srcIsVoid && dstIsRef) { // reference memlet / address-of / get-element-ptr equivalent
+                    this->stream_ << "&";
+                    subsetOnSrc = true;
+                } else if (srcIsVoid && dstIsDeref) { // Dereference memlet / load from address
+                    this->stream_ << "*";
+                    auto& subset = iedge.subset();
+                    if (subset.size() != 1 && symbolic::eq(subset[0], symbolic::integer(0))) { // does not match memlet
+                                                                                               // definition -> fallback
+                        subsetOnSrc = true;
+                    }
+                } else if (srcIsVoid) {
+                    subsetOnSrc = true;
+                }
+                this->stream_ << srcVar;
+                if (subsetOnSrc) {
+                    this->visualizeSubset(iedge.subset(), &iedge.base_type());
+                }
+            } else {
+                this->stream_ << src_conn;
+            }
+            this->stream_ << "   \"];" << std::endl;
+        }
+
+        if (!node_will_show_literal_connectors) {
+            for (uint64_t i = 0; i < in_connectors.size(); ++i) {
+                auto& in_conn = in_connectors[i];
+                auto it = unused_connectors.find(in_conn);
+                if (it != unused_connectors.end()) {
+                    auto literal_id = escapeDotId(node->element_id(), "id") + "_" + escapeDotId(i, "in");
+                    this->stream_ << literal_id << " [style=\"invis\", label=\"\"];" << std::endl;
+                    this->stream_ << literal_id << " -> " << nodeId << " [style=\"dotted\", label=\"" << i << ":"
+                                  << in_conn << "\"]" << ";" << std::endl;
+                }
+            }
+        }
+    }
 }
 
-void DotVisualizer::writeToFile(const StructuredSDFG& sdfg, const std::filesystem::path& file) {
-    writeToFile(sdfg, &file);
-}
+void DotVisualizer::writeToFile(const Function& sdfg, const std::filesystem::path& file) { writeToFile(sdfg, &file); }
 
-void DotVisualizer::writeToFile(const StructuredSDFG& sdfg, const std::filesystem::path* file) {
+void DotVisualizer::writeToFile(const Function& sdfg, const std::filesystem::path* file) {
     DotVisualizer viz(sdfg);
     viz.visualize();
 

--- a/sdfg/src/visualizer/visualizer.cpp
+++ b/sdfg/src/visualizer/visualizer.cpp
@@ -16,6 +16,7 @@
 #include "sdfg/structured_control_flow/return.h"
 #include "sdfg/structured_control_flow/sequence.h"
 #include "sdfg/structured_control_flow/while.h"
+#include "sdfg/structured_sdfg.h"
 #include "sdfg/symbolic/symbolic.h"
 #include "sdfg/types/type.h"
 #include "symengine/basic.h"
@@ -147,23 +148,22 @@ std::string Visualizer::subsetRangeString(data_flow::Subset const& subset, int s
 }
 
 /// @brief If known, use the type to better visualize structures. Then track the type as far as it goes.
-void Visualizer::
-    visualizeSubset(Function const& function, data_flow::Subset const& sub, types::IType const* type, int subIdx) {
+void Visualizer::visualizeSubset(data_flow::Subset const& sub, types::IType const* type, int subIdx) {
     if (static_cast<int>(sub.size()) <= subIdx) {
         return;
     }
     if (auto structure_type = dynamic_cast<const types::Structure*>(type)) {
-        types::StructureDefinition const& definition = function.structure(structure_type->name());
+        types::StructureDefinition const& definition = this->sdfg_.structure(structure_type->name());
 
         auto& memberIdx = sub.at(subIdx);
         if (!memberIdx.is_null() && SymEngine::is_a<SymEngine::Integer>(*memberIdx)) {
             this->stream_ << ".member_" << this->expression(memberIdx->__str__());
             auto& member_type = definition.member_type(SymEngine::rcp_dynamic_cast<const SymEngine::Integer>(memberIdx)
             );
-            this->visualizeSubset(function, sub, &member_type, subIdx + 1);
+            this->visualizeSubset(sub, &member_type, subIdx + 1);
         } else {
             this->stream_ << ".member[" << subsetRangeString(sub, subIdx) << "]";
-            this->visualizeSubset(function, sub, nullptr, subIdx + 1);
+            this->visualizeSubset(sub, nullptr, subIdx + 1);
         }
     } else if (auto tensor_type = dynamic_cast<const types::Tensor*>(type)) {
         auto& shape = tensor_type->shape();
@@ -175,12 +175,12 @@ void Visualizer::
             ++i;
         }
         if (subIdx < sub.size()) {
-            this->visualizeSubset(function, sub, &tensor_type->element_type(), subIdx);
+            this->visualizeSubset(sub, &tensor_type->element_type(), subIdx);
         }
     } else if (auto array_type = dynamic_cast<const types::Array*>(type)) {
         this->stream_ << "[" << subsetRangeString(sub, subIdx) << "]";
         types::IType const& element_type = array_type->element_type();
-        this->visualizeSubset(function, sub, &element_type, subIdx + 1);
+        this->visualizeSubset(sub, &element_type, subIdx + 1);
     } else if (auto pointer_type = dynamic_cast<const types::Pointer*>(type)) {
         this->stream_ << "[" << subsetRangeString(sub, subIdx) << "]";
         const types::IType* pointee_type;
@@ -193,13 +193,23 @@ void Visualizer::
             }
             pointee_type = nullptr;
         }
-        this->visualizeSubset(function, sub, pointee_type, subIdx + 1);
+        this->visualizeSubset(sub, pointee_type, subIdx + 1);
     } else {
         if (type == nullptr) {
             this->stream_ << "(rogue)";
         }
         this->stream_ << "[" << subsetRangeString(sub, subIdx) << "]";
-        visualizeSubset(function, sub, nullptr, subIdx + 1);
+        visualizeSubset(sub, nullptr, subIdx + 1);
+    }
+}
+
+void Visualizer::visualize() {
+    if (const auto* unstructured_sdfg = dynamic_cast<const SDFG*>(&this->sdfg_)) {
+        this->visualizeSDFG(*unstructured_sdfg);
+    } else if (const auto* structured_sdfg = dynamic_cast<const StructuredSDFG*>(&this->sdfg_)) {
+        this->visualizeStructuredSDFG(*structured_sdfg);
+    } else {
+        throw InvalidSDFGException("Visualizer: Invalid SDFG type");
     }
 }
 

--- a/sdfg/tests/visualizer/dot_visualizer_test.cpp
+++ b/sdfg/tests/visualizer/dot_visualizer_test.cpp
@@ -765,7 +765,7 @@ TEST(DotVisualizerTest, visualizeSubset_does_not_fail_on_incomplete_opaque_ptr) 
     {
         visualizer::DotVisualizer dot(sdfg);
 
-        dot.visualizeSubset(sdfg, {symbolic::zero()}, &opaque_desc);
+        dot.visualizeSubset({symbolic::zero()}, &opaque_desc);
 
         EXPECT_EQ(dot.getStream().str(), "[0]");
     }
@@ -773,7 +773,7 @@ TEST(DotVisualizerTest, visualizeSubset_does_not_fail_on_incomplete_opaque_ptr) 
     {
         visualizer::DotVisualizer dot(sdfg);
 
-        dot.visualizeSubset(sdfg, {symbolic::one()}, &opaque_desc);
+        dot.visualizeSubset({symbolic::one()}, &opaque_desc);
 
         EXPECT_EQ(dot.getStream().str(), "[1]#illgl");
     }
@@ -781,7 +781,7 @@ TEST(DotVisualizerTest, visualizeSubset_does_not_fail_on_incomplete_opaque_ptr) 
     {
         visualizer::DotVisualizer dot(sdfg);
 
-        dot.visualizeSubset(sdfg, {symbolic::zero(), symbolic::one()}, &opaque_desc);
+        dot.visualizeSubset({symbolic::zero(), symbolic::one()}, &opaque_desc);
 
         EXPECT_EQ(dot.getStream().str(), "[0](rogue)[1]");
     }


### PR DESCRIPTION
- Added c-compile unit tests to github workflow
- Fixed c-compile unit test regarding trailing slashs of paths
- Reactivated -docc-dump-sdfg flag of LLVM frontend to dump intermediate sdfgs to JSON and DOT
- Adapted DOT visualizer to also handle (unstructured) SDFGs
- Fixed a bug where the LLVM frontend created a FreeNode with an output edge
- Fixed a bug where the include files from library nodes where not used in code generation for LLVM frontend