### PR TITLE
Choose rocm gemm dispatcher based on precision

### DIFF
--- a/opt/src/targets/rocm/plugin.cpp
+++ b/opt/src/targets/rocm/plugin.cpp
@@ -81,10 +81,16 @@ void register_rocm_plugin(plugins::Context& context) {
         [](codegen::LanguageExtension& language_extension,
            const Function& function,
            const data_flow::DataFlowGraph& data_flow_graph,
-           const data_flow::LibraryNode& node) {
-            return std::make_unique<blas::GEMMNodeDispatcher_ROCMHandTuned>(
-                language_extension, function, data_flow_graph, dynamic_cast<const math::blas::GEMMNode&>(node)
-            );
+           const data_flow::LibraryNode& node) -> std::unique_ptr<codegen::LibraryNodeDispatcher> {
+            auto& library_node = dynamic_cast<const math::blas::GEMMNode&>(node);
+            if (library_node.precision() != math::blas::BLAS_Precision::s) {
+                return std::make_unique<blas::GEMMNodeDispatcher_ROCMBLASWithoutTransfers>(
+                    language_extension, function, data_flow_graph, library_node
+                );
+            } else {
+                return std::make_unique<
+                    blas::GEMMNodeDispatcher_ROCMHandTuned>(language_extension, function, data_flow_graph, library_node);
+            }
         }
     );
 

--- a/opt/tests/rocm/rocm_library_nodes_test.cpp
+++ b/opt/tests/rocm/rocm_library_nodes_test.cpp
@@ -5,6 +5,7 @@
 #include "sdfg/codegen/utils.h"
 #include "sdfg/symbolic/symbolic.h"
 #include "sdfg/targets/offloading/data_offloading_node.h"
+#include "sdfg/targets/rocm/plugin.h"
 #include "sdfg/targets/rocm/rocm.h"
 #include "sdfg/targets/rocm/rocm_data_offloading_node.h"
 #include "symengine/symengine_rcp.h"
@@ -142,5 +143,147 @@ TEST(ROCMFreeTest, DispatcherNoThrow) {
     ROCMDataOffloadingNodeDispatcher dispatcher(language_extension, builder.subject(), block.dataflow(), free_node);
     EXPECT_NO_THROW(dispatcher.dispatch(pretty_printer, globals_printer, snippet_factory));
 }
+
+
+TEST(RocBlasTest, GemmNodeWithoutDataTransfers_DoublePrecisionNoThrow) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+
+    int dim_i = 10;
+    int dim_j = 20;
+    int dim_k = 30;
+
+    types::Scalar desc(types::PrimitiveType::Double);
+    types::Array arr_a_type(desc, symbolic::mul(symbolic::integer(dim_k), symbolic::integer(dim_i)));
+    types::Array arr_b_type(desc, symbolic::mul(symbolic::integer(dim_j), symbolic::integer(dim_k)));
+    types::Array arr_res_type(desc, symbolic::mul(symbolic::integer(dim_j), symbolic::integer(dim_i)));
+
+    builder.add_container("arr_a", arr_a_type);
+    builder.add_container("arr_b", arr_b_type);
+    builder.add_container("output", arr_res_type);
+
+    auto& block = builder.add_block(sdfg.root());
+
+    auto& input_a_node = builder.add_access(block, "arr_a");
+    auto& input_b_node = builder.add_access(block, "arr_b");
+    auto& dummy_input_node = builder.add_access(block, "output");
+    auto& gemm_node = static_cast<math::blas::GEMMNode&>(builder.add_library_node<math::blas::GEMMNode>(
+        block,
+        DebugInfo(),
+        rocm::ImplementationType_ROCMWithoutTransfers,
+        math::blas::BLAS_Precision::d,
+        math::blas::BLAS_Layout::RowMajor,
+        math::blas::BLAS_Transpose::No,
+        math::blas::BLAS_Transpose::No,
+        symbolic::integer(dim_i),
+        symbolic::integer(dim_j),
+        symbolic::integer(dim_k),
+        symbolic::integer(dim_j),
+        symbolic::integer(dim_k),
+        symbolic::integer(dim_j)
+    ));
+
+    auto& alpha_node = builder.add_constant(block, "1.0", desc);
+    auto& beta_node = builder.add_constant(block, "0.0", desc);
+
+    builder.add_computational_memlet(block, input_a_node, gemm_node, "__A", {symbolic::integer(0)}, arr_a_type);
+    builder.add_computational_memlet(block, input_b_node, gemm_node, "__B", {symbolic::integer(0)}, arr_b_type);
+    builder.add_computational_memlet(block, dummy_input_node, gemm_node, "__C", {symbolic::integer(0)}, arr_res_type);
+    builder.add_computational_memlet(block, alpha_node, gemm_node, "__alpha", {}, desc);
+    builder.add_computational_memlet(block, beta_node, gemm_node, "__beta", {}, desc);
+
+    // Use a local registry so the test is isolated from global plugin state.
+    codegen::LibraryNodeDispatcherRegistry local_registry;
+    plugins::Context ctx{
+        serializer::LibraryNodeSerializerRegistry::instance(),
+        codegen::NodeDispatcherRegistry::instance(),
+        codegen::MapDispatcherRegistry::instance(),
+        local_registry,
+        passes::scheduler::SchedulerRegistry::instance()
+    };
+    rocm::register_rocm_plugin(ctx);
+
+    auto dispatcher_fn = local_registry.get_library_node_dispatcher(
+        math::blas::LibraryNodeType_GEMM.value() + "::" + rocm::ImplementationType_ROCMWithoutTransfers.value()
+    );
+    ASSERT_NE(dispatcher_fn, nullptr);
+
+    codegen::CLanguageExtension language_extension(sdfg);
+    auto dispatcher = dispatcher_fn(language_extension, sdfg, block.dataflow(), gemm_node);
+
+    codegen::PrettyPrinter stream;
+    codegen::PrettyPrinter globals_stream;
+    codegen::CodeSnippetFactory snippet_factory;
+
+    EXPECT_NO_THROW(dispatcher->dispatch(stream, globals_stream, snippet_factory));
+}
+
+TEST(RocBlasTest, GemmNodeWithoutDataTransfers_SinglePrecisionUsesHandTuned) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+
+    int dim_i = 10;
+    int dim_j = 20;
+    int dim_k = 30;
+
+    types::Scalar desc(types::PrimitiveType::Float);
+    types::Array arr_a_type(desc, symbolic::mul(symbolic::integer(dim_k), symbolic::integer(dim_i)));
+    types::Array arr_b_type(desc, symbolic::mul(symbolic::integer(dim_j), symbolic::integer(dim_k)));
+    types::Array arr_res_type(desc, symbolic::mul(symbolic::integer(dim_j), symbolic::integer(dim_i)));
+
+    builder.add_container("arr_a", arr_a_type);
+    builder.add_container("arr_b", arr_b_type);
+    builder.add_container("output", arr_res_type);
+
+    auto& block = builder.add_block(sdfg.root());
+
+    auto& input_a_node = builder.add_access(block, "arr_a");
+    auto& input_b_node = builder.add_access(block, "arr_b");
+    auto& dummy_input_node = builder.add_access(block, "output");
+    auto& gemm_node = static_cast<math::blas::GEMMNode&>(builder.add_library_node<math::blas::GEMMNode>(
+        block,
+        DebugInfo(),
+        rocm::ImplementationType_ROCMWithoutTransfers,
+        math::blas::BLAS_Precision::s,
+        math::blas::BLAS_Layout::RowMajor,
+        math::blas::BLAS_Transpose::No,
+        math::blas::BLAS_Transpose::No,
+        symbolic::integer(dim_i),
+        symbolic::integer(dim_j),
+        symbolic::integer(dim_k),
+        symbolic::integer(dim_j),
+        symbolic::integer(dim_k),
+        symbolic::integer(dim_j)
+    ));
+
+    builder.add_computational_memlet(block, input_a_node, gemm_node, "__A", {symbolic::integer(0)}, arr_a_type);
+    builder.add_computational_memlet(block, input_b_node, gemm_node, "__B", {symbolic::integer(0)}, arr_b_type);
+    builder.add_computational_memlet(block, dummy_input_node, gemm_node, "__C", {symbolic::integer(0)}, arr_res_type);
+    builder.add_constant(block, "1.0", desc);
+    builder.add_constant(block, "0.0", desc);
+
+    codegen::LibraryNodeDispatcherRegistry local_registry;
+    plugins::Context ctx{
+        serializer::LibraryNodeSerializerRegistry::instance(),
+        codegen::NodeDispatcherRegistry::instance(),
+        codegen::MapDispatcherRegistry::instance(),
+        local_registry,
+        passes::scheduler::SchedulerRegistry::instance()
+    };
+    rocm::register_rocm_plugin(ctx);
+
+    auto dispatcher_fn = local_registry.get_library_node_dispatcher(
+        math::blas::LibraryNodeType_GEMM.value() + "::" + rocm::ImplementationType_ROCMWithoutTransfers.value()
+    );
+    ASSERT_NE(dispatcher_fn, nullptr);
+
+    codegen::CLanguageExtension language_extension(sdfg);
+    auto dispatcher = dispatcher_fn(language_extension, sdfg, block.dataflow(), gemm_node);
+
+    // Single precision must be routed to the hand-tuned dispatcher.
+    auto* hand_tuned = dynamic_cast<rocm::blas::GEMMNodeDispatcher_ROCMHandTuned*>(dispatcher.get());
+    EXPECT_NE(hand_tuned, nullptr);
+}
+
 
 } // namespace sdfg::rocm


### PR DESCRIPTION
- Adds factory for ROCM Gemm Node based on precision type
- Adds unit test, testing no throw of dispatching, when using the plugin
- Adds unit test to ensure the hand_tuned version is still used for single precision
- Fixes NPBench failure in benchmark repo