### PR TITLE
Enable remote tuning for pytorch

### DIFF
--- a/.github/workflows/unit_tests_linux.yml
+++ b/.github/workflows/unit_tests_linux.yml
@@ -283,6 +283,8 @@ jobs:
           ninja check-docc-mlir
 
       - name: Integration Tests
+        env:
+          DOCC_ACCESS_TOKEN: ${{ secrets.DOCC_CI_TOKEN }}
         run: |
           pip install -r mlir/requirements.txt
 

--- a/mlir/docc/torch/torch_program.py
+++ b/mlir/docc/torch/torch_program.py
@@ -160,8 +160,10 @@ class TorchProgram(DoccProgram):
             compile_start_time = time.perf_counter()
 
         # Resolve options
-        instrumentation_mode, capture_args, remote_tuning = self._resolve_compile_options(
-            instrumentation_mode, capture_args, remote_tuning
+        instrumentation_mode, capture_args, remote_tuning = (
+            self._resolve_compile_options(
+                instrumentation_mode, capture_args, remote_tuning
+            )
         )
 
         # Determine example input
@@ -490,6 +492,7 @@ def compile_torch(
     example_input,
     target: str = "none",
     category: str = "server",
+    remote_tuning: bool = False,
     force_rebuild: bool = False,
 ) -> CompiledSDFG:
     return TorchProgram(
@@ -497,6 +500,7 @@ def compile_torch(
         example_input=example_input,
         target=target,
         category=category,
+        remote_tuning=remote_tuning,
         force_rebuild=force_rebuild,
     )
 
@@ -505,15 +509,22 @@ def compile_torch(
 # torch.compile backend registration
 # ============================================================================
 
-def _docc_get_backend_options(options: None | dict[str, str]) -> tuple[str, str]:
+
+def _docc_get_backend_options(
+    options: None | dict[str, str | bool],
+) -> tuple[str, str, bool]:
     target = "none"
     category = "server"
+    remote_tuning = False
     if options:
         if "target" in options:
             target = options["target"]
         if "category" in options:
             category = options["category"]
-    return target, category
+        if "remote_tuning" in options:
+            remote_tuning = options["remote_tuning"]
+    return target, category, remote_tuning
+
 
 def _docc_dynamo_compiler(gm, example_inputs, backend_options):
     """Dynamic Compiler based on TorchProgram (inference only)."""
@@ -524,12 +535,13 @@ def _docc_dynamo_compiler(gm, example_inputs, backend_options):
     else:
         example_input = tuple(example_inputs)
 
-    target, category = _docc_get_backend_options(backend_options)
+    target, category, remote_tuning = _docc_get_backend_options(backend_options)
     program = TorchProgram(
         gm,
         example_input=example_input,
         target=target,
         category=category,
+        remote_tuning=remote_tuning,
     )
 
     def compiled_fn(*args):
@@ -541,7 +553,7 @@ def _docc_dynamo_compiler(gm, example_inputs, backend_options):
     return compiled_fn
 
 
-def _docc_aot_compiler_wrapper(target: str, category: str):
+def _docc_aot_compiler_wrapper(target: str, category: str, remote_tuning: bool):
     def _docc_aot_compiler(gm, example_inputs):
         """AOTAutograd Compiler based on TorchProgram (inference and training)."""
         from functorch.compile import make_boxed_func
@@ -558,6 +570,7 @@ def _docc_aot_compiler_wrapper(target: str, category: str):
             example_input=example_input,
             target=target,
             category=category,
+            remote_tuning=remote_tuning,
         )
 
         def compiled_fn(*args):
@@ -598,10 +611,10 @@ def _docc_backend(gm, example_inputs, *, options=None):
     if _needs_autograd(gm, example_inputs):
         from torch._dynamo.backends.common import aot_autograd
 
-        target, category = _docc_get_backend_options(options)
+        target, category, remote_tuning = _docc_get_backend_options(options)
         aot_backend = aot_autograd(
-            fw_compiler=_docc_aot_compiler_wrapper(target, category),
-            bw_compiler=_docc_aot_compiler_wrapper(target, category),
+            fw_compiler=_docc_aot_compiler_wrapper(target, category, remote_tuning),
+            bw_compiler=_docc_aot_compiler_wrapper(target, category, remote_tuning),
         )
         return aot_backend(gm, example_inputs)
     else:

--- a/mlir/docc/torch/torch_program.py
+++ b/mlir/docc/torch/torch_program.py
@@ -150,6 +150,7 @@ class TorchProgram(DoccProgram):
         output_folder: Optional[str] = None,
         instrumentation_mode: Optional[str] = None,
         capture_args: Optional[bool] = None,
+        remote_tuning: Optional[bool] = None,
     ) -> CompiledSDFG:
         original_output_folder = output_folder
 
@@ -159,10 +160,9 @@ class TorchProgram(DoccProgram):
             compile_start_time = time.perf_counter()
 
         # Resolve options
-        if instrumentation_mode is None:
-            instrumentation_mode = self.instrumentation_mode or ""
-        if capture_args is None:
-            capture_args = self.capture_args or False
+        instrumentation_mode, capture_args, remote_tuning = self._resolve_compile_options(
+            instrumentation_mode, capture_args, remote_tuning
+        )
 
         # Determine example input
         if self.example_input is None:
@@ -263,7 +263,7 @@ class TorchProgram(DoccProgram):
             sdfg = self._sdfg
 
             lib_path = self.sdfg_pipe(
-                sdfg, output_folder, instrumentation_mode, capture_args
+                sdfg, output_folder, instrumentation_mode, capture_args, remote_tuning
             )
 
         # Prepend buffer info for any buffers that torch-mlir left as

--- a/mlir/integration/torch/check.py
+++ b/mlir/integration/torch/check.py
@@ -3,19 +3,19 @@ import copy
 
 import docc.torch
 
-def check_backend(model, *inputs, rtol=1e-4, atol=1e-5, target="none", category="server"):
+def check_backend(model, *inputs, rtol=1e-4, atol=1e-5, target="none", category="server", remote_tuning=False):
     model_ref = copy.deepcopy(model)
-    program = torch.compile(model, backend="docc", options={"target": target, "category": category})
+    program = torch.compile(model, backend="docc", options={"target": target, "category": category, "remote_tuning": remote_tuning})
     with torch.no_grad():
         res = program(*inputs)
         ref = model_ref(*inputs)
     assert torch.allclose(res, ref, rtol=rtol, atol=atol)
 
 
-def check_compile(model, *inputs, rtol=1e-4, atol=1e-5):
+def check_compile(model, *inputs, rtol=1e-4, atol=1e-5, target="none", category="server", remote_tuning=False):
     model_ref = copy.deepcopy(model)
     example_input = inputs[0] if len(inputs) == 1 else inputs
-    program = docc.torch.compile_torch(model, example_input)
+    program = docc.torch.compile_torch(model, example_input, target=target, category=category, remote_tuning=remote_tuning)
     with torch.no_grad():
         res = program(*inputs)
         ref = model_ref(*inputs)

--- a/mlir/integration/torch/test_remote_tuning.py
+++ b/mlir/integration/torch/test_remote_tuning.py
@@ -1,5 +1,7 @@
 import copy
+from xml.parsers.expat import model
 
+from integration.torch.check import check_backend, check_compile
 import torch
 import torch.nn as nn
 
@@ -16,56 +18,17 @@ class LinearNet(nn.Module):
         return self.linear(x)
 
 
-def test_remote_tuning_init_flag():
+def test_remote_tuning_backend():
     """TorchProgram constructed with remote_tuning=True compiles and gives correct result."""
     model = LinearNet().eval()
-    model_ref = copy.deepcopy(model)
-
     example_input = torch.randn(4, 8)
-    program = TorchProgram(model, example_input=example_input, remote_tuning=True)
 
-    with torch.no_grad():
-        res = program(example_input)
-        ref = model_ref(example_input)
-
-    assert res.shape == ref.shape
-    assert torch.allclose(res, ref, rtol=1e-5)
+    check_backend(model, example_input, rtol=1e-4, atol=1e-5, target="sequential", category="server", remote_tuning=True)
 
 
 def test_remote_tuning_compile_override():
     """remote_tuning=True passed directly to compile() compiles and gives correct result."""
     model = LinearNet().eval()
-    model_ref = copy.deepcopy(model)
 
     example_input = torch.randn(4, 8)
-    program = TorchProgram(model, example_input=example_input)
-    compiled = program.compile(remote_tuning=True)
-
-    with torch.no_grad():
-        res = compiled(example_input.numpy())
-        ref = model_ref(example_input)
-
-    assert torch.allclose(torch.from_numpy(res) if not isinstance(res, torch.Tensor) else res,
-                          ref, rtol=1e-5)
-
-
-def test_remote_tuning_sequential_target():
-    """remote_tuning=True with sequential target compiles and gives correct result."""
-    model = LinearNet().eval()
-    model_ref = copy.deepcopy(model)
-
-    example_input = torch.randn(4, 8)
-    program = TorchProgram(
-        model,
-        example_input=example_input,
-        target="sequential",
-        category="server",
-        remote_tuning=True,
-    )
-
-    with torch.no_grad():
-        res = program(example_input)
-        ref = model_ref(example_input)
-
-    assert res.shape == ref.shape
-    assert torch.allclose(res, ref, rtol=1e-5)
+    check_compile(model, example_input, rtol=1e-4, atol=1e-5, target="sequential", category="server", remote_tuning=True)

--- a/mlir/integration/torch/test_remote_tuning.py
+++ b/mlir/integration/torch/test_remote_tuning.py
@@ -1,0 +1,71 @@
+import copy
+
+import torch
+import torch.nn as nn
+
+import docc.torch
+from docc.torch import TorchProgram
+
+
+class LinearNet(nn.Module):
+    def __init__(self, in_features=8, out_features=4):
+        super().__init__()
+        self.linear = nn.Linear(in_features, out_features, bias=False)
+
+    def forward(self, x: torch.Tensor):
+        return self.linear(x)
+
+
+def test_remote_tuning_init_flag():
+    """TorchProgram constructed with remote_tuning=True compiles and gives correct result."""
+    model = LinearNet().eval()
+    model_ref = copy.deepcopy(model)
+
+    example_input = torch.randn(4, 8)
+    program = TorchProgram(model, example_input=example_input, remote_tuning=True)
+
+    with torch.no_grad():
+        res = program(example_input)
+        ref = model_ref(example_input)
+
+    assert res.shape == ref.shape
+    assert torch.allclose(res, ref, rtol=1e-5)
+
+
+def test_remote_tuning_compile_override():
+    """remote_tuning=True passed directly to compile() compiles and gives correct result."""
+    model = LinearNet().eval()
+    model_ref = copy.deepcopy(model)
+
+    example_input = torch.randn(4, 8)
+    program = TorchProgram(model, example_input=example_input)
+    compiled = program.compile(remote_tuning=True)
+
+    with torch.no_grad():
+        res = compiled(example_input.numpy())
+        ref = model_ref(example_input)
+
+    assert torch.allclose(torch.from_numpy(res) if not isinstance(res, torch.Tensor) else res,
+                          ref, rtol=1e-5)
+
+
+def test_remote_tuning_sequential_target():
+    """remote_tuning=True with sequential target compiles and gives correct result."""
+    model = LinearNet().eval()
+    model_ref = copy.deepcopy(model)
+
+    example_input = torch.randn(4, 8)
+    program = TorchProgram(
+        model,
+        example_input=example_input,
+        target="sequential",
+        category="server",
+        remote_tuning=True,
+    )
+
+    with torch.no_grad():
+        res = program(example_input)
+        ref = model_ref(example_input)
+
+    assert res.shape == ref.shape
+    assert torch.allclose(res, ref, rtol=1e-5)

--- a/python/docc/compiler/docc_program.py
+++ b/python/docc/compiler/docc_program.py
@@ -94,12 +94,51 @@ class DoccProgram(ABC):
     def compile(self, *args: Any, output_folder: Optional[str] = None) -> CompiledSDFG:
         pass
 
+    def _resolve_compile_options(
+        self,
+        instrumentation_mode: Optional[str] = None,
+        capture_args: Optional[bool] = None,
+        remote_tuning: Optional[bool] = None,
+    ) -> tuple[str, bool, bool]:
+        """Resolve compile-time options, falling back to instance defaults and env vars."""
+        if instrumentation_mode is None:
+            instrumentation_mode = self.instrumentation_mode
+        if capture_args is None:
+            capture_args = self.capture_args
+        if remote_tuning is None:
+            remote_tuning = self.remote_tuning
+
+        # Check environment variable DOCC_CI
+        docc_ci = os.environ.get("DOCC_CI", "")
+        if docc_ci:
+            if docc_ci == "regions":
+                if instrumentation_mode is None:
+                    instrumentation_mode = "ols"
+            elif docc_ci == "arg-capture":
+                if capture_args is None:
+                    capture_args = True
+            else:
+                # Full mode (or unknown value treated as full)
+                if instrumentation_mode is None:
+                    instrumentation_mode = "ols"
+                if capture_args is None:
+                    capture_args = True
+
+        # Defaults
+        if instrumentation_mode is None:
+            instrumentation_mode = ""
+        if capture_args is None:
+            capture_args = False
+
+        return instrumentation_mode, capture_args, remote_tuning
+
     def sdfg_pipe(
         self,
         sdfg: StructuredSDFG,
         output_folder: Optional[str],
         instrumentation_mode: str,
         capture_args: bool,
+        remote_tuning: Optional[bool] = None,
     ) -> str:
 
         if self.debug_dump:
@@ -111,10 +150,13 @@ class DoccProgram(ABC):
 
         sdfg.validate()
 
+        if remote_tuning is None:
+            remote_tuning = self.remote_tuning
+
         target_options = TargetOptions()
         target_options.target = self.target
         target_options.category = self.category
-        target_options.remote_tuning = self.remote_tuning
+        target_options.remote_tuning = remote_tuning
 
         # Einsum detection
         sdfg.einsum()
@@ -152,9 +194,7 @@ class DoccProgram(ABC):
 
         custom_schedule_fn = get_target_schedule_fn(self.target)
         if custom_schedule_fn is not None:
-            custom_schedule_fn(
-                sdfg, self.category, {"remote_tuning": self.remote_tuning}
-            )
+            custom_schedule_fn(sdfg, self.category, {"remote_tuning": remote_tuning})
         else:
             sdfg.schedule(target_options)
 

--- a/python/docc/python/python_program.py
+++ b/python/docc/python/python_program.py
@@ -161,36 +161,16 @@ class PythonProgram(DoccProgram):
         output_folder: Optional[str] = None,
         instrumentation_mode: Optional[str] = None,
         capture_args: Optional[bool] = None,
+        remote_tuning: Optional[bool] = None,
     ) -> CompiledSDFG:
         original_output_folder = output_folder
 
         # Resolve options
-        if instrumentation_mode is None:
-            instrumentation_mode = self.instrumentation_mode
-        if capture_args is None:
-            capture_args = self.capture_args
-
-        # Check environment variable DOCC_CI
-        docc_ci = os.environ.get("DOCC_CI", "")
-        if docc_ci:
-            if docc_ci == "regions":
-                if instrumentation_mode is None:
-                    instrumentation_mode = "ols"
-            elif docc_ci == "arg-capture":
-                if capture_args is None:
-                    capture_args = True
-            else:
-                # Full mode (or unknown value treated as full)
-                if instrumentation_mode is None:
-                    instrumentation_mode = "ols"
-                if capture_args is None:
-                    capture_args = True
-
-        # Defaults
-        if instrumentation_mode is None:
-            instrumentation_mode = ""
-        if capture_args is None:
-            capture_args = False
+        instrumentation_mode, capture_args, remote_tuning = (
+            self._resolve_compile_options(
+                instrumentation_mode, capture_args, remote_tuning
+            )
+        )
 
         # 1. Analyze arguments and shapes
         arg_types = []
@@ -266,7 +246,7 @@ class PythonProgram(DoccProgram):
         )
 
         lib_path = self.sdfg_pipe(
-            sdfg, output_folder, instrumentation_mode, capture_args
+            sdfg, output_folder, instrumentation_mode, capture_args, remote_tuning
         )
 
         # 4. Create CompiledSDFG


### PR DESCRIPTION
- Refactors flag and environment variable logic into docc_program
- Enables transfer tuning from the PyTorch frontend
- Adds a pytest for remote tuning 