### PR TITLE
Add tenstorrent github tests

### DIFF
--- a/.github/workflows/llvm_tests_san.yml
+++ b/.github/workflows/llvm_tests_san.yml
@@ -13,7 +13,7 @@ jobs:
       group: dahlia
       labels: Linux
     container:
-      image: daisytuner/docc-build-env-llvm19-ubuntu-24.04:latest-amd64
+      image: daisytuner/docc-run-env-llvm19-ubuntu-24.04:latest-amd64
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
           merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@v1.10.0
-  
+
   packages-llvm:
     strategy:
       matrix:
@@ -122,7 +122,7 @@ jobs:
             upload-dist-version: 24.04
             runner: build-amd64-big
             architecture: x64
-            image: daisytuner/docc-build-env-llvm19-ubuntu-24.04:latest
+            image: daisytuner/docc-build-env-llvm19-ubuntu-24.04:latest-amd64
           - platform: ubuntu-24.04
             package-format: deb
             cpack-generator: DEB
@@ -130,7 +130,7 @@ jobs:
             upload-dist-version: 24.04
             runner: build-arm64-big
             architecture: arm64
-            image: daisytuner/docc-build-env-llvm19:latest-arm64
+            image: daisytuner/docc-build-env-llvm19-ubuntu-24.04:latest-arm64
           - platform: rhel-10
             package-format: rpm
             cpack-generator: RPM
@@ -139,7 +139,7 @@ jobs:
             upload-dist-platform-id: platform:el10
             runner: build-amd64-big
             architecture: x64
-            image: daisytuner/docc-build-env-llvm19-rhel-10:latest
+            image: daisytuner/docc-build-env-llvm19-rhel-10:latest-amd64
           - platform: debian-13
             package-format: deb
             cpack-generator: DEB
@@ -147,7 +147,7 @@ jobs:
             upload-dist-version: 13
             runner: build-amd64-big
             architecture: x64
-            image: daisytuner/docc-build-env-llvm19-debian-13:latest
+            image: daisytuner/docc-build-env-llvm19-debian-13:latest-amd64
 
     runs-on: ${{ matrix.runner }}
     container:

--- a/.github/workflows/sanitizer_tests_asan.yml
+++ b/.github/workflows/sanitizer_tests_asan.yml
@@ -13,7 +13,7 @@ jobs:
       group: dahlia
       labels: openmp
     container:
-      image: daisytuner/docc-build-env-llvm19-base:latest-amd64
+      image: daisytuner/docc-run-env-llvm19-ubuntu-24.04:latest-amd64
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sanitizer_tests_lsan.yml
+++ b/.github/workflows/sanitizer_tests_lsan.yml
@@ -13,7 +13,7 @@ jobs:
       group: dahlia
       labels: openmp
     container:
-      image: daisytuner/docc-build-env-llvm19-base:latest-amd64
+      image: daisytuner/docc-run-env-llvm19-ubuntu-24.04:latest-amd64
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sanitizer_tests_ubsan.yml
+++ b/.github/workflows/sanitizer_tests_ubsan.yml
@@ -13,7 +13,7 @@ jobs:
       group: dahlia
       labels: openmp
     container:
-      image: daisytuner/docc-build-env-llvm19-base:latest-amd64
+      image: daisytuner/docc-run-env-llvm19-ubuntu-24.04:latest-amd64
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit_tests_linux.yml
+++ b/.github/workflows/unit_tests_linux.yml
@@ -308,7 +308,6 @@ jobs:
       image: daisytuner/docc-run-env-llvm19-ubuntu-24.04:latest-amd64
       options: >-
         --cap-add=PERFMON
-        --gpus=all
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/unit_tests_linux.yml
+++ b/.github/workflows/unit_tests_linux.yml
@@ -15,7 +15,7 @@ jobs:
       group: dahlia
       labels: RTX5060
     container:
-      image: daisytuner/docc-build-env-llvm19-ubuntu-24.04-et:latest
+      image: daisytuner/docc-run-env-llvm19-ubuntu-24.04-et:latest-amd64
       options: >-
         --cap-add=PERFMON
         --gpus=all
@@ -144,7 +144,7 @@ jobs:
       group: dahlia
       labels: cuda
     container:
-      image: daisytuner/docc-build-env-llvm19-ubuntu-24.04-et:latest
+      image: daisytuner/docc-run-env-llvm19-ubuntu-24.04-et:latest-amd64
       options: >-
         --cap-add=PERFMON
         --gpus=all
@@ -201,8 +201,7 @@ jobs:
           nvidia-smi
           export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
-          export ETSOC_TESTS=1
-          coverage run --source=python/docc -m pytest -v python/tests
+          coverage run --source=python/docc -m pytest -v python/tests -m "unmarked or cuda or etsoc"
           coverage xml
 
       - name: Integration Tests
@@ -224,7 +223,7 @@ jobs:
       group: dahlia
       labels: Linux
     container:
-      image: daisytuner/docc-build-env-llvm19-base:latest-amd64
+      image: daisytuner/docc-run-env-llvm19-ubuntu-24.04-et:latest-amd64
     strategy:
       fail-fast: false
       matrix:
@@ -289,7 +288,7 @@ jobs:
           pip install -r mlir/requirements.txt
 
           cd mlir/
-          pytest -v integration/
+          pytest -v integration/ -m "unmarked"
 
       # - name: Model Zoo Tests (Nightly only)
       #   if: github.event_name == 'schedule'
@@ -300,6 +299,74 @@ jobs:
       #     # Run fasterrcnn test (will fail if assertions don't pass)
       #     cd mlir/benchmarks/torch/model_zoo/
       #     python fasterrcnn_resnet50.py
+
+  tenstorrent-tests-linux:
+    runs-on:
+      group: dahlia
+      labels: tenstorrent
+    container:
+      image: daisytuner/docc-run-env-llvm19-ubuntu-24.04:latest-amd64
+      options: >-
+        --cap-add=PERFMON
+        --gpus=all
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.12" ]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Create virtual environment
+        run: |
+          python -m venv .venv
+          echo "$PWD/.venv/bin" >> $GITHUB_PATH
+          echo "PYTHONPATH=$PWD/python:$PWD/mlir" >> $GITHUB_ENV
+
+      - name: Mark GitHub Actions workdir as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pybind11 pytest coverage black==25.9.0 build scikit-build-core
+          pip install numpy scipy ml_dtypes
+          pip install -r mlir/requirements.txt
+
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake -G Ninja \
+            -DCMAKE_C_COMPILER=clang-19 \
+            -DCMAKE_CXX_COMPILER=clang++-19 \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DPYTHON_BUILD_FRONTEND=ON \
+            -Dpybind11_DIR=$GITHUB_WORKSPACE/.venv/lib/python${{ matrix.python-version }}/site-packages/pybind11/share/cmake/pybind11 \
+            -DMLIR_BUILD_FRONTEND=ON \
+            -DMLIR_BUILD_BINDINGS=ON \
+            -DMLIR_BUILD_TESTS=ON \
+            -DMLIR_DIR=/usr/lib/llvm-19/lib/cmake/mlir \
+            -DLLVM_EXTERNAL_LIT=/usr/lib/llvm-19/build/utils/lit/lit.py \
+            -DINSTALL_GTEST=OFF \
+            -DBUILD_TESTS:BOOL=OFF \
+            -DBUILD_BENCHMARKS:BOOL=OFF \
+            -DBUILD_BENCHMARKS_GOOGLE:BOOL=OFF \
+            ..
+          ninja -j$(nproc)
+
+      - name: Python & MLIR Tests
+        env:
+          DOCC_ACCESS_TOKEN: ${{ secrets.DOCC_CI_TOKEN }}
+        run: |
+          pytest -v python/tests mlir/integration -m "tenstorrent"
 
   llvm-tests-linux:
     runs-on:

--- a/.github/workflows/unit_tests_macos.yml
+++ b/.github/workflows/unit_tests_macos.yml
@@ -74,7 +74,7 @@ jobs:
           DOCC_ACCESS_TOKEN: ${{ secrets.DOCC_CI_TOKEN }}
         run: |
           export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-          pytest -v python/tests
+          pytest -v python/tests -m "unmarked"
 
       - name: Python Integration Tests
         run: |

--- a/.github/workflows/unit_tests_release.yml
+++ b/.github/workflows/unit_tests_release.yml
@@ -15,7 +15,7 @@ jobs:
       group: dahlia
       labels: RTX5060
     container:
-      image: daisytuner/docc-build-env-llvm19-base:latest-amd64
+      image: daisytuner/docc-run-env-llvm19-ubuntu-24.04:latest-amd64
       options: >-
         --cap-add=PERFMON
         --gpus=all

--- a/mlir/integration/conftest.py
+++ b/mlir/integration/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+def pytest_collection_modifyitems(items):
+    # Pytest applies some built-in markers automatically under the hood.
+    # We ignore those so they don't count as "marked".
+    builtin_markers = {
+        "parametrize",
+        "skip",
+        "skipif",
+        "xfail",
+        "usefixtures",
+        "filterwarnings",
+    }
+
+    for item in items:
+        # Get all markers applied to this test (including from classes/modules)
+        test_markers = {m.name for m in item.iter_markers()}
+        custom_markers = test_markers - builtin_markers
+
+        # If no custom markers exist, apply our automatically generated one
+        if not custom_markers:
+            item.add_marker(pytest.mark.unmarked)

--- a/mlir/integration/pytest.toml
+++ b/mlir/integration/pytest.toml
@@ -1,0 +1,8 @@
+[pytest]
+markers = [
+    "unmarked",
+    "slow",
+    "etsoc",
+    "tenstorrent",
+    "cuda"
+]

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+def pytest_collection_modifyitems(items):
+    # Pytest applies some built-in markers automatically under the hood.
+    # We ignore those so they don't count as "marked".
+    builtin_markers = {
+        "parametrize",
+        "skip",
+        "skipif",
+        "xfail",
+        "usefixtures",
+        "filterwarnings",
+    }
+
+    for item in items:
+        # Get all markers applied to this test (including from classes/modules)
+        test_markers = {m.name for m in item.iter_markers()}
+        custom_markers = test_markers - builtin_markers
+
+        # If no custom markers exist, apply our automatically generated one
+        if not custom_markers:
+            item.add_marker(pytest.mark.unmarked)

--- a/python/tests/pytest.toml
+++ b/python/tests/pytest.toml
@@ -1,0 +1,8 @@
+[pytest]
+markers = [
+    "unmarked",
+    "slow",
+    "etsoc",
+    "tenstorrent",
+    "cuda"
+]

--- a/python/tests/python/program/test_scheduling.py
+++ b/python/tests/python/program/test_scheduling.py
@@ -50,9 +50,7 @@ def test_scheduling_openmp():
     assert np.allclose(C, A + B)
 
 
-@pytest.mark.skipif(
-    sys.platform == "darwin", reason="Instrumentation not supported on macOS"
-)
+@pytest.mark.cuda()
 def test_scheduling_cuda():
     # Assuming CUDA is available and supported
     @native(target="cuda", category="server")
@@ -69,9 +67,7 @@ def test_scheduling_cuda():
     assert np.allclose(C, A + B)
 
 
-@pytest.mark.skipif(
-    sys.platform == "darwin", reason="Instrumentation not supported on macOS"
-)
+@pytest.mark.cuda()
 def test_scheduling_cuda_gemm():
     # Assuming CUDA is available and supported
     @native(target="cuda", category="server")
@@ -91,9 +87,7 @@ def test_scheduling_cuda_gemm():
     assert np.allclose(C, A @ B)
 
 
-@pytest.mark.skipif(
-    sys.platform == "darwin", reason="Instrumentation not supported on macOS"
-)
+@pytest.mark.cuda()
 def test_scheduling_cuda_dot():
     # Assuming CUDA is available and supported
     @native(target="cuda", category="server")

--- a/python/tests/python/targets/test_etsoc.py
+++ b/python/tests/python/targets/test_etsoc.py
@@ -7,9 +7,7 @@ import sys
 
 
 # COR-1607 find a way to depend on target plugins being available or not for pytest
-@pytest.mark.skipif(
-    os.environ.get("ETSOC_TESTS") != "1", reason="ETSoC tests are disabled"
-)
+@pytest.mark.etsoc()
 def test_scheduling_etsoc_matmul_mini():
     @native(target="etsoc", category="server")
     def matmul_etsoc(A, B, C):
@@ -31,6 +29,8 @@ def test_scheduling_etsoc_matmul_mini():
 @pytest.mark.skipif(
     os.environ.get("ETSOC_SLOW_TESTS") != "1", reason="ETSoC Slow tests are disabled"
 )
+@pytest.mark.etsoc()
+@pytest.mark.slow()
 def test_scheduling_etsoc_matmul_large():
     @native(target="etsoc", category="server")
     def matmul_etsoc(A, B, C):

--- a/python/tests/python/targets/test_tenstorrent.py
+++ b/python/tests/python/targets/test_tenstorrent.py
@@ -8,13 +8,10 @@ import sys
 
 # COR-1607 find a way to depend on target plugins being available or not for pytest
 @pytest.mark.skipif(
-    not os.path.exists("/dev/tenstorrent") or os.environ.get("TT_TESTS") != "1",
-    reason=(
-        "TT tests are disabled"
-        if os.path.exists("/dev/tenstorrent")
-        else "No TT Accelerator present"
-    ),
+    not os.path.exists("/dev/tenstorrent"),
+    reason="No TT Accelerator present",
 )
+@pytest.mark.tenstorrent()
 def test_scheduling_tt_matmul_large():
     @native(target="tenstorrent", category="server")
     def matmul_tt(A, B, C):


### PR DESCRIPTION
 * updated docker images to current naming scheme
 + added tenstorrrent test job to run on a machine with accelerator
 * introduced markers to pytests so that we can filter for "unmarked" to match all tests that do not require additional accelerators and add the various accelerators (cuda, etsoc, tenstorrent) as supported by the used runner