### PR TITLE
Handle reference from cutout

### DIFF
--- a/rpc/src/transformations/rpc_node_transform.cpp
+++ b/rpc/src/transformations/rpc_node_transform.cpp
@@ -230,24 +230,11 @@ void RPCNodeTransform::
                 continue;
             }
             auto& type = sdfg_response->type(container);
-            if (type.type_id() == sdfg::types::TypeID::Reference)
-            {
+            if (type.type_id() == sdfg::types::TypeID::Reference) {
                 auto& reference_type = dynamic_cast<const sdfg::codegen::Reference&>(type).reference_type();
-                builder.add_container(
-                    container,
-                    reference_type,
-                    false,
-                    false
-                );
-            }
-            else
-            {
-                builder.add_container(
-                    container,
-                    type,
-                    false,
-                    false
-                );
+                builder.add_container(container, reference_type, false, false);
+            } else {
+                builder.add_container(container, type, false, false);
             }
         }
 

--- a/rpc/src/transformations/rpc_node_transform.cpp
+++ b/rpc/src/transformations/rpc_node_transform.cpp
@@ -10,6 +10,7 @@
 
 #include "sdfg/analysis/loop_analysis.h"
 #include "sdfg/analysis/scope_analysis.h"
+#include "sdfg/codegen/utils.h"
 #include "sdfg/cutouts/cutouts.h"
 #include "sdfg/optimization_report/pass_report_consumer.h"
 #include "sdfg/passes/rpc/rpc_context.h"
@@ -229,12 +230,25 @@ void RPCNodeTransform::
                 continue;
             }
             auto& type = sdfg_response->type(container);
-            builder.add_container(
-                container,
-                type,
-                false,
-                false
-            );
+            if (type.type_id() == sdfg::types::TypeID::Reference)
+            {
+                auto& reference_type = dynamic_cast<const sdfg::codegen::Reference&>(type).reference_type();
+                builder.add_container(
+                    container,
+                    reference_type,
+                    false,
+                    false
+                );
+            }
+            else
+            {
+                builder.add_container(
+                    container,
+                    type,
+                    false,
+                    false
+                );
+            }
         }
 
         opt.sdfg_result->sdfg.reset();

--- a/rpc/tests/transformations/rpc_node_transform_test.cpp
+++ b/rpc/tests/transformations/rpc_node_transform_test.cpp
@@ -14,6 +14,8 @@
 #include "sdfg/transformations/loop_interchange.h"
 #include "sdfg/transformations/loop_tiling.h"
 #include "sdfg/transformations/recorder.h"
+#include "sdfg/codegen/utils.h"
+#include "sdfg/serializer/json_serializer.h"
 #include "sdfg/types/pointer.h"
 #include "sdfg/types/type.h"
 
@@ -258,4 +260,50 @@ TEST_F(RPCNodeTransformTest, HandleOtherHttpErrors) {
     std::string error = std::get<std::string>(response);
     EXPECT_FALSE(error.empty());
     EXPECT_NE(error.find("HTTP error: 500"), std::string::npos);
+}
+
+TEST_F(RPCNodeTransformTest, ApplyUnwrapsReferenceTypedContainersFromResponse) {
+    // Build a "response" SDFG: clone the main SDFG and add a Reference-typed container.
+    // Before the Reference handling was added to apply(), this container would have been
+    // stored with Reference type in the main SDFG, causing the final assertion to fail.
+    auto response_sdfg = builder_->subject().clone();
+    {
+        sdfg::builder::StructuredSDFGBuilder resp_builder(*response_sdfg);
+        sdfg::types::Scalar inner_type(sdfg::types::PrimitiveType::Float);
+        sdfg::codegen::Reference ref_type(inner_type);
+        resp_builder.add_container("ref_tmp", ref_type, false, false);
+    }
+
+    // Serialize the response SDFG to a temp file so the transfer server can return it.
+    const std::string sdfg_path = "/tmp/rpc_ref_test.sdfg.json";
+    sdfg::serializer::JSONSerializer serializer;
+    sdfg::serializer::JSONSerializer::writeToFile(*response_sdfg, sdfg_path);
+    setenv("SDFG_TEST_SDFG_PATH", sdfg_path.c_str(), 1);
+
+    // Build an RPC context that sends the file path as SDFG-Result-Path header,
+    // so the transfer server loads this SDFG as its response (same pattern as matmul tests).
+    passes::rpc::SimpleRpcContextBuilder ctx_builder;
+    auto test_ctx = ctx_builder
+                        .initialize_local_default()
+                        .add_header("SDFG-Result-Path", std::string(std::getenv("SDFG_TEST_SDFG_PATH")))
+                        .build();
+
+    auto sdfg_initial = builder_->subject().clone();
+    sdfg::builder::StructuredSDFGBuilder builder(sdfg_initial);
+    sdfg::analysis::AnalysisManager analysis_manager(builder.subject());
+    auto& loop_analysis = analysis_manager.get<sdfg::analysis::LoopAnalysis>();
+    auto outer_loops = loop_analysis.outermost_loops();
+    ASSERT_EQ(outer_loops.size(), 1);
+    auto outer_loop = static_cast<structured_control_flow::StructuredLoop*>(outer_loops[0]);
+
+    sdfg::transformations::RPCNodeTransform transform(*outer_loop, "sequential", "server", *test_ctx, false);
+    ASSERT_TRUE(transform.can_be_applied(builder, analysis_manager));
+    transform.apply(builder, analysis_manager);
+
+    // The Reference-typed container must have been added with the inner (Float) type, not
+    // wrapped as Reference. Before the fix, this assertion would fail.
+    ASSERT_TRUE(builder.subject().exists("ref_tmp"));
+    auto& added_type = builder.subject().type("ref_tmp");
+    EXPECT_EQ(added_type.type_id(), sdfg::types::TypeID::Scalar);
+    EXPECT_EQ(added_type.primitive_type(), sdfg::types::PrimitiveType::Float);
 }


### PR DESCRIPTION
- Enables rpc handling of reference types as they are created created during cutouts
- Adds a unit test to ensure that handling

Problem: When creating a cutout, scalar arguments are converted to reference types of scalars in order to check their value within the harness.

https://app.daisytuner.com/daisytuner/Benchmarks/runs/qSzpSWVT3VgFXGDGub2G/logs fails with the error: 
`/output/DOCC/test_ludcmp.py-kernel-sequential-f23ddf90ebd235ce/kernel_sdfg.cpp:11:10: error: declaration of reference variable 'i_tile0' requires an initializer
627.
 11 | int64_t &i_tile0;
628.
 |          ^~~~~~~
629.
 1 error generated.
630.
 terminate called after throwing an instance of 'std::runtime_error'`

The current fix handles this problem.

Next steps:
- Remove the reference types as it was never meant to be
- Figure out why a reference to a variable that was not in the original sdfg is created in the first place