### PR TITLE
Rename interim access nodes for iterative mapfusion calls on nested l…

### DIFF
--- a/opt/src/transformations/map_fusion.cpp
+++ b/opt/src/transformations/map_fusion.cpp
@@ -1,5 +1,6 @@
 #include "sdfg/transformations/map_fusion.h"
 
+#include <iostream>
 #include <isl/ctx.h>
 #include <isl/map.h>
 #include <isl/options.h>
@@ -773,12 +774,23 @@ void MapFusion::apply(builder::StructuredSDFGBuilder& builder, analysis::Analysi
 
             // Deep copy all nodes from producer block to new block
             std::unordered_map<const data_flow::DataFlowNode*, data_flow::DataFlowNode*> node_mapping;
+            std::unordered_map<std::string, std::string> intermediate_renames;
             for (auto& node : first_dataflow.nodes()) {
                 node_mapping[&node] = &builder.copy_node(new_block, node);
                 auto* copied = node_mapping[&node];
                 if (auto* access_node = dynamic_cast<data_flow::AccessNode*>(copied)) {
                     if (access_node->data() == candidate.container) {
                         access_node->data(temp_name);
+                    } else if (first_dataflow.in_degree(node) > 0 && first_dataflow.out_degree(node) > 0) {
+                        // Intermediate access node (e.g. from a prior BlockFusion): clone
+                        // its container so each inlined copy gets its own private scalar
+                        auto it = intermediate_renames.find(access_node->data());
+                        if (it == intermediate_renames.end()) {
+                            std::string fresh = builder.find_new_name(access_node->data());
+                            builder.add_container(fresh, sdfg.type(access_node->data()));
+                            intermediate_renames[access_node->data()] = fresh;
+                        }
+                        access_node->data(intermediate_renames[access_node->data()]);
                     }
                 }
             }
@@ -961,6 +973,7 @@ void MapFusion::apply(builder::StructuredSDFGBuilder& builder, analysis::Analysi
 
                 // Deep copy all nodes from consumer block
                 std::unordered_map<const data_flow::DataFlowNode*, data_flow::DataFlowNode*> node_mapping;
+                std::unordered_map<std::string, std::string> intermediate_renames;
                 for (auto& node : consumer_dataflow.nodes()) {
                     node_mapping[&node] = &builder.copy_node(new_block, node);
                     auto* copied = node_mapping[&node];
@@ -971,6 +984,16 @@ void MapFusion::apply(builder::StructuredSDFGBuilder& builder, analysis::Analysi
                             if (consumer_dataflow.in_degree(node) == 0) {
                                 access_node->data(temp_name);
                             }
+                        } else if (consumer_dataflow.in_degree(node) > 0 && consumer_dataflow.out_degree(node) > 0) {
+                            // Intermediate access node (e.g. from a prior BlockFusion): clone
+                            // its container so each inlined copy gets its own private scalar
+                            auto it = intermediate_renames.find(access_node->data());
+                            if (it == intermediate_renames.end()) {
+                                std::string fresh = builder.find_new_name(access_node->data());
+                                builder.add_container(fresh, sdfg.type(access_node->data()));
+                                intermediate_renames[access_node->data()] = fresh;
+                            }
+                            access_node->data(intermediate_renames[access_node->data()]);
                         }
                     }
                 }

--- a/opt/src/transformations/map_fusion.cpp
+++ b/opt/src/transformations/map_fusion.cpp
@@ -781,6 +781,7 @@ void MapFusion::apply(builder::StructuredSDFGBuilder& builder, analysis::Analysi
                         access_node->data(temp_name);
                     } else if (first_dataflow.in_degree(node) > 0 && first_dataflow.out_degree(node) > 0 &&
                                dynamic_cast<const types::Scalar*>(&sdfg.type(access_node->data())) != nullptr) {
+                        // SSA Dataflow required to check for non-local use of the access node's container.
                         // Intermediate access node (e.g. from a prior BlockFusion): clone
                         // its container so each inlined copy gets its own private scalar
                         auto it = intermediate_renames.find(access_node->data());
@@ -985,6 +986,7 @@ void MapFusion::apply(builder::StructuredSDFGBuilder& builder, analysis::Analysi
                             }
                         } else if (consumer_dataflow.in_degree(node) > 0 && consumer_dataflow.out_degree(node) > 0 &&
                                    dynamic_cast<const types::Scalar*>(&sdfg.type(access_node->data())) != nullptr) {
+                            // SSA Dataflow required to check for non-local use of the access node's container.
                             // Intermediate access node (e.g. from a prior BlockFusion): clone
                             // its container so each inlined copy gets its own private scalar
                             auto it = intermediate_renames.find(access_node->data());

--- a/opt/src/transformations/map_fusion.cpp
+++ b/opt/src/transformations/map_fusion.cpp
@@ -779,7 +779,8 @@ void MapFusion::apply(builder::StructuredSDFGBuilder& builder, analysis::Analysi
                 if (auto* access_node = dynamic_cast<data_flow::AccessNode*>(copied)) {
                     if (access_node->data() == candidate.container) {
                         access_node->data(temp_name);
-                    } else if (first_dataflow.in_degree(node) > 0 && first_dataflow.out_degree(node) > 0) {
+                    } else if (first_dataflow.in_degree(node) > 0 && first_dataflow.out_degree(node) > 0 &&
+                               dynamic_cast<const types::Scalar*>(&sdfg.type(access_node->data())) != nullptr) {
                         // Intermediate access node (e.g. from a prior BlockFusion): clone
                         // its container so each inlined copy gets its own private scalar
                         auto it = intermediate_renames.find(access_node->data());
@@ -982,7 +983,8 @@ void MapFusion::apply(builder::StructuredSDFGBuilder& builder, analysis::Analysi
                             if (consumer_dataflow.in_degree(node) == 0) {
                                 access_node->data(temp_name);
                             }
-                        } else if (consumer_dataflow.in_degree(node) > 0 && consumer_dataflow.out_degree(node) > 0) {
+                        } else if (consumer_dataflow.in_degree(node) > 0 && consumer_dataflow.out_degree(node) > 0 &&
+                                   dynamic_cast<const types::Scalar*>(&sdfg.type(access_node->data())) != nullptr) {
                             // Intermediate access node (e.g. from a prior BlockFusion): clone
                             // its container so each inlined copy gets its own private scalar
                             auto it = intermediate_renames.find(access_node->data());

--- a/opt/src/transformations/map_fusion.cpp
+++ b/opt/src/transformations/map_fusion.cpp
@@ -1,6 +1,5 @@
 #include "sdfg/transformations/map_fusion.h"
 
-#include <iostream>
 #include <isl/ctx.h>
 #include <isl/map.h>
 #include <isl/options.h>
@@ -10,7 +9,6 @@
 #include "sdfg/analysis/arguments_analysis.h"
 #include "sdfg/analysis/loop_analysis.h"
 #include "sdfg/analysis/scope_analysis.h"
-#include "sdfg/analysis/users.h"
 
 #include "sdfg/analysis/assumptions_analysis.h"
 #include "sdfg/control_flow/interstate_edge.h"


### PR DESCRIPTION
…oos to avoid reusing tmp variable introduced by the map fusion.