### PR TITLE
Faster depthwise convolution

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgCustomOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgCustomOps.td
@@ -85,7 +85,8 @@ def LinalgCustom_Conv2DNchwFchwOp : LinalgCustom_Op<"conv_2d_nchw_fchw",
                          TensorRankOf<[AnyType], [4]>:$output,
                          DenseI64ArrayAttr:$strides,
                          DenseI64ArrayAttr:$dilations,
-                         DenseI64ArrayAttr:$paddings);
+                         DenseI64ArrayAttr:$paddings,
+                         I64Attr:$groups);
     let results = (outs TensorRankOf<[AnyType], [4]>:$result);
     let assemblyFormat = [{
         attr-dict

--- a/mlir/integration/torch/test_conv2d.py
+++ b/mlir/integration/torch/test_conv2d.py
@@ -270,3 +270,79 @@ def test_depthwise_backend():
             return self.conv(x)
 
     check_backend(DepthwiseConv2dNet().eval(), torch.randn(1, 16, 32, 32))
+
+
+def test_depthwise_bias_compile():
+    class DepthwiseConv2dBiasNet(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(16, 16, kernel_size=3, groups=16)
+
+        def forward(self, x: torch.Tensor):
+            return self.conv(x)
+
+    check_compile(DepthwiseConv2dBiasNet().eval(), torch.randn(1, 16, 32, 32))
+
+
+def test_depthwise_bias_backend():
+    class DepthwiseConv2dBiasNet(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(16, 16, kernel_size=3, groups=16)
+
+        def forward(self, x: torch.Tensor):
+            return self.conv(x)
+
+    check_backend(DepthwiseConv2dBiasNet().eval(), torch.randn(1, 16, 32, 32))
+
+
+def test_depthwise_padding_compile():
+    class DepthwiseConv2dPaddingNet(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(
+                16, 16, kernel_size=3, padding=1, groups=16, bias=False
+            )
+
+        def forward(self, x: torch.Tensor):
+            return self.conv(x)
+
+    check_compile(DepthwiseConv2dPaddingNet().eval(), torch.randn(1, 16, 32, 32))
+
+
+def test_depthwise_padding_backend():
+    class DepthwiseConv2dPaddingNet(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(
+                16, 16, kernel_size=3, padding=1, groups=16, bias=False
+            )
+
+        def forward(self, x: torch.Tensor):
+            return self.conv(x)
+
+    check_backend(DepthwiseConv2dPaddingNet().eval(), torch.randn(1, 16, 32, 32))
+
+
+def test_depthwise_padding_bias_compile():
+    class DepthwiseConv2dPaddingBiasNet(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(16, 16, kernel_size=3, padding=1, groups=16)
+
+        def forward(self, x: torch.Tensor):
+            return self.conv(x)
+
+    check_compile(DepthwiseConv2dPaddingBiasNet().eval(), torch.randn(1, 16, 32, 32))
+
+
+def test_depthwise_padding_bias_backend():
+    class DepthwiseConv2dPaddingBiasNet(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(16, 16, kernel_size=3, padding=1, groups=16)
+
+        def forward(self, x: torch.Tensor):
+            return self.conv(x)
+
+    check_backend(DepthwiseConv2dPaddingBiasNet().eval(), torch.randn(1, 16, 32, 32))

--- a/mlir/lib/Dialect/Linalg/IR/LinalgCustomOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgCustomOps.cpp
@@ -102,7 +102,7 @@ LogicalResult Conv2DNchwFchwOp::verify() {
     if (inputType.getDimSize(0) != outputType.getDimSize(0)) {
         return this->emitOpError("incompatible N shape");
     }
-    if (inputType.getDimSize(1) != weightsType.getDimSize(1)) {
+    if (inputType.getDimSize(1) != static_cast<int64_t>(weightsType.getDimSize(1) * this->getGroups())) {
         return this->emitOpError("incompatible C shape");
     }
     if (weightsType.getDimSize(0) != outputType.getDimSize(1)) {
@@ -138,6 +138,10 @@ LogicalResult Conv2DNchwFchwOp::verify() {
     }
     if (Wo != outputType.getDimSize(3)) {
         return this->emitOpError("output width should be ") << Wo;
+    }
+
+    if (inputType.getDimSize(1) % this->getGroups() != 0) {
+        return this->emitOpError("input/output channels must be divisable by groups");
     }
 
     return success();

--- a/mlir/lib/Dialect/Linalg/Transforms/CustomFusePadding.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/CustomFusePadding.cpp
@@ -16,8 +16,41 @@ namespace mlir {
 
 namespace linalg {
 
-struct FusePaddingIntoConv2DNchwFchw : OpRewritePattern<Conv2DNchwFchwOp> {
-    using OpRewritePattern<Conv2DNchwFchwOp>::OpRewritePattern;
+template<typename Conv2DNchwOp>
+struct FusePaddingIntoConv2DNchwBase : OpRewritePattern<Conv2DNchwOp> {
+    using OpRewritePattern<Conv2DNchwOp>::OpRewritePattern;
+
+    bool paddingOpHasValue(tensor::PadOp pad_op, double value_as_float, uint64_t value_as_int) const {
+        if (!pad_op || pad_op.getStaticLow().size() != 4 || pad_op.getStaticLow()[0] != 0 ||
+            pad_op.getStaticLow()[1] != 0 || pad_op.getStaticLow()[2] == INT64_MIN ||
+            pad_op.getStaticLow()[3] == INT64_MIN || pad_op.getStaticHigh().size() != 4 ||
+            pad_op.getStaticHigh()[0] != 0 || pad_op.getStaticHigh()[1] != 0 ||
+            pad_op.getStaticHigh()[2] == INT64_MIN || pad_op.getStaticHigh()[3] == INT64_MIN ||
+            pad_op.getRegion().getBlocks().size() != 1) {
+            return false;
+        }
+        auto& block = pad_op.getRegion().getBlocks().front();
+        if (block.getOperations().size() != 1) {
+            return false;
+        }
+        auto yield_op = llvm::dyn_cast_or_null<tensor::YieldOp>(block.getOperations().front());
+        if (!yield_op) {
+            return false;
+        }
+
+        // Check that padding is performed with specified value
+        auto constant_op = llvm::dyn_cast_or_null<arith::ConstantOp>(yield_op.getValue().getDefiningOp());
+        if (!constant_op) {
+            return false;
+        }
+        if (auto float_attr = llvm::dyn_cast<FloatAttr>(constant_op.getValue())) {
+            return (float_attr.getValueAsDouble() == value_as_float);
+        } else if (auto integer_attr = llvm::dyn_cast<IntegerAttr>(constant_op.getValue())) {
+            return (integer_attr.getUInt() == value_as_int);
+        } else {
+            return false;
+        }
+    }
 
     bool broadcastOpIsConvBias(BroadcastOp broadcast_op) const {
         auto dims = broadcast_op.getDimensions();
@@ -33,6 +66,10 @@ struct FusePaddingIntoConv2DNchwFchw : OpRewritePattern<Conv2DNchwFchwOp> {
 
         return true;
     }
+};
+
+struct FusePaddingIntoConv2DNchwFchw : FusePaddingIntoConv2DNchwBase<Conv2DNchwFchwOp> {
+    using FusePaddingIntoConv2DNchwBase<Conv2DNchwFchwOp>::FusePaddingIntoConv2DNchwBase;
 
     LogicalResult matchAndRewrite(Conv2DNchwFchwOp conv_op, PatternRewriter& rewriter) const override {
         // Check and get values
@@ -45,39 +82,9 @@ struct FusePaddingIntoConv2DNchwFchw : OpRewritePattern<Conv2DNchwFchwOp> {
         Value bias;
         Value output = conv_op.getOutputs()[0];
 
-        // Check padding operation
+        // Check padding operation is performed with zero
         auto pad_op = llvm::dyn_cast_or_null<tensor::PadOp>(input.getDefiningOp());
-        if (!pad_op || pad_op.getStaticLow().size() != 4 || pad_op.getStaticLow()[0] != 0 ||
-            pad_op.getStaticLow()[1] != 0 || pad_op.getStaticLow()[2] == INT64_MIN ||
-            pad_op.getStaticLow()[3] == INT64_MIN || pad_op.getStaticHigh().size() != 4 ||
-            pad_op.getStaticHigh()[0] != 0 || pad_op.getStaticHigh()[1] != 0 ||
-            pad_op.getStaticHigh()[2] == INT64_MIN || pad_op.getStaticHigh()[3] == INT64_MIN ||
-            pad_op.getRegion().getBlocks().size() != 1) {
-            return failure();
-        }
-        auto& block = pad_op.getRegion().getBlocks().front();
-        if (block.getOperations().size() != 1) {
-            return failure();
-        }
-        auto yield_op = llvm::dyn_cast_or_null<tensor::YieldOp>(block.getOperations().front());
-        if (!yield_op) {
-            return failure();
-        }
-
-        // Check that padding is performed with a zero
-        auto constant_op = llvm::dyn_cast_or_null<arith::ConstantOp>(yield_op.getValue().getDefiningOp());
-        if (!constant_op) {
-            return failure();
-        }
-        if (auto float_attr = llvm::dyn_cast<FloatAttr>(constant_op.getValue())) {
-            if (float_attr.getValueAsDouble() != 0.0) {
-                return failure();
-            }
-        } else if (auto integer_attr = llvm::dyn_cast<IntegerAttr>(constant_op.getValue())) {
-            if (integer_attr.getUInt() != 0) {
-                return failure();
-            }
-        } else {
+        if (!paddingOpHasValue(pad_op, 0.0, 0ul)) {
             return failure();
         }
 
@@ -111,10 +118,96 @@ struct FusePaddingIntoConv2DNchwFchw : OpRewritePattern<Conv2DNchwFchwOp> {
         auto strides_attr = DenseI64ArrayAttr::get(this->getContext(), strides);
         auto dilations_attr = DenseI64ArrayAttr::get(this->getContext(), dilations);
         auto paddings_attr = DenseI64ArrayAttr::get(this->getContext(), paddings);
+        auto groups_attr = IntegerAttr::get(IntegerType::get(this->getContext(), 64), 1);
 
         // Create the custom convolution with paddings
         rewriter.replaceOpWithNewOp<custom::Conv2DNchwFchwOp>(
-            conv_op, resultType, input, weights, bias, output, strides_attr, dilations_attr, paddings_attr
+            conv_op, resultType, input, weights, bias, output, strides_attr, dilations_attr, paddings_attr, groups_attr
+        );
+
+        return success();
+    }
+};
+
+struct FusePaddingIntoDepthwiseConv2DNchwChwOp : FusePaddingIntoConv2DNchwBase<DepthwiseConv2DNchwChwOp> {
+    using FusePaddingIntoConv2DNchwBase<DepthwiseConv2DNchwChwOp>::FusePaddingIntoConv2DNchwBase;
+
+    LogicalResult matchAndRewrite(DepthwiseConv2DNchwChwOp conv_op, PatternRewriter& rewriter) const override {
+        // Check and get values
+        if (conv_op.getInputs().size() != 2 || conv_op.getOutputs().size() != 1 || conv_op.getResults().size() != 1) {
+            return failure();
+        }
+        Type resultType = conv_op.getResults()[0].getType();
+        Value input = conv_op.getInputs()[0];
+        Value weights = conv_op.getInputs()[1];
+        Value bias;
+        Value output = conv_op.getOutputs()[0];
+
+        // Check that weights are collapsed
+        auto collapse_shape_op = llvm::dyn_cast_or_null<tensor::CollapseShapeOp>(weights.getDefiningOp());
+        if (!collapse_shape_op || collapse_shape_op.getSrcType().getRank() != 4 ||
+            collapse_shape_op.getResultType().getRank() != 3 ||
+            collapse_shape_op.getSrcType().getDimSize(0) != collapse_shape_op.getResultType().getDimSize(0) ||
+            collapse_shape_op.getSrcType().getDimSize(2) != collapse_shape_op.getResultType().getDimSize(1) ||
+            collapse_shape_op.getSrcType().getDimSize(3) != collapse_shape_op.getResultType().getDimSize(2) ||
+            collapse_shape_op.getSrcType().getDimSize(1) != 1) {
+            return failure();
+        }
+
+        // Remap the weights to the un-collapsed value
+        weights = collapse_shape_op.getSrc();
+
+        // Check padding operation is performed with zero
+        SmallVector<int64_t> paddings;
+        auto pad_op = llvm::dyn_cast_or_null<tensor::PadOp>(input.getDefiningOp());
+        if (paddingOpHasValue(pad_op, 0.0, 0ul)) {
+            // Remap the input to the un-padded value
+            input = pad_op.getSource();
+
+            // Copy the padding values
+            paddings.push_back(pad_op.getStaticLow()[2]);
+            paddings.push_back(pad_op.getStaticLow()[3]);
+            paddings.push_back(pad_op.getStaticHigh()[2]);
+            paddings.push_back(pad_op.getStaticHigh()[3]);
+        } else {
+            // Default padding values
+            paddings.push_back(0);
+            paddings.push_back(0);
+            paddings.push_back(0);
+            paddings.push_back(0);
+        }
+
+        // Check if the output is a broadcasted value
+        if (auto broadcast_op = llvm::dyn_cast_or_null<BroadcastOp>(output.getDefiningOp())) {
+            if (this->broadcastOpIsConvBias(broadcast_op)) {
+                // Add bias & remap output
+                bias = broadcast_op.getInput();
+                output = broadcast_op.getInit();
+            }
+        }
+
+        // Copy strides and dilations
+        SmallVector<int64_t> strides, dilations;
+        for (int64_t stride : conv_op.getStrides().getValues<int64_t>()) {
+            strides.push_back(stride);
+        }
+        for (int64_t dilation : conv_op.getDilations().getValues<int64_t>()) {
+            dilations.push_back(dilation);
+        }
+        auto strides_attr = DenseI64ArrayAttr::get(this->getContext(), strides);
+        auto dilations_attr = DenseI64ArrayAttr::get(this->getContext(), dilations);
+        auto paddings_attr = DenseI64ArrayAttr::get(this->getContext(), paddings);
+
+        // Get groups
+        auto input_type = llvm::dyn_cast_or_null<RankedTensorType>(input.getType());
+        if (!input_type || input_type.getRank() != 4) {
+            return failure();
+        }
+        auto groups_attr = IntegerAttr::get(IntegerType::get(this->getContext(), 64), input_type.getDimSize(1));
+
+        // Create the custom convolution with paddings
+        rewriter.replaceOpWithNewOp<custom::Conv2DNchwFchwOp>(
+            conv_op, resultType, input, weights, bias, output, strides_attr, dilations_attr, paddings_attr, groups_attr
         );
 
         return success();
@@ -260,6 +353,7 @@ struct LinalgCustomFusePaddingPass : public impl::LinalgCustomFusePaddingPassBas
 void populateLinalgCustomFusePaddingPass(RewritePatternSet& patterns) {
     patterns.add<
         FusePaddingIntoConv2DNchwFchw,
+        FusePaddingIntoDepthwiseConv2DNchwChwOp,
         FusePaddingIntoPoolingNchwOp<PoolingNchwMaxOp>,
         FusePaddingIntoPoolingNchwOp<PoolingNchwSumOp>>(patterns.getContext());
 }

--- a/mlir/lib/Dialect/Linalg/Transforms/CustomRemoveRedundant.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/CustomRemoveRedundant.cpp
@@ -80,6 +80,7 @@ struct LinalgCustomRemoveRedundantOpsPass
 void populateLinalgCustomRemoveRedundantOpsPass(RewritePatternSet& patterns) {
     patterns.add<
         Linalg2DNchwRemoveLinalgFill<Conv2DNchwFchwOp, 0x0000000000000000>,
+        Linalg2DNchwRemoveLinalgFill<DepthwiseConv2DNchwChwOp, 0x0000000000000000>,
         Linalg2DNchwRemoveLinalgFill<PoolingNchwMaxOp, 0xFFF0000000000000>,
         Linalg2DNchwRemoveLinalgFill<PoolingNchwSumOp, 0x0000000000000000>>(patterns.getContext());
 }

--- a/mlir/lib/Target/SDFG/LinalgToSDFGTranslator.cpp
+++ b/mlir/lib/Target/SDFG/LinalgToSDFGTranslator.cpp
@@ -602,7 +602,7 @@ LogicalResult translateLinalgCustomConv2DNchwFchwOp(SDFGTranslator& translator, 
         dilations.push_back(::sdfg::symbolic::integer(dilation));
     }
     ::sdfg::symbolic::Expression output_channels = ::sdfg::symbolic::integer(weights.getType().getShape()[0]);
-    ::sdfg::symbolic::Expression group = ::sdfg::symbolic::one();
+    ::sdfg::symbolic::Expression group = ::sdfg::symbolic::integer(conv_op->getGroups());
 
     auto& block = builder.add_block(translator.insertion_point(), {}, deb_info);
     auto& input_access = builder.add_access(block, input_container, deb_info);


### PR DESCRIPTION
- Added group attribute to custom conv2D operation and adapted translation
- Set default value for group attribute to 1 (nothing changes)
- Implemented MLIR passes to fuse padding into depthwise convolution by replacing it with custom conv2D operation with groups=channels
- Added different test cases for depthwise convolutions