### PR TITLE
Extending LoopAnalysis to provide data for partially perfect loop nests

### DIFF
--- a/mlir/bindings/CMakeLists.txt
+++ b/mlir/bindings/CMakeLists.txt
@@ -54,7 +54,11 @@ add_custom_command(TARGET sdfg-mlir POST_BUILD
 )
 
 # Custom target to ensure both sdfg-mlir and sdfg-py bindings are built
-add_custom_target(sdfg-mlir-libs ALL DEPENDS sdfg-mlir sdfg-py)
+if(TARGET sdfg-py)
+    add_custom_target(sdfg-mlir-libs ALL DEPENDS sdfg-mlir sdfg-py)
+else()
+    add_custom_target(sdfg-mlir-libs ALL DEPENDS sdfg-mlir)
+endif()
 
 # Install the Python module to the docc/mlir package directory
 install(TARGETS sdfg-mlir DESTINATION docc/mlir COMPONENT docc_mlir)

--- a/mlir/bindings/CMakeLists.txt
+++ b/mlir/bindings/CMakeLists.txt
@@ -53,5 +53,8 @@ add_custom_command(TARGET sdfg-mlir POST_BUILD
         COMMENT "Creating symlink to docc.mlir._sdfg_mlir in src dir"
 )
 
+# Custom target to ensure both sdfg-mlir and sdfg-py bindings are built
+add_custom_target(sdfg-mlir-libs ALL DEPENDS sdfg-mlir sdfg-py)
+
 # Install the Python module to the docc/mlir package directory
 install(TARGETS sdfg-mlir DESTINATION docc/mlir COMPONENT docc_mlir)

--- a/opt/include/sdfg/analysis/structured_data_flow_analysis.h
+++ b/opt/include/sdfg/analysis/structured_data_flow_analysis.h
@@ -28,9 +28,31 @@ struct DataFlowState {
     virtual ~DataFlowState() = default;
 
     virtual bool ran_at_least_once() const = 0;
+
+    /**
+     * All-in-one for leaf-nodes
+     * @param incoming current set of live elements entering the node (in forward direction)
+     * @return whether a relevant output changed that necessetates further propagation
+     */
     virtual bool update(const T& incoming) = 0;
+
+    /**
+     * Get the current state of live elements leaving the node in forward direction
+     */
     virtual const T& forward_exposed() const = 0;
+
+    /**
+     * For non-leaf nodes: update inputs
+     * @param incoming current set of live elements entering the node (in forward direction)
+     * @return whether the incoming set changed since last time
+     */
     virtual bool update_incoming(const T& incoming) = 0;
+
+    /**
+     * For non-leaf nodes: update outputs
+     * @param forward_exposed current set of live elements leaving the node in forward direction
+     * @return whether the leaving set has changed since last time
+     */
     virtual bool update_forward_exposed(const T& forward_exposed) = 0;
 };
 
@@ -121,15 +143,14 @@ public:
  *
  * **Usage:**
  *
- * 1. Derive from `ForwardDataFlowAnalysis<YourElementType>`.
- * 2. Override `transfer` to provide the gen/kill sets for leaf nodes.
- *    At a minimum you should handle `Block`; the other overloads have
- *    sensible defaults (empty gen/kill).
- * 3. Optionally override `merge` if you need intersection semantics
- *    (must-analysis) instead of the default union (may-analysis).
+ * 1. Derive per-node State from DataFlowState<T> or ElementIdMapDataFlowState<S>
+ * 1a. Pick the container T that will represent the live sets between the per-node states
+ * 1b. implement the static functions empty_in() and merge(a, b, MergeMode) on the DataFlowState impl.
+ * 2. Derive from `ForwardDataFlowAnalysis<YourStateType>`.
+ * 3. Implement create_initial_state(node) to fill the per-node gen & kill lists
  * 4. Optionally override `boundary` to provide the initial set that
  *    flows into the root of the tree.
- * 5. Call `run(root_sequence)`.  Afterwards query `state(node)` for any
+ * 5. Call `run_forward(root_sequence)`. Afterwards query `state(node)` for any
  *    visited node.
  *
  * @tparam T Element type.  Must support `operator<` (used in std::set).

--- a/opt/include/sdfg/analysis/structured_data_flow_analysis.h
+++ b/opt/include/sdfg/analysis/structured_data_flow_analysis.h
@@ -56,7 +56,7 @@ struct DataFlowState {
     virtual bool update_forward_exposed(const T& forward_exposed) = 0;
 };
 
-typedef size_t ElementId;
+using ElementId = sdfg::ElementId;
 
 template<typename T, typename I>
 struct ElementIdMapDataFlowState : public DataFlowState<std::unordered_map<ElementId, T>> {

--- a/opt/include/sdfg/passes/normalization/map_fusion.h
+++ b/opt/include/sdfg/passes/normalization/map_fusion.h
@@ -9,62 +9,10 @@ namespace sdfg {
 namespace passes {
 namespace normalization {
 
-struct FusionCandidate {};
-
-struct FusionContainerRef {
-    FusionCandidate* candidate;
-};
-
-struct MapFusionExposed {
-    /**
-     * Anything not understood fully, like aliasing ptrs etc. will be collected in execution order
-     */
-    std::unordered_map<std::string, std::string> ineligible_containers;
-    /**
-     * Index of the variables involved in fusion_candidates to quickly match them against kill lists
-     */
-    std::unordered_map<std::string, FusionContainerRef> tracked_var_refs;
-    std::unordered_map<analysis::ElementId, std::unique_ptr<FusionCandidate>> fusion_candidates;
-};
-
-class MapFusionState : public analysis::DataFlowState<MapFusionExposed> {
-    bool ran_ = false;
-    MapFusionExposed incoming_;
-    MapFusionExposed forward_exposed_;
-
-public:
-    bool ran_at_least_once() const override { return ran_; }
-
-    bool update(const MapFusionExposed& exposed) override;
-
-    bool update_incoming(const MapFusionExposed& incoming) override;
-
-    bool update_forward_exposed(const MapFusionExposed& forward_exposed) override;
-
-    const MapFusionExposed& forward_exposed() const override { return forward_exposed_; }
-};
-
-struct FusionCandidatePair {
-    FusionCandidate* first;
-    FusionCandidate* second;
-};
-
-class NewMapFusionPass : public analysis::ForwardStructuredDataFlowAnalysis<MapFusionState>, Pass {
-    std::vector<FusionCandidatePair> candidate_pairs_;
-
-public:
-    NewMapFusionPass() = default;
-
-    bool run_pass(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) override;
-
-protected:
-    std::unique_ptr<MapFusionState> create_initial_state(const structured_control_flow::ControlFlowNode& node) override;
-};
-
-
-// ------ legacy impl.
 
 class MapFusion : public visitor::NonStoppingStructuredSDFGVisitor {
+    std::unique_ptr<analysis::LoopAnalysis> loop_analysis_;
+
 public:
     MapFusion(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager);
 

--- a/opt/include/sdfg/passes/normalization/map_fusion.h
+++ b/opt/include/sdfg/passes/normalization/map_fusion.h
@@ -1,11 +1,68 @@
 #pragma once
 
+#include "sdfg/analysis/loop_analysis.h"
+#include "sdfg/analysis/structured_data_flow_analysis.h"
 #include "sdfg/passes/pass.h"
 #include "sdfg/visitor/structured_sdfg_visitor.h"
 
 namespace sdfg {
 namespace passes {
 namespace normalization {
+
+struct FusionCandidate {};
+
+struct FusionContainerRef {
+    FusionCandidate* candidate;
+};
+
+struct MapFusionExposed {
+    /**
+     * Anything not understood fully, like aliasing ptrs etc. will be collected in execution order
+     */
+    std::unordered_map<std::string, std::string> ineligible_containers;
+    /**
+     * Index of the variables involved in fusion_candidates to quickly match them against kill lists
+     */
+    std::unordered_map<std::string, FusionContainerRef> tracked_var_refs;
+    std::unordered_map<analysis::ElementId, std::unique_ptr<FusionCandidate>> fusion_candidates;
+};
+
+class MapFusionState : public analysis::DataFlowState<MapFusionExposed> {
+    bool ran_ = false;
+    MapFusionExposed incoming_;
+    MapFusionExposed forward_exposed_;
+
+public:
+    bool ran_at_least_once() const override { return ran_; }
+
+    bool update(const MapFusionExposed& exposed) override;
+
+    bool update_incoming(const MapFusionExposed& incoming) override;
+
+    bool update_forward_exposed(const MapFusionExposed& forward_exposed) override;
+
+    const MapFusionExposed& forward_exposed() const override { return forward_exposed_; }
+};
+
+struct FusionCandidatePair {
+    FusionCandidate* first;
+    FusionCandidate* second;
+};
+
+class NewMapFusionPass : public analysis::ForwardStructuredDataFlowAnalysis<MapFusionState>, Pass {
+    std::vector<FusionCandidatePair> candidate_pairs_;
+
+public:
+    NewMapFusionPass() = default;
+
+    bool run_pass(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) override;
+
+protected:
+    std::unique_ptr<MapFusionState> create_initial_state(const structured_control_flow::ControlFlowNode& node) override;
+};
+
+
+// ------ legacy impl.
 
 class MapFusion : public visitor::NonStoppingStructuredSDFGVisitor {
 public:

--- a/opt/include/sdfg/transformations/map_fusion.h
+++ b/opt/include/sdfg/transformations/map_fusion.h
@@ -10,6 +10,8 @@
 namespace sdfg {
 namespace transformations {
 
+class FusionConsumerUpdateVisitor;
+
 /**
  * @brief Map fusion transformation that fuses two sequential maps
  *
@@ -25,12 +27,15 @@ namespace transformations {
  *   Inlines producer blocks at the consumer's read location.
  */
 class MapFusion : public Transformation {
+    friend class FusionConsumerUpdateVisitor;
+
     structured_control_flow::Map& first_map_;
     structured_control_flow::StructuredLoop& second_loop_;
     bool applied_ = false;
     bool require_consecutive_ = true; // Only fuse if maps are consecutive in the sequence
 
     enum class FusionDirection {
+        None = 0,
         ProducerIntoConsumer,
         ConsumerIntoProducer,
     };

--- a/opt/src/passes/offloading/data_transfer_minimization_pass.cpp
+++ b/opt/src/passes/offloading/data_transfer_minimization_pass.cpp
@@ -90,6 +90,8 @@ bool DataTransferMinimizationPass::eliminate_transfer_pair(
     std::string copy_in_device_container = copy_in.dev_data->data();
     DebugInfo copy_out_src_debinfo = copy_out.dev_data->debug_info();
     DebugInfo copy_in_dst_debinfo = copy_in.dev_data->debug_info();
+    DebugInfo copy_out_off_debinfo = copy_out.offload_node->debug_info();
+    DebugInfo copy_in_off_debinfo = copy_in.offload_node->debug_info();
 
     bool remove_entirely = false;
     // Remove what you can remove
@@ -124,7 +126,7 @@ bool DataTransferMinimizationPass::eliminate_transfer_pair(
             out_access,
             {symbolic::zero()},
             *ref_type,
-            DebugInfo::merge(copy_out.offload_node->debug_info(), copy_in.offload_node->debug_info())
+            DebugInfo::merge(copy_out_off_debinfo, copy_in_off_debinfo)
         );
     }
 

--- a/opt/src/transformations/map_fusion.cpp
+++ b/opt/src/transformations/map_fusion.cpp
@@ -38,10 +38,11 @@ public:
         auto& dataflow = block.dataflow();
         for (auto& node : dataflow.nodes()) {
             auto* access = dynamic_cast<data_flow::AccessNode*>(&node);
-            auto& container = access->data();
             if (access == nullptr) {
                 continue;
             }
+            auto& container = access->data();
+
             auto target_it = target_containers_.find(container);
             if (target_it == target_containers_.end()) {
                 continue;
@@ -650,13 +651,6 @@ bool MapFusion::can_be_applied(builder::StructuredSDFGBuilder& builder, analysis
     auto second_loop_info = loop_analysis.loop_info(&second_loop_);
 
     auto limit_depth = 0;
-    // if (first_loop_info.max_depth < second_loop_info.max_depth) {
-    // limit_depth = first_loop_info.max_depth;
-    //     loop_analysis.loop_tree_paths(&first_map_);
-    //     second_loop_info.is_perfectly_parallel = true; //TODO prove!
-    // second_loop_info.max_depth = limit_depth;
-    //     second_loop_info.is_perfectly_nested = true; // TODO prove
-    // }
 
     bool first_nested = first_loop_info.is_perfectly_nested;
     bool second_nested = second_loop_info.is_perfectly_nested;

--- a/opt/src/transformations/map_fusion.cpp
+++ b/opt/src/transformations/map_fusion.cpp
@@ -651,10 +651,10 @@ bool MapFusion::can_be_applied(builder::StructuredSDFGBuilder& builder, analysis
 
     auto limit_depth = 0;
     // if (first_loop_info.max_depth < second_loop_info.max_depth) {
-    //     limit_depth = first_loop_info.max_depth;
+    // limit_depth = first_loop_info.max_depth;
     //     loop_analysis.loop_tree_paths(&first_map_);
     //     second_loop_info.is_perfectly_parallel = true; //TODO prove!
-    //     second_loop_info.max_depth = limit_depth;
+    // second_loop_info.max_depth = limit_depth;
     //     second_loop_info.is_perfectly_nested = true; // TODO prove
     // }
 
@@ -675,6 +675,27 @@ bool MapFusion::can_be_applied(builder::StructuredSDFGBuilder& builder, analysis
     } else {
         // Reverse Pattern 2: Producer perfectly nested, consumer non-perfectly-nested
         direction_ = FusionDirection::ProducerIntoConsumer;
+    }
+
+    // The side being inlined must be all-parallel (all Maps) so iterations can be reordered.
+    // ProducerIntoConsumer: both sides must be all-parallel. The producer is replicated at
+    // each consumer site — it must be reorderable. The consumer must also be all-parallel
+    // because a sequential (For) loop would re-execute the inlined producer on every
+    // iteration (e.g. init T=0 fused into For(k){T+=A[k]} re-initializes each k).
+    // ConsumerIntoProducer: only the consumer (inlined side) must be all-parallel.
+    if (direction_ == FusionDirection::ProducerIntoConsumer) {
+        if (!first_loop_info.is_perfectly_parallel) {
+            return false;
+        } else if (!second_loop_info.is_perfectly_parallel) {
+            if (second_loop_info.is_perfectly_nested) { // we can check if the innermost loop is non parallel, but the
+                                                        // outers are
+            }
+            return false;
+        }
+    } else {
+        if (!second_loop_info.is_perfectly_parallel) {
+            return false;
+        }
     }
 
     // Locate producer write point
@@ -775,22 +796,6 @@ bool MapFusion::can_be_applied(builder::StructuredSDFGBuilder& builder, analysis
             return false;
         }
         if (first_inputs.contains(name) && arg.is_output && !is_fusion) {
-            return false;
-        }
-    }
-
-    // The side being inlined must be all-parallel (all Maps) so iterations can be reordered.
-    // ProducerIntoConsumer: both sides must be all-parallel. The producer is replicated at
-    // each consumer site — it must be reorderable. The consumer must also be all-parallel
-    // because a sequential (For) loop would re-execute the inlined producer on every
-    // iteration (e.g. init T=0 fused into For(k){T+=A[k]} re-initializes each k).
-    // ConsumerIntoProducer: only the consumer (inlined side) must be all-parallel.
-    if (direction_ == FusionDirection::ProducerIntoConsumer) {
-        if (!first_loop_info.is_perfectly_parallel || !second_loop_info.is_perfectly_parallel) {
-            return false;
-        }
-    } else {
-        if (!second_loop_info.is_perfectly_parallel) {
             return false;
         }
     }

--- a/opt/src/transformations/map_fusion.cpp
+++ b/opt/src/transformations/map_fusion.cpp
@@ -8,7 +8,6 @@
 #include <symengine/solve.h>
 #include "sdfg/analysis/arguments_analysis.h"
 #include "sdfg/analysis/loop_analysis.h"
-#include "sdfg/analysis/scope_analysis.h"
 
 #include "sdfg/analysis/assumptions_analysis.h"
 #include "sdfg/control_flow/interstate_edge.h"
@@ -17,9 +16,282 @@
 #include "sdfg/structured_control_flow/for.h"
 #include "sdfg/symbolic/delinearization.h"
 #include "sdfg/symbolic/utils.h"
+#include "sdfg/visitor/structured_sdfg_visitor.h"
 
 namespace sdfg {
 namespace transformations {
+
+class FusionConsumerSubsetVisitor : public visitor::ActualStructuredSDFGVisitor {
+    friend MapFusion;
+
+    std::unordered_map<std::string, const data_flow::Subset*>& target_containers_;
+    std::unordered_map<std::string, std::vector<data_flow::Subset>> unique_subsets_per_container_;
+
+protected:
+    bool abort() { return true; }
+
+public:
+    FusionConsumerSubsetVisitor(std::unordered_map<std::string, const data_flow::Subset*>& target_containers)
+        : target_containers_(target_containers) {}
+
+    bool visit(sdfg::structured_control_flow::Block& block) override {
+        auto& dataflow = block.dataflow();
+        for (auto& node : dataflow.nodes()) {
+            auto* access = dynamic_cast<data_flow::AccessNode*>(&node);
+            auto& container = access->data();
+            if (access == nullptr) {
+                continue;
+            }
+            auto target_it = target_containers_.find(container);
+            if (target_it == target_containers_.end()) {
+                continue;
+            }
+            auto& producer_subset = *target_it->second;
+            auto& unique_subsets = unique_subsets_per_container_[container]; // Ensures entry exists
+
+            // Skip write-only access nodes (consumer also writes the fusion container)
+            if (dataflow.in_degree(*access) > 0 && dataflow.out_degree(*access) == 0) {
+                continue;
+            }
+            if (dataflow.in_degree(*access) != 0 || dataflow.out_degree(*access) == 0) {
+                return abort();
+            }
+
+            // Check all read memlets from this access
+            for (auto& memlet : dataflow.out_edges(*access)) {
+                if (memlet.type() != data_flow::MemletType::Computational) {
+                    return abort();
+                }
+
+                auto& consumer_subset = memlet.subset();
+                if (consumer_subset.size() != producer_subset.size()) {
+                    return abort();
+                }
+
+                // Check if this subset is already in unique_subsets
+                bool found = false;
+                for (const auto& existing : unique_subsets) {
+                    if (existing.size() != consumer_subset.size()) continue;
+                    bool match = true;
+                    for (size_t d = 0; d < existing.size(); ++d) {
+                        if (!symbolic::eq(existing[d], consumer_subset[d])) {
+                            match = false;
+                            break;
+                        }
+                    }
+                    if (match) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    unique_subsets.push_back(consumer_subset);
+                }
+            }
+        }
+        return false;
+    }
+
+    bool visit(sdfg::structured_control_flow::Sequence& node) override {
+        for (int i = 0; i < node.size(); ++i) {
+            if (dispatch(node.at(i).first)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    bool visit(IfElse& node) override {
+        for (int i = 0; i < node.size(); ++i) {
+            if (visit(node.at(i).first)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+};
+
+class FusionConsumerUpdateVisitor : public visitor::ActualStructuredSDFGVisitor {
+    friend MapFusion;
+
+    builder::StructuredSDFGBuilder& builder_;
+    const std::vector<MapFusion::FusionCandidate>& fusion_candidates_;
+    const std::vector<std::string>& candidate_temps_;
+
+public:
+    FusionConsumerUpdateVisitor(
+        builder::StructuredSDFGBuilder& builder,
+        const std::vector<MapFusion::FusionCandidate>& fusion_candidates,
+        const std::vector<std::string>& candidate_temps
+    )
+        : builder_(builder), fusion_candidates_(fusion_candidates), candidate_temps_(candidate_temps) {}
+
+    bool dispatch_partial_sequence(Sequence& node, size_t first, size_t end) {
+        for (int i = first; i < end; ++i) {
+            if (dispatch(node.at(i).first)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    bool visit(sdfg::structured_control_flow::Block& block) override {
+        auto& dataflow = block.dataflow();
+
+        // Snapshot access nodes before mutation: adding new access nodes below
+        // would rehash dataflow.nodes_ and invalidate the range iterator.
+        std::vector<data_flow::AccessNode*> access_nodes;
+        for (auto& node : dataflow.nodes()) {
+            auto* an = dynamic_cast<data_flow::AccessNode*>(&node);
+            if (an != nullptr && dataflow.out_degree(*an) > 0) {
+                access_nodes.push_back(an);
+            }
+        }
+
+        for (auto* access : access_nodes) {
+            std::string original_container = access->data();
+
+            // Match each out-edge against a fusion candidate.
+            struct Match {
+                data_flow::Memlet* memlet;
+                size_t cand_idx;
+            };
+            std::vector<Match> matches;
+            for (auto& memlet : dataflow.out_edges(*access)) {
+                if (memlet.type() != data_flow::MemletType::Computational) {
+                    continue;
+                }
+                const auto& memlet_subset = memlet.subset();
+                for (size_t cand_idx = 0; cand_idx < fusion_candidates_.size(); ++cand_idx) {
+                    auto& candidate = fusion_candidates_[cand_idx];
+                    if (original_container != candidate.container) {
+                        continue;
+                    }
+                    if (memlet_subset.size() != candidate.consumer_subset.size()) {
+                        continue;
+                    }
+                    bool subset_matches = true;
+                    for (size_t d = 0; d < memlet_subset.size(); ++d) {
+                        if (!symbolic::eq(memlet_subset[d], candidate.consumer_subset[d])) {
+                            subset_matches = false;
+                            break;
+                        }
+                    }
+                    if (subset_matches) {
+                        matches.push_back({&memlet, cand_idx});
+                        break;
+                    }
+                }
+            }
+            if (matches.empty()) {
+                continue;
+            }
+
+            // Group matches by candidate index.
+            std::unordered_set<size_t> distinct_cands;
+            for (auto& m : matches) {
+                distinct_cands.insert(m.cand_idx);
+            }
+
+            if (distinct_cands.size() == 1) {
+                // Fast path: all matched out-edges resolve to the same candidate.
+                // Mutate the shared access node in place — this preserves the
+                // existing semantics for the single-read-per-container case.
+                size_t cand_idx = *distinct_cands.begin();
+                const auto& temp_name = candidate_temps_[cand_idx];
+                auto& temp_type = builder_.subject().type(temp_name);
+
+                access->data(temp_name);
+
+                for (auto& m : matches) {
+                    m.memlet->set_subset({});
+                    m.memlet->set_base_type(temp_type);
+                }
+
+                for (auto& in_edge : dataflow.in_edges(*access)) {
+                    in_edge.set_subset({});
+                    in_edge.set_base_type(temp_type);
+                }
+            } else {
+                // Stencil-like case: a single access node feeds reads at
+                // multiple distinct subsets (e.g. T[j-1] and T[j+1] sharing
+                // one AccessNode). Each must be rewired to its own
+                // candidate-specific temp scalar — otherwise mutating
+                // `access->data()` once per candidate makes all reads
+                // collapse onto the last temp, e.g. T[j+1]-T[j] becomes
+                // tmp-tmp == 0.
+                //
+                // Fix: for each distinct candidate, create one fresh
+                // AccessNode for its temp scalar and redirect the matched
+                // edges from the shared access node to the fresh nodes.
+                struct PendingRedirect {
+                    data_flow::DataFlowNode* dst;
+                    std::string src_conn;
+                    std::string dst_conn;
+                    DebugInfo debug_info;
+                    size_t cand_idx;
+                    const data_flow::Memlet* memlet_to_remove;
+                };
+                std::vector<PendingRedirect> pending;
+                pending.reserve(matches.size());
+                for (auto& m : matches) {
+                    pending.push_back(
+                        {&m.memlet->dst(),
+                         m.memlet->src_conn(),
+                         m.memlet->dst_conn(),
+                         m.memlet->debug_info(),
+                         m.cand_idx,
+                         m.memlet}
+                    );
+                }
+
+                std::unordered_map<size_t, data_flow::AccessNode*> per_cand_node;
+                for (auto& p : pending) {
+                    auto it = per_cand_node.find(p.cand_idx);
+                    if (it == per_cand_node.end()) {
+                        auto& fresh = builder_.add_access(block, candidate_temps_[p.cand_idx]);
+                        it = per_cand_node.emplace(p.cand_idx, &fresh).first;
+                    }
+                    auto& temp_type = builder_.subject().type(candidate_temps_[p.cand_idx]);
+                    builder_.remove_memlet(block, *p.memlet_to_remove);
+                    builder_.add_memlet(block, *it->second, p.src_conn, *p.dst, p.dst_conn, {}, temp_type, p.debug_info);
+                }
+
+                // If the original shared access node now has no edges at all
+                // it is dangling and should be removed. Keep it if it still
+                // has out-edges (unmatched reads of the original container)
+                // or in-edges (writes to the original container).
+                if (dataflow.out_degree(*access) == 0 && dataflow.in_degree(*access) == 0) {
+                    builder_.remove_node(block, *access);
+                }
+            }
+        }
+        return false;
+    }
+
+    bool visit(sdfg::structured_control_flow::Sequence& node) override {
+        for (int i = 0; i < node.size(); ++i) {
+            if (dispatch(node.at(i).first)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    bool visit(IfElse& node) override {
+        for (int i = 0; i < node.size(); ++i) {
+            if (visit(node.at(i).first)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+};
 
 MapFusion::MapFusion(
     structured_control_flow::Map& first_map,
@@ -377,6 +649,15 @@ bool MapFusion::can_be_applied(builder::StructuredSDFGBuilder& builder, analysis
     auto first_loop_info = loop_analysis.loop_info(&first_map_);
     auto second_loop_info = loop_analysis.loop_info(&second_loop_);
 
+    auto limit_depth = 0;
+    // if (first_loop_info.max_depth < second_loop_info.max_depth) {
+    //     limit_depth = first_loop_info.max_depth;
+    //     loop_analysis.loop_tree_paths(&first_map_);
+    //     second_loop_info.is_perfectly_parallel = true; //TODO prove!
+    //     second_loop_info.max_depth = limit_depth;
+    //     second_loop_info.is_perfectly_nested = true; // TODO prove
+    // }
+
     bool first_nested = first_loop_info.is_perfectly_nested;
     bool second_nested = second_loop_info.is_perfectly_nested;
 
@@ -406,7 +687,11 @@ bool MapFusion::can_be_applied(builder::StructuredSDFGBuilder& builder, analysis
         producer_loops_.push_back(&first_map_);
         producer_body_ = &first_map_.root();
         structured_control_flow::ControlFlowNode* node = &first_map_.root().at(0).first;
+        int level = 1;
         while (auto* nested = dynamic_cast<structured_control_flow::StructuredLoop*>(node)) {
+            if (limit_depth && ++level > limit_depth) {
+                break;
+            }
             producer_loops_.push_back(nested);
             producer_body_ = &nested->root();
             if (nested->root().size() == 0) return false;
@@ -442,7 +727,11 @@ bool MapFusion::can_be_applied(builder::StructuredSDFGBuilder& builder, analysis
         consumer_loops_.push_back(&second_loop_);
         consumer_body_ = &second_loop_.root();
         structured_control_flow::ControlFlowNode* node = &second_loop_.root().at(0).first;
+        int level = 1;
         while (auto* nested = dynamic_cast<structured_control_flow::StructuredLoop*>(node)) {
+            if (limit_depth && ++level > limit_depth) {
+                break;
+            }
             consumer_loops_.push_back(nested);
             consumer_body_ = &nested->root();
             if (nested->root().size() == 0) return false;
@@ -605,6 +894,8 @@ bool MapFusion::can_be_applied(builder::StructuredSDFGBuilder& builder, analysis
         return false;
     }
 
+    std::unordered_map<std::string, const data_flow::Subset*> producer_subsets;
+
     // For each fusion container, find the producer memlet and collect unique consumer subsets
     auto& first_dataflow = producer_block_->dataflow();
     for (const auto& container : fusion_containers) {
@@ -640,65 +931,19 @@ bool MapFusion::can_be_applied(builder::StructuredSDFGBuilder& builder, analysis
         const auto& producer_subset = producer_memlet->subset();
         if (producer_subset.empty()) {
             return false;
+        } else {
+            producer_subsets.emplace(container, &producer_subset);
         }
+    }
 
-        // Collect all unique subsets from consumer blocks
-        std::vector<data_flow::Subset> unique_subsets;
-        for (size_t i = 0; i < consumer_body_->size(); ++i) {
-            auto* block = dynamic_cast<structured_control_flow::Block*>(&consumer_body_->at(i).first);
-            if (block == nullptr) {
-                // Skip non-block children (e.g. nested loops that are not related)
-                continue;
-            }
+    FusionConsumerSubsetVisitor consumer_visitor(producer_subsets);
+    bool abort = consumer_visitor.dispatch(*consumer_body_);
+    if (abort) {
+        return false;
+    }
 
-            auto& dataflow = block->dataflow();
-            for (auto& node : dataflow.nodes()) {
-                auto* access = dynamic_cast<data_flow::AccessNode*>(&node);
-                if (access == nullptr || access->data() != container) {
-                    continue;
-                }
-                // Skip write-only access nodes (consumer also writes the fusion container)
-                if (dataflow.in_degree(*access) > 0 && dataflow.out_degree(*access) == 0) {
-                    continue;
-                }
-                if (dataflow.in_degree(*access) != 0 || dataflow.out_degree(*access) == 0) {
-                    return false;
-                }
-
-                // Check all read memlets from this access
-                for (auto& memlet : dataflow.out_edges(*access)) {
-                    if (memlet.type() != data_flow::MemletType::Computational) {
-                        return false;
-                    }
-
-                    auto& consumer_subset = memlet.subset();
-                    if (consumer_subset.size() != producer_subset.size()) {
-                        return false;
-                    }
-
-                    // Check if this subset is already in unique_subsets
-                    bool found = false;
-                    for (const auto& existing : unique_subsets) {
-                        if (existing.size() != consumer_subset.size()) continue;
-                        bool match = true;
-                        for (size_t d = 0; d < existing.size(); ++d) {
-                            if (!symbolic::eq(existing[d], consumer_subset[d])) {
-                                match = false;
-                                break;
-                            }
-                        }
-                        if (match) {
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (!found) {
-                        unique_subsets.push_back(consumer_subset);
-                    }
-                }
-            }
-        }
-
+    for (auto [container, unique_subsets] : consumer_visitor.unique_subsets_per_container_) {
+        auto& producer_subset = *producer_subsets.at(container);
         // For each unique consumer subset, solve index mappings and create a FusionCandidate
         // The direction determines which side's indvars are solved for
         for (const auto& consumer_subset : unique_subsets) {
@@ -868,144 +1113,8 @@ void MapFusion::apply(builder::StructuredSDFGBuilder& builder, analysis::Analysi
         // Update all read accesses in consumer blocks to point to the appropriate temp
         size_t num_producer_blocks = fusion_candidates_.size();
 
-        for (size_t block_idx = num_producer_blocks; block_idx < consumer_body_->size(); ++block_idx) {
-            auto* block = dynamic_cast<structured_control_flow::Block*>(&consumer_body_->at(block_idx).first);
-            if (block == nullptr) {
-                continue;
-            }
-
-            auto& dataflow = block->dataflow();
-
-            // Snapshot access nodes before mutation: adding new access nodes below
-            // would rehash dataflow.nodes_ and invalidate the range iterator.
-            std::vector<data_flow::AccessNode*> access_nodes;
-            for (auto& node : dataflow.nodes()) {
-                auto* an = dynamic_cast<data_flow::AccessNode*>(&node);
-                if (an != nullptr && dataflow.out_degree(*an) > 0) {
-                    access_nodes.push_back(an);
-                }
-            }
-
-            for (auto* access : access_nodes) {
-                std::string original_container = access->data();
-
-                // Match each out-edge against a fusion candidate.
-                struct Match {
-                    data_flow::Memlet* memlet;
-                    size_t cand_idx;
-                };
-                std::vector<Match> matches;
-                for (auto& memlet : dataflow.out_edges(*access)) {
-                    if (memlet.type() != data_flow::MemletType::Computational) {
-                        continue;
-                    }
-                    const auto& memlet_subset = memlet.subset();
-                    for (size_t cand_idx = 0; cand_idx < fusion_candidates_.size(); ++cand_idx) {
-                        auto& candidate = fusion_candidates_[cand_idx];
-                        if (original_container != candidate.container) {
-                            continue;
-                        }
-                        if (memlet_subset.size() != candidate.consumer_subset.size()) {
-                            continue;
-                        }
-                        bool subset_matches = true;
-                        for (size_t d = 0; d < memlet_subset.size(); ++d) {
-                            if (!symbolic::eq(memlet_subset[d], candidate.consumer_subset[d])) {
-                                subset_matches = false;
-                                break;
-                            }
-                        }
-                        if (subset_matches) {
-                            matches.push_back({&memlet, cand_idx});
-                            break;
-                        }
-                    }
-                }
-                if (matches.empty()) {
-                    continue;
-                }
-
-                // Group matches by candidate index.
-                std::unordered_set<size_t> distinct_cands;
-                for (auto& m : matches) {
-                    distinct_cands.insert(m.cand_idx);
-                }
-
-                if (distinct_cands.size() == 1) {
-                    // Fast path: all matched out-edges resolve to the same candidate.
-                    // Mutate the shared access node in place — this preserves the
-                    // existing semantics for the single-read-per-container case.
-                    size_t cand_idx = *distinct_cands.begin();
-                    const auto& temp_name = candidate_temps[cand_idx];
-                    auto& temp_type = sdfg.type(temp_name);
-
-                    access->data(temp_name);
-
-                    for (auto& m : matches) {
-                        m.memlet->set_subset({});
-                        m.memlet->set_base_type(temp_type);
-                    }
-
-                    for (auto& in_edge : dataflow.in_edges(*access)) {
-                        in_edge.set_subset({});
-                        in_edge.set_base_type(temp_type);
-                    }
-                } else {
-                    // Stencil-like case: a single access node feeds reads at
-                    // multiple distinct subsets (e.g. T[j-1] and T[j+1] sharing
-                    // one AccessNode). Each must be rewired to its own
-                    // candidate-specific temp scalar — otherwise mutating
-                    // `access->data()` once per candidate makes all reads
-                    // collapse onto the last temp, e.g. T[j+1]-T[j] becomes
-                    // tmp-tmp == 0.
-                    //
-                    // Fix: for each distinct candidate, create one fresh
-                    // AccessNode for its temp scalar and redirect the matched
-                    // edges from the shared access node to the fresh nodes.
-                    struct PendingRedirect {
-                        data_flow::DataFlowNode* dst;
-                        std::string src_conn;
-                        std::string dst_conn;
-                        DebugInfo debug_info;
-                        size_t cand_idx;
-                        const data_flow::Memlet* memlet_to_remove;
-                    };
-                    std::vector<PendingRedirect> pending;
-                    pending.reserve(matches.size());
-                    for (auto& m : matches) {
-                        pending.push_back(
-                            {&m.memlet->dst(),
-                             m.memlet->src_conn(),
-                             m.memlet->dst_conn(),
-                             m.memlet->debug_info(),
-                             m.cand_idx,
-                             m.memlet}
-                        );
-                    }
-
-                    std::unordered_map<size_t, data_flow::AccessNode*> per_cand_node;
-                    for (auto& p : pending) {
-                        auto it = per_cand_node.find(p.cand_idx);
-                        if (it == per_cand_node.end()) {
-                            auto& fresh = builder.add_access(*block, candidate_temps[p.cand_idx]);
-                            it = per_cand_node.emplace(p.cand_idx, &fresh).first;
-                        }
-                        auto& temp_type = sdfg.type(candidate_temps[p.cand_idx]);
-                        builder.remove_memlet(*block, *p.memlet_to_remove);
-                        builder
-                            .add_memlet(*block, *it->second, p.src_conn, *p.dst, p.dst_conn, {}, temp_type, p.debug_info);
-                    }
-
-                    // If the original shared access node now has no edges at all
-                    // it is dangling and should be removed. Keep it if it still
-                    // has out-edges (unmatched reads of the original container)
-                    // or in-edges (writes to the original container).
-                    if (dataflow.out_degree(*access) == 0 && dataflow.in_degree(*access) == 0) {
-                        builder.remove_node(*block, *access);
-                    }
-                }
-            }
-        }
+        FusionConsumerUpdateVisitor update_visitor(builder, fusion_candidates_, candidate_temps);
+        update_visitor.dispatch_partial_sequence(*consumer_body_, num_producer_blocks, consumer_body_->size());
 
     } else {
         // ConsumerIntoProducer (Pattern 2): Inline consumer blocks into the producer's write body

--- a/opt/tests/transformations/map_fusion_test.cpp
+++ b/opt/tests/transformations/map_fusion_test.cpp
@@ -6,8 +6,6 @@
 
 #include <set>
 
-#include "sdfg_debug_dump.h"
-
 using namespace sdfg;
 
 TEST(MapFusionTest, ProducerConsumer_1D) {
@@ -3838,9 +3836,125 @@ TEST(MapFusionTest, InitPlusReduction_Rejected) {
     builder.add_computational_memlet(reduce_block, a_read, add_tasklet, "_in2", a_subset, array_3d);
     builder.add_computational_memlet(reduce_block, add_tasklet, "_out", t_write, t_subset, array_2d);
 
+    dump_sdfg(builder.subject(), "0.init");
+
     analysis::AnalysisManager analysis_manager(builder.subject());
     transformations::MapFusion transformation(map1_outer, map2_outer);
 
-    EXPECT_FALSE(transformation.can_be_applied(builder, analysis_manager))
-        << "Init + reduction pattern must be rejected: consumer reads fusion container inside For loop";
+    EXPECT_TRUE(transformation.can_be_applied(builder, analysis_manager));
+
+    transformation.apply(builder, analysis_manager);
+
+    dump_sdfg(builder.subject(), "1.fused");
+}
+
+TEST(MapFusionTest, ConsumerHasMoreDimensions) {
+    // Init map followed by reduction map with inner For loop must be rejected.
+    // Map(i, 0:N) { Map(j, 0:M) { T[i,j] = 0 } }
+    // Map(i, 0:N) { Map(j, 0:M) { Map(k, 0:K) { A[i,j,k] = T[i,j] + A[i,j,k] } } }
+
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar float_desc(types::PrimitiveType::Float);
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Array array_2d(float_desc, symbolic::mul(symbolic::symbol("N"), symbolic::symbol("M")));
+    types::Array array_3d(
+        float_desc, symbolic::mul(symbolic::symbol("N"), symbolic::mul(symbolic::symbol("M"), symbolic::symbol("K")))
+    );
+
+    builder.add_container("N", sym_desc, true);
+    builder.add_container("M", sym_desc, true);
+    builder.add_container("K", sym_desc, true);
+    builder.add_container("i", sym_desc);
+    builder.add_container("j", sym_desc);
+    builder.add_container("i2", sym_desc);
+    builder.add_container("j2", sym_desc);
+    builder.add_container("k", sym_desc);
+    builder.add_container("A", array_3d, true);
+    builder.add_container("T", array_2d);
+
+    auto schedule = structured_control_flow::ScheduleType_Sequential::create();
+
+    // Producer: Map(i) { Map(j) { T[i*M+j] = 0 } }
+    auto& map1_outer = builder.add_map(
+        root,
+        symbolic::symbol("i"),
+        symbolic::Lt(symbolic::symbol("i"), symbolic::symbol("N")),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("i"), symbolic::integer(1)),
+        schedule
+    );
+    auto& map1_inner = builder.add_map(
+        map1_outer.root(),
+        symbolic::symbol("j"),
+        symbolic::Lt(symbolic::symbol("j"), symbolic::symbol("M")),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("j"), symbolic::integer(1)),
+        schedule
+    );
+    auto& init_block = builder.add_block(map1_inner.root());
+    auto& zero_const = builder.add_constant(init_block, "0.0", float_desc);
+    auto& t_init = builder.add_access(init_block, "T");
+    auto& assign_tasklet = builder.add_tasklet(init_block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(init_block, zero_const, assign_tasklet, "_in", {});
+    auto init_subset = data_flow::Subset{
+        symbolic::add(symbolic::symbol("j"), symbolic::mul(symbolic::symbol("M"), symbolic::symbol("i")))
+    };
+    builder.add_computational_memlet(init_block, assign_tasklet, "_out", t_init, init_subset, array_2d);
+
+    // Consumer: Map(i2) { Map(j2) { For(k) { T[i2*M+j2] = T[i2*M+j2] + A[...] } } }
+    auto& map2_outer = builder.add_map(
+        root,
+        symbolic::symbol("i2"),
+        symbolic::Lt(symbolic::symbol("i2"), symbolic::symbol("N")),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("i2"), symbolic::integer(1)),
+        schedule
+    );
+    auto& map2_inner = builder.add_map(
+        map2_outer.root(),
+        symbolic::symbol("j2"),
+        symbolic::Lt(symbolic::symbol("j2"), symbolic::symbol("M")),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("j2"), symbolic::integer(1)),
+        schedule
+    );
+    auto& map3_inner = builder.add_map(
+        map2_inner.root(),
+        symbolic::symbol("k"),
+        symbolic::Lt(symbolic::symbol("k"), symbolic::symbol("K")),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("k"), symbolic::integer(1)),
+        ScheduleType_Sequential::create()
+    );
+    auto& eltwise_block = builder.add_block(map3_inner.root());
+    auto t_subset = data_flow::Subset{
+        symbolic::add(symbolic::symbol("j2"), symbolic::mul(symbolic::symbol("M"), symbolic::symbol("i2")))
+    };
+    auto& t_read = builder.add_access(eltwise_block, "T");
+    auto& a_read = builder.add_access(eltwise_block, "A");
+    auto& a_write = builder.add_access(eltwise_block, "A");
+    auto& add_tasklet = builder.add_tasklet(eltwise_block, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+    builder.add_computational_memlet(eltwise_block, t_read, add_tasklet, "_in1", t_subset, array_2d);
+    auto a_subset = data_flow::Subset{symbolic::add(
+        symbolic::symbol("k"),
+        symbolic::
+            add(symbolic::mul(symbolic::symbol("K"), symbolic::symbol("j2")),
+                symbolic::mul(symbolic::symbol("K"), symbolic::mul(symbolic::symbol("M"), symbolic::symbol("i2"))))
+    )};
+    builder.add_computational_memlet(eltwise_block, a_read, add_tasklet, "_in2", a_subset, array_3d);
+    builder.add_computational_memlet(eltwise_block, add_tasklet, "_out", a_write, t_subset, array_2d);
+
+    dump_sdfg(builder.subject(), "0.init");
+
+    analysis::AnalysisManager analysis_manager(builder.subject());
+    transformations::MapFusion transformation(map1_outer, map2_outer);
+
+    EXPECT_TRUE(transformation.can_be_applied(builder, analysis_manager));
+
+    transformation.apply(builder, analysis_manager);
+
+    dump_sdfg(builder.subject(), "1.fused");
 }

--- a/opt/tests/transformations/map_fusion_test.cpp
+++ b/opt/tests/transformations/map_fusion_test.cpp
@@ -3841,11 +3841,7 @@ TEST(MapFusionTest, InitPlusReduction_Rejected) {
     analysis::AnalysisManager analysis_manager(builder.subject());
     transformations::MapFusion transformation(map1_outer, map2_outer);
 
-    EXPECT_TRUE(transformation.can_be_applied(builder, analysis_manager));
-
-    transformation.apply(builder, analysis_manager);
-
-    dump_sdfg(builder.subject(), "1.fused");
+    EXPECT_FALSE(transformation.can_be_applied(builder, analysis_manager));
 }
 
 TEST(MapFusionTest, ConsumerHasMoreDimensions) {

--- a/sdfg/include/sdfg/analysis/loop_analysis.h
+++ b/sdfg/include/sdfg/analysis/loop_analysis.h
@@ -24,7 +24,7 @@ struct DFSLoopComparator {
 
 #define LOOP_INFO_PROPERTIES              \
     X(int, loopnest_index, -1)            \
-    X(size_t, element_id, 0)              \
+    X(sdfg::ElementId, element_id, 0)     \
     X(size_t, num_loops, 0)               \
     X(size_t, num_maps, 0)                \
     X(size_t, num_fors, 0)                \
@@ -33,13 +33,58 @@ struct DFSLoopComparator {
     X(bool, is_perfectly_nested, false)   \
     X(bool, is_perfectly_parallel, false) \
     X(bool, is_elementwise, false)        \
-    X(bool, has_side_effects, false)
+    X(bool, has_side_effects, false)      \
+    X(uint32_t, loop_level, 0)            \
+    X(uint32_t, map_stack_depth, 0)
+
+/// is_perfectly_nested: is the entire loop hierarchy with loop at the top perfectly nested on every level
+/// is_perfectly_parallel: is the entire loop hierarchy with loop at the top perfectly parallel on every level
+
+/// loop_level: nesting level of loop: 0 == outermost loop
+
+/// map_stack_depth: how many layers deep from here (including the loop itself), do we have perfectly parallel & nested
+///   i.e. a value of 3 here, means this loop and the next 2 levels of loops are all maps, all perfectly nested, but no
+///   info on what's below that Mostly relevant in case there are children that are not perfectly parallel or nested,
+///   but some of the parents are
 
 struct LoopInfo {
 #define X(type, name, val) type name = val;
     LOOP_INFO_PROPERTIES
 #undef X
 };
+
+/**
+ * Meant to contain only per-loop data (does not reflect what loops nested inside do / have)
+ * This is a pre-processing step to collect the loop-nest-wide info.
+ * It is a separate struct to not change the previous interface too much or pollute it with confusingly similar data
+ * And to allow for separate allocation in the future
+ */
+struct LocalLoopInfo {
+    /**
+     * Unique ID for each loop, not just loop nests. Numbered in  pre-order DFS (children will always have higher
+     * numbers than their parents)
+     */
+    uint32_t loop_id;
+    /**
+     * ID of the last child. Allows for efficient, transitive is_parent / is_child checks
+     *   `parent.loop_id > child.loop_id && parent.last_child_id >= child.loop_id` => is (transitive) child
+     */
+    uint32_t last_child_id;
+    uint32_t loop_level;
+    bool is_map;
+    bool is_elementwise;
+    /**
+     * The loop contains anything other than a direct child loop. Be it a block, an additional sequence or multiple
+     * loops
+     */
+    bool contains_non_perfectly_nested;
+    /**
+     * The loop contains side-effects directly in its body (does not include anything that happens in child loops)
+     */
+    bool contains_side_effects;
+};
+
+typedef std::pair<LocalLoopInfo, LoopInfo> LoopState;
 
 inline nlohmann::json loop_info_to_json(LoopInfo info) {
     nlohmann::json j = nlohmann::json{
@@ -53,28 +98,61 @@ inline nlohmann::json loop_info_to_json(LoopInfo info) {
         {"is_perfectly_nested", info.is_perfectly_nested},
         {"is_perfectly_parallel", info.is_perfectly_parallel},
         {"is_elementwise", info.is_elementwise},
-        {"has_side_effects", info.has_side_effects}
+        {"has_side_effects", info.has_side_effects},
+        {"loop_level", info.loop_level},
+        {"map_stack_depth", info.map_stack_depth}
     };
     return j;
 }
 
+/**
+ * A perfectly nested, perfectly parallel loop-nest (only maps, 1 map per level, no instructions other then inside the
+ * innermost map) Because you likely want to look at multiple dimensions at once to be more efficient. The stack ends at
+ * the first loop that does not fit the criteria. So there might be further loops inside, but they would then require
+ * more complex logic to handle as one
+ */
+struct MapStack {
+    std::vector<structured_control_flow::ControlFlowNode*> outer_to_inner;
+    /**
+     * There are no more loops nested inside the innermost of the stack
+     */
+    bool innermost_is_leaf;
+};
+
 class LoopAnalysis : public Analysis {
 private:
+    uint32_t next_loop_id_ = 0;
+
     std::vector<structured_control_flow::ControlFlowNode*> loops_;
     std::map<structured_control_flow::ControlFlowNode*, structured_control_flow::ControlFlowNode*, DFSLoopComparator>
         loop_tree_;
+    std::unordered_map<structured_control_flow::ControlFlowNode*, std::vector<structured_control_flow::ControlFlowNode*>>
+        loop_children_;
 
-    std::unordered_map<structured_control_flow::ControlFlowNode*, LoopInfo> loop_infos_;
+    std::unordered_map<structured_control_flow::ControlFlowNode*, LoopState> loop_infos_;
 
-    void run(structured_control_flow::ControlFlowNode& scope, structured_control_flow::ControlFlowNode* parent_loop);
+    /**
+     *
+     * @param info reference to fill
+     * @param loop_level current loop level
+     * @param loop the loop for which this is the info
+     * @param map if the loop is a map, also supply this one
+     * @param while_loop
+     */
+    void init_new_loop_info(
+        LoopState& info,
+        uint32_t loop_level,
+        structured_control_flow::ControlFlowNode* loop,
+        structured_control_flow::Map* map,
+        structured_control_flow::ControlFlowNode* while_loop
+    );
 
-    std::vector<sdfg::structured_control_flow::ControlFlowNode*> children(
-        sdfg::structured_control_flow::ControlFlowNode* node,
-        const std::map<
-            sdfg::structured_control_flow::ControlFlowNode*,
-            sdfg::structured_control_flow::ControlFlowNode*,
-            DFSLoopComparator>& tree
-    ) const;
+    void
+    run(structured_control_flow::ControlFlowNode& scope,
+        structured_control_flow::ControlFlowNode* parent_loop,
+        uint32_t loop_level);
+
+    structured_control_flow::Sequence* get_loop_content_root(structured_control_flow::ControlFlowNode* loop);
 
     std::list<std::vector<sdfg::structured_control_flow::ControlFlowNode*>> loop_tree_paths(
         sdfg::structured_control_flow::ControlFlowNode* loop,
@@ -84,7 +162,7 @@ private:
             DFSLoopComparator>& tree
     ) const;
 
-    void compute_loop_infos(structured_control_flow::ControlFlowNode* loop);
+    LoopState& compute_loop_infos(structured_control_flow::ControlFlowNode* loop);
 
 public:
     LoopAnalysis(StructuredSDFG& sdfg);
@@ -100,24 +178,28 @@ public:
 
     LoopInfo loop_info(structured_control_flow::ControlFlowNode* loop) const;
 
+    const LocalLoopInfo& loop_info_local(structured_control_flow::ControlFlowNode* loop) const;
+
     structured_control_flow::ControlFlowNode* find_loop_by_indvar(const std::string& indvar);
 
     structured_control_flow::ControlFlowNode* parent_loop(structured_control_flow::ControlFlowNode* loop) const;
 
-    const std::vector<structured_control_flow::ControlFlowNode*> outermost_loops() const;
+    const std::vector<structured_control_flow::ControlFlowNode*>& outermost_loops() const;
 
     bool is_outermost_loop(structured_control_flow::ControlFlowNode* loop) const;
 
     const std::vector<structured_control_flow::ControlFlowNode*> outermost_maps() const;
 
-    std::vector<sdfg::structured_control_flow::ControlFlowNode*> children(sdfg::structured_control_flow::ControlFlowNode*
-                                                                              node) const;
+    const std::vector<sdfg::structured_control_flow::ControlFlowNode*>&
+    children(sdfg::structured_control_flow::ControlFlowNode* node) const;
 
     std::list<std::vector<sdfg::structured_control_flow::ControlFlowNode*>>
     loop_tree_paths(sdfg::structured_control_flow::ControlFlowNode* loop) const;
 
     std::unordered_set<sdfg::structured_control_flow::ControlFlowNode*>
     descendants(sdfg::structured_control_flow::ControlFlowNode* loop) const;
+
+    void dump_to_file(std::filesystem::path file) const;
 };
 
 } // namespace analysis

--- a/sdfg/include/sdfg/element.h
+++ b/sdfg/include/sdfg/element.h
@@ -96,4 +96,6 @@ public:
     virtual void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) = 0;
 };
 
+typedef size_t ElementId;
+
 } // namespace sdfg

--- a/sdfg/src/analysis/loop_analysis.cpp
+++ b/sdfg/src/analysis/loop_analysis.cpp
@@ -13,49 +13,145 @@ namespace analysis {
 
 LoopAnalysis::LoopAnalysis(StructuredSDFG& sdfg) : Analysis(sdfg), loops_(), loop_tree_(DFSLoopComparator(&loops_)) {}
 
+void LoopAnalysis::init_new_loop_info(
+    std::pair<LocalLoopInfo, LoopInfo>& info,
+    uint32_t loop_level,
+    structured_control_flow::ControlFlowNode* loop,
+    structured_control_flow::Map* map,
+    structured_control_flow::ControlFlowNode* while_loop
+) {
+    auto is_elementwise = (map != nullptr && map->is_contiguous());
+
+    info.first = {
+        .loop_id = this->next_loop_id_++,
+        .loop_level = loop_level,
+        .is_map = map != nullptr,
+        .is_elementwise = is_elementwise,
+        .contains_non_perfectly_nested = false,
+        .contains_side_effects = false
+    };
+    info.second.element_id = loop->element_id();
+    info.second.is_elementwise = is_elementwise;
+    info.second.has_side_effects = false;
+    info.second.max_depth = 1;
+    info.second.num_loops = 1;
+    info.second.loop_level = loop_level;
+    if (map != nullptr) {
+        info.second.num_maps = 1;
+        info.second.num_fors = 0;
+        info.second.num_whiles = 0;
+    } else if (while_loop != nullptr) {
+        info.second.num_maps = 0;
+        info.second.num_fors = 0;
+        info.second.num_whiles = 1;
+    } else {
+        info.second.num_maps = 0;
+        info.second.num_fors = 1;
+        info.second.num_whiles = 0;
+    }
+}
+
 void LoopAnalysis::
-    run(structured_control_flow::ControlFlowNode& scope, structured_control_flow::ControlFlowNode* parent_loop) {
+    run(structured_control_flow::ControlFlowNode& scope,
+        structured_control_flow::ControlFlowNode* parent_loop,
+        uint32_t loop_level) {
     std::list<structured_control_flow::ControlFlowNode*> queue = {&scope};
+    bool non_perfectly_nested = false;
+    bool side_effects = false;
+
     while (!queue.empty()) {
         auto current = queue.front();
         queue.pop_front();
 
+        structured_control_flow::While* new_while = nullptr;
+        structured_control_flow::Map* new_map = nullptr;
+        structured_control_flow::For* new_for = nullptr;
+        structured_control_flow::ControlFlowNode* new_loop = nullptr;
         // Loop detected
         if (auto while_stmt = dynamic_cast<structured_control_flow::While*>(current)) {
-            this->loops_.push_back(while_stmt);
-            this->loop_tree_[while_stmt] = parent_loop;
-        } else if (auto loop_stmt = dynamic_cast<structured_control_flow::StructuredLoop*>(current)) {
-            this->loops_.push_back(loop_stmt);
-            this->loop_tree_[loop_stmt] = parent_loop;
+            new_loop = while_stmt;
+            new_while = while_stmt;
+        } else if (auto map_stmt = dynamic_cast<structured_control_flow::Map*>(current)) {
+            new_map = map_stmt;
+            new_loop = map_stmt;
+        } else if (auto for_stmt = dynamic_cast<structured_control_flow::For*>(current)) {
+            new_for = for_stmt;
+            new_loop = for_stmt;
         }
 
-        if (dynamic_cast<structured_control_flow::Block*>(current)) {
-            continue;
+        if (new_loop != nullptr) {
+            this->loops_.push_back(new_loop);
+            this->loop_tree_[new_loop] = parent_loop;
+            this->loop_children_[parent_loop].push_back(new_loop);
+            this->loop_children_[new_loop]; // ensure it gets created
+            auto& loop_info = loop_infos_[new_loop];
+            init_new_loop_info(loop_info, loop_level, new_loop, new_map, new_while);
+        }
+
+        if (auto block = dynamic_cast<structured_control_flow::Block*>(current)) {
+            non_perfectly_nested = true;
+            for (auto& node : block->dataflow().nodes()) {
+                if (auto library_node = dynamic_cast<data_flow::LibraryNode*>(&node)) {
+                    if (library_node->side_effect()) { // also look at pointer metadata (no capture to not infer
+                                                       // side-effects)
+                        side_effects = true;
+                        break;
+                    }
+                }
+            }
         } else if (auto sequence_stmt = dynamic_cast<structured_control_flow::Sequence*>(current)) {
-            for (size_t i = 0; i < sequence_stmt->size(); i++) {
-                queue.push_back(&sequence_stmt->at(i).first);
+            auto seq_entries = sequence_stmt->size();
+            if (current != &scope) { // the body-root of each loop is expected to be a sequence
+                non_perfectly_nested = true;
+            }
+            for (size_t i = 0; i < seq_entries; i++) {
+                auto entry = sequence_stmt->at(i);
+                if (i > 0 || !entry.second.empty()) {
+                    non_perfectly_nested = true;
+                }
+                queue.push_back(&entry.first);
             }
         } else if (auto if_else_stmt = dynamic_cast<structured_control_flow::IfElse*>(current)) {
+            non_perfectly_nested = true;
             for (size_t i = 0; i < if_else_stmt->size(); i++) {
                 queue.push_back(&if_else_stmt->at(i).first);
             }
         } else if (auto while_stmt = dynamic_cast<structured_control_flow::While*>(current)) {
-            this->run(while_stmt->root(), while_stmt);
+            this->run(while_stmt->root(), while_stmt, loop_level + 1);
         } else if (auto for_stmt = dynamic_cast<structured_control_flow::StructuredLoop*>(current)) {
-            this->run(for_stmt->root(), for_stmt);
+            this->run(for_stmt->root(), for_stmt, loop_level + 1);
         } else if (dynamic_cast<structured_control_flow::Break*>(current)) {
+            non_perfectly_nested = true;
             continue;
         } else if (dynamic_cast<structured_control_flow::Continue*>(current)) {
+            non_perfectly_nested = true;
             continue;
         } else if (dynamic_cast<structured_control_flow::Return*>(current)) {
+            non_perfectly_nested = true;
             continue;
         } else {
             throw std::runtime_error("Unsupported control flow node type");
         }
     }
+
+    if (parent_loop != nullptr) {
+        auto child_count = loop_children_.at(parent_loop).size();
+        auto& state = loop_infos_.at(parent_loop);
+        state.first.last_child_id = this->next_loop_id_ - 1;
+        state.first.contains_side_effects = side_effects;
+
+        if (child_count > 1) {
+            non_perfectly_nested = true;
+        } else if (child_count < 1) {
+            non_perfectly_nested = false;
+        }
+        if (non_perfectly_nested) {
+            state.first.contains_non_perfectly_nested = non_perfectly_nested;
+        }
+    }
 }
 
-void LoopAnalysis::compute_loop_infos(structured_control_flow::ControlFlowNode* loop) {
+structured_control_flow::Sequence* LoopAnalysis::get_loop_content_root(structured_control_flow::ControlFlowNode* loop) {
     structured_control_flow::Sequence* root = nullptr;
     if (auto while_stmt = dynamic_cast<structured_control_flow::While*>(loop)) {
         root = &while_stmt->root();
@@ -64,149 +160,84 @@ void LoopAnalysis::compute_loop_infos(structured_control_flow::ControlFlowNode* 
     } else {
         throw std::runtime_error("Node is not a loop");
     }
+    return root;
+}
 
-    LoopInfo init_info;
-    init_info.element_id = loop->element_id();
-    init_info.loopnest_index = -1;
-    init_info.is_perfectly_nested = true;
-    init_info.is_perfectly_parallel = true;
-    init_info.is_elementwise = (dynamic_cast<structured_control_flow::Map*>(loop) != nullptr);
-    init_info.has_side_effects = false;
-    init_info.max_depth = 1;
-    init_info.num_loops = 1;
-    if (dynamic_cast<structured_control_flow::Map*>(loop)) {
-        init_info.num_maps = 1;
-        init_info.num_fors = 0;
-        init_info.num_whiles = 0;
-    } else if (dynamic_cast<structured_control_flow::StructuredLoop*>(loop)) {
-        init_info.num_maps = 0;
-        init_info.num_fors = 1;
-        init_info.num_whiles = 0;
-    } else if (dynamic_cast<structured_control_flow::While*>(loop)) {
-        init_info.num_maps = 0;
-        init_info.num_fors = 0;
-        init_info.num_whiles = 1;
-    }
-    this->loop_infos_[loop] = init_info;
-
+LoopState& LoopAnalysis::compute_loop_infos(structured_control_flow::ControlFlowNode* loop) {
     // Recursion
-    LoopInfo& info = this->loop_infos_[loop];
-    std::list<structured_control_flow::ControlFlowNode*> queue = {root};
-    while (!queue.empty()) {
-        auto current = queue.front();
-        queue.pop_front();
+    auto& loop_state = this->loop_infos_.at(loop);
+    LoopInfo& info = loop_state.second;
+    auto& loop_children = this->loop_children_.at(loop);
 
-        if (auto block = dynamic_cast<structured_control_flow::Block*>(current)) {
-            for (auto& node : block->dataflow().nodes()) {
-                if (auto library_node = dynamic_cast<data_flow::LibraryNode*>(&node)) {
-                    if (library_node->side_effect()) {
-                        info.has_side_effects = true;
-                        break;
-                    }
-                }
-            }
-        } else if (auto seq = dynamic_cast<structured_control_flow::Sequence*>(current)) {
-            for (size_t i = 0; i < seq->size(); i++) {
-                auto& child = seq->at(i).first;
-                queue.push_back(&child);
-            }
-        } else if (auto ifelse = dynamic_cast<structured_control_flow::IfElse*>(current)) {
-            for (size_t i = 0; i < ifelse->size(); i++) {
-                auto& branch = ifelse->at(i).first;
-                queue.push_back(&branch);
-            }
-        } else if (auto loop_stmt = dynamic_cast<structured_control_flow::StructuredLoop*>(current)) {
-            this->compute_loop_infos(loop_stmt);
+    bool is_perfectly_nested = !loop_state.first.contains_non_perfectly_nested;
+    bool is_perfectly_parallel = loop_state.first.is_map;
+    bool is_elementwise = loop_state.first.is_elementwise;
+    bool map_stack_member = loop_state.first.is_map;
+    bool has_side_effects = loop_state.first.contains_side_effects;
+    bool map_stack_children = map_stack_member && loop_children.size() <= 1;
+    uint32_t map_stack_depth = 0;
 
-            auto& sub_info = this->loop_infos_[loop_stmt];
-            info.num_loops += sub_info.num_loops;
-            info.num_maps += sub_info.num_maps;
-            info.num_fors += sub_info.num_fors;
-            info.num_whiles += sub_info.num_whiles;
-            info.max_depth = std::max(info.max_depth, 1 + sub_info.max_depth);
+    for (auto& child_loop : loop_children) {
+        this->compute_loop_infos(child_loop);
 
-            info.has_side_effects = info.has_side_effects || sub_info.has_side_effects;
-            info.is_elementwise = info.is_elementwise && sub_info.is_elementwise;
-            info.is_perfectly_nested = info.is_perfectly_nested && sub_info.is_perfectly_nested;
-            info.is_perfectly_parallel = info.is_perfectly_parallel && sub_info.is_perfectly_parallel;
-        } else if (auto while_stmt = dynamic_cast<structured_control_flow::While*>(current)) {
-            this->compute_loop_infos(while_stmt);
+        auto& sub_info = this->loop_infos_.at(child_loop).second;
+        info.num_loops += sub_info.num_loops;
+        info.num_maps += sub_info.num_maps;
+        info.num_fors += sub_info.num_fors;
+        info.num_whiles += sub_info.num_whiles;
+        info.max_depth = std::max(info.max_depth, 1 + sub_info.max_depth);
 
-            auto& sub_info = this->loop_infos_[while_stmt];
-            info.num_loops += sub_info.num_loops;
-            info.num_maps += sub_info.num_maps;
-            info.num_fors += sub_info.num_fors;
-            info.num_whiles += sub_info.num_whiles;
-            info.max_depth = std::max(info.max_depth, 1 + sub_info.max_depth);
-
-            info.has_side_effects = info.has_side_effects || sub_info.has_side_effects;
-            info.is_elementwise = info.is_elementwise && sub_info.is_elementwise;
-            info.is_perfectly_nested = info.is_perfectly_nested && sub_info.is_perfectly_nested;
-            info.is_perfectly_parallel = info.is_perfectly_parallel && sub_info.is_perfectly_parallel;
-        } else if (dynamic_cast<structured_control_flow::Break*>(current)) {
-            continue;
-        } else if (dynamic_cast<structured_control_flow::Continue*>(current)) {
-            continue;
-        } else if (dynamic_cast<structured_control_flow::Return*>(current)) {
-            info.has_side_effects = false;
-            continue;
-        } else {
-            throw std::runtime_error("Unsupported control flow node type");
+        has_side_effects |= sub_info.has_side_effects;
+        is_perfectly_nested &= sub_info.is_perfectly_nested;
+        is_perfectly_parallel &= sub_info.is_perfectly_parallel;
+        is_elementwise &= sub_info.is_elementwise;
+        if (map_stack_children) {
+            map_stack_depth = sub_info.map_stack_depth; // only allowed if there is just a single, direct child
         }
     }
 
-    // Perfectly nested
-    if (info.is_perfectly_nested) {
-        if (info.num_loops != info.max_depth) {
-            info.is_perfectly_nested = false;
-        } else {
-            if (info.num_loops == 1) {
-                // Leaf-nodes are by definition perfectly nested
-                info.is_perfectly_nested = true;
-            } else {
-                // Non-leaf loop: body contains next loop
-                info.is_perfectly_nested = (root->size() == 1 && root->at(0).second.empty());
-            }
+    info.is_perfectly_parallel = is_perfectly_parallel;
+    info.is_perfectly_nested = is_perfectly_nested;
+    info.is_elementwise &= is_elementwise && is_perfectly_nested & is_perfectly_parallel;
+    info.has_side_effects = has_side_effects;
+    if (map_stack_member) {
+        if (!is_perfectly_nested) { // needs to be perfectly nested to form a larger stack
+            map_stack_depth = 0;
         }
+        info.map_stack_depth = map_stack_depth + 1;
     }
 
-    // Perfectly parallel if all loops are maps
-    if (info.is_perfectly_parallel) {
-        info.is_perfectly_parallel = (info.num_maps == info.num_loops);
-    }
-
-    // Elementwise: perfectly nested, perfectly parallel, one increment
-    if (info.is_elementwise) {
-        if (info.is_perfectly_nested && info.is_perfectly_parallel) {
-            auto loop_stmt = dynamic_cast<structured_control_flow::Map*>(loop);
-            info.is_elementwise = loop_stmt->is_contiguous();
-        } else {
-            info.is_elementwise = false;
-        }
-    }
+    return loop_state;
 }
 
 void LoopAnalysis::run(AnalysisManager& analysis_manager) {
     this->loops_.clear();
     this->loop_tree_.clear();
     this->loop_infos_.clear();
-    this->run(this->sdfg_.root(), nullptr);
+    this->loop_children_.clear();
+    this->loop_children_[nullptr]; // ensure it exists
+    this->run(this->sdfg_.root(), nullptr, 0);
 
     // Set loopnest indices for outermost loops
     int loopnest_index = 0;
-    for (const auto& [loop, parent] : this->loop_tree_) {
-        if (parent != nullptr) {
-            continue;
+    auto root_it = this->loop_children_.find(nullptr);
+    if (root_it != this->loop_children_.end()) {
+        auto& root_loops = root_it->second;
+        for (auto* root_loop : root_loops) {
+            this->compute_loop_infos(root_loop);
+            this->loop_infos_[root_loop].second.loopnest_index = loopnest_index++;
         }
-        this->compute_loop_infos(loop);
-        this->loop_infos_[loop].loopnest_index = loopnest_index++;
     }
 }
 
 const std::vector<structured_control_flow::ControlFlowNode*> LoopAnalysis::loops() const { return this->loops_; }
 
 LoopInfo LoopAnalysis::loop_info(structured_control_flow::ControlFlowNode* loop) const {
-    return this->loop_infos_.at(loop);
+    return this->loop_infos_.at(loop).second;
+}
+
+const LocalLoopInfo& LoopAnalysis::loop_info_local(structured_control_flow::ControlFlowNode* loop) const {
+    return this->loop_infos_.at(loop).first;
 }
 
 structured_control_flow::ControlFlowNode* LoopAnalysis::find_loop_by_indvar(const std::string& indvar) {
@@ -230,14 +261,8 @@ structured_control_flow::ControlFlowNode* LoopAnalysis::parent_loop(structured_c
     return this->loop_tree_.at(loop);
 }
 
-const std::vector<structured_control_flow::ControlFlowNode*> LoopAnalysis::outermost_loops() const {
-    std::vector<structured_control_flow::ControlFlowNode*> outermost_loops_;
-    for (const auto& [loop, parent] : this->loop_tree_) {
-        if (parent == nullptr) {
-            outermost_loops_.push_back(loop);
-        }
-    }
-    return outermost_loops_;
+const std::vector<structured_control_flow::ControlFlowNode*>& LoopAnalysis::outermost_loops() const {
+    return loop_children_.at(nullptr);
 }
 
 bool LoopAnalysis::is_outermost_loop(structured_control_flow::ControlFlowNode* loop) const {
@@ -267,28 +292,11 @@ const std::vector<structured_control_flow::ControlFlowNode*> LoopAnalysis::outer
     return outermost_maps_;
 }
 
-std::vector<sdfg::structured_control_flow::ControlFlowNode*> LoopAnalysis::
+const std::vector<sdfg::structured_control_flow::ControlFlowNode*>& LoopAnalysis::
     children(sdfg::structured_control_flow::ControlFlowNode* node) const {
     // Find unique child
-    return this->children(node, this->loop_tree_);
-};
-
-std::vector<sdfg::structured_control_flow::ControlFlowNode*> LoopAnalysis::children(
-    sdfg::structured_control_flow::ControlFlowNode* node,
-    const std::map<
-        sdfg::structured_control_flow::ControlFlowNode*,
-        sdfg::structured_control_flow::ControlFlowNode*,
-        DFSLoopComparator>& tree
-) const {
-    // Find unique child
-    std::vector<sdfg::structured_control_flow::ControlFlowNode*> c;
-    for (auto& entry : tree) {
-        if (entry.second == node) {
-            c.push_back(entry.first);
-        }
-    }
-    return c;
-};
+    return loop_children_.at(node);
+}
 
 std::list<std::vector<sdfg::structured_control_flow::ControlFlowNode*>> LoopAnalysis::
     loop_tree_paths(sdfg::structured_control_flow::ControlFlowNode* loop) const {
@@ -304,7 +312,7 @@ std::list<std::vector<sdfg::structured_control_flow::ControlFlowNode*>> LoopAnal
 ) const {
     // Collect all paths in tree starting from loop recursively (DFS)
     std::list<std::vector<sdfg::structured_control_flow::ControlFlowNode*>> paths;
-    auto children = this->children(loop, tree);
+    auto& children = this->children(loop);
     if (children.empty()) {
         paths.push_back({loop});
         return paths;
@@ -328,7 +336,7 @@ std::unordered_set<sdfg::structured_control_flow::ControlFlowNode*> LoopAnalysis
     while (!queue.empty()) {
         auto current = queue.front();
         queue.pop_front();
-        auto children = this->children(current, this->loop_tree_);
+        auto& children = this->children(current);
         for (auto& child : children) {
             if (desc.find(child) == desc.end()) {
                 desc.insert(child);
@@ -337,6 +345,24 @@ std::unordered_set<sdfg::structured_control_flow::ControlFlowNode*> LoopAnalysis
         }
     }
     return desc;
+}
+
+void LoopAnalysis::dump_to_file(std::filesystem::path file) const {
+    nlohmann::json arr;
+    for (auto& loop : this->loops_) {
+        auto& info = loop_infos_.at(loop);
+
+        arr.push_back(loop_info_to_json(info.second));
+    }
+
+
+    std::filesystem::create_directories(file.parent_path());
+    std::ofstream out(file, std::ofstream::out);
+    if (!out.is_open()) {
+        std::cerr << "Could not open file " << file << " for writing JSON output." << std::endl;
+    }
+    out << arr << std::endl;
+    out.close();
 }
 
 } // namespace analysis

--- a/sdfg/tests/analysis/loop_analysis_info_test.cpp
+++ b/sdfg/tests/analysis/loop_analysis_info_test.cpp
@@ -3,6 +3,7 @@
 #include "sdfg/analysis/loop_analysis.h"
 
 #include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/data_flow/library_nodes/stdlib/malloc.h"
 #include "sdfg/structured_control_flow/structured_loop.h"
 
 using namespace sdfg;
@@ -32,6 +33,8 @@ TEST(LoopAnalysisInfoTest, SingleLoop) {
     EXPECT_EQ(info.max_depth, 1);
     EXPECT_TRUE(info.is_perfectly_nested);
     EXPECT_FALSE(info.is_perfectly_parallel);
+    EXPECT_EQ(info.loop_level, 0);
+    EXPECT_EQ(info.map_stack_depth, 0);
 }
 
 TEST(LoopAnalysisInfoTest, NestedLoops) {
@@ -67,6 +70,8 @@ TEST(LoopAnalysisInfoTest, NestedLoops) {
     EXPECT_TRUE(info_j.is_perfectly_nested);
     EXPECT_FALSE(info_j.is_perfectly_parallel);
     EXPECT_FALSE(info_j.is_elementwise);
+    EXPECT_EQ(info_j.loop_level, 1);
+    EXPECT_EQ(info_j.map_stack_depth, 0);
 
     auto info_i = loop_analysis.loop_info(&loop_i);
     EXPECT_EQ(info_i.num_loops, 2);
@@ -77,6 +82,8 @@ TEST(LoopAnalysisInfoTest, NestedLoops) {
     EXPECT_TRUE(info_i.is_perfectly_nested);
     EXPECT_FALSE(info_i.is_perfectly_parallel);
     EXPECT_FALSE(info_i.is_elementwise);
+    EXPECT_EQ(info_i.loop_level, 0);
+    EXPECT_EQ(info_i.map_stack_depth, 0);
 }
 
 TEST(LoopAnalysisInfoTest, NestedLoopsWithExtraStatement) {
@@ -114,6 +121,8 @@ TEST(LoopAnalysisInfoTest, NestedLoopsWithExtraStatement) {
     EXPECT_TRUE(info_j.is_perfectly_nested);
     EXPECT_FALSE(info_j.is_perfectly_parallel);
     EXPECT_FALSE(info_j.is_elementwise);
+    EXPECT_EQ(info_j.loop_level, 1);
+    EXPECT_EQ(info_j.map_stack_depth, 0);
 
     auto info_i = loop_analysis.loop_info(&loop_i);
     EXPECT_EQ(info_i.num_loops, 2);
@@ -124,6 +133,8 @@ TEST(LoopAnalysisInfoTest, NestedLoopsWithExtraStatement) {
     EXPECT_FALSE(info_i.is_perfectly_nested);
     EXPECT_FALSE(info_i.is_perfectly_parallel);
     EXPECT_FALSE(info_i.is_elementwise);
+    EXPECT_EQ(info_i.loop_level, 0);
+    EXPECT_EQ(info_i.map_stack_depth, 0);
 }
 
 TEST(LoopAnalysisInfoTest, NestedLoopsWithInnerSequence) {
@@ -200,6 +211,8 @@ TEST(LoopAnalysisInfoTest, PerfectlyParallel) {
     EXPECT_TRUE(info.is_perfectly_nested);
     EXPECT_TRUE(info.is_perfectly_parallel);
     EXPECT_TRUE(info.is_elementwise);
+    EXPECT_EQ(info.loop_level, 0);
+    EXPECT_EQ(info.map_stack_depth, 1);
 }
 
 TEST(LoopAnalysisInfoTest, ElementWise) {
@@ -315,12 +328,15 @@ TEST(LoopAnalysisInfoTest, NotPerfectlyParallel_MapFor) {
     analysis::AnalysisManager manager(sdfg);
     auto& loop_analysis = manager.get<analysis::LoopAnalysis>();
 
-    auto info = loop_analysis.loop_info(&loop_map);
-    EXPECT_EQ(info.num_loops, 2);
-    EXPECT_EQ(info.num_maps, 1);
-    EXPECT_EQ(info.num_fors, 1);
-    EXPECT_FALSE(info.is_perfectly_parallel);
-    EXPECT_FALSE(info.is_elementwise);
+    auto info_map = loop_analysis.loop_info(&loop_map);
+    EXPECT_EQ(info_map.num_loops, 2);
+    EXPECT_EQ(info_map.num_maps, 1);
+    EXPECT_EQ(info_map.num_fors, 1);
+    EXPECT_FALSE(info_map.is_perfectly_parallel);
+    EXPECT_FALSE(info_map.is_elementwise);
+    EXPECT_EQ(info_map.map_stack_depth, 1);
+    EXPECT_EQ(info_map.loop_level, 0);
+    EXPECT_EQ(info_map.map_stack_depth, 1);
 }
 
 TEST(LoopAnalysisInfoTest, NotElementWise_NotPerfectlyNested) {
@@ -356,7 +372,132 @@ TEST(LoopAnalysisInfoTest, NotElementWise_NotPerfectlyNested) {
     auto info = loop_analysis.loop_info(&loop_map_outer);
     EXPECT_FALSE(info.is_perfectly_nested);
     EXPECT_FALSE(info.is_elementwise);
+    EXPECT_EQ(info.loop_level, 0);
+    EXPECT_EQ(info.map_stack_depth, 1);
+
+    auto info_inner = loop_analysis.loop_info(&loop_map_inner);
+    EXPECT_TRUE(info_inner.is_perfectly_nested);
+    EXPECT_EQ(info_inner.loop_level, 1);
+    EXPECT_EQ(info_inner.map_stack_depth, 1);
 }
+
+TEST(LoopAnalysisInfoTest, MapStack2_of_3) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    builder.add_container("i", types::Scalar(types::PrimitiveType::Int32));
+    builder.add_container("j", types::Scalar(types::PrimitiveType::Int32));
+    builder.add_container("k", types::Scalar(types::PrimitiveType::Int32));
+    builder.add_container("N", types::Scalar(types::PrimitiveType::Int32));
+
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    // Outer Map
+    auto indvar_i = symbolic::symbol("i");
+    auto update_i = symbolic::add(indvar_i, symbolic::one());
+    auto condition_i = symbolic::Lt(indvar_i, symbolic::symbol("N"));
+    auto init_i = symbolic::zero();
+    auto schedule = structured_control_flow::ScheduleType_Sequential::create();
+    auto& loop_map_outer = builder.add_map(root, indvar_i, condition_i, init_i, update_i, schedule);
+
+    // Middle Map
+    auto indvar_j = symbolic::symbol("j");
+    auto update_j = symbolic::add(indvar_j, symbolic::one());
+    auto condition_j = symbolic::Lt(indvar_j, symbolic::symbol("N"));
+    auto init_j = symbolic::zero();
+    auto& loop_map_middle = builder.add_map(loop_map_outer.root(), indvar_j, condition_j, init_j, update_j, schedule);
+
+    // Inner For
+    auto indvar_k = symbolic::symbol("k");
+    auto update_k = symbolic::add(indvar_k, symbolic::one());
+    auto condition_k = symbolic::Lt(indvar_k, symbolic::symbol("N"));
+    auto init_k = symbolic::zero();
+    auto& loop_for_inner = builder.add_for(loop_map_middle.root(), indvar_k, condition_k, init_k, update_k);
+
+    analysis::AnalysisManager manager(sdfg);
+    auto& loop_analysis = manager.get<analysis::LoopAnalysis>();
+
+    auto info_outer = loop_analysis.loop_info(&loop_map_outer);
+    EXPECT_FALSE(info_outer.is_perfectly_parallel);
+    EXPECT_TRUE(info_outer.is_perfectly_nested);
+    EXPECT_FALSE(info_outer.is_elementwise);
+    EXPECT_EQ(info_outer.loop_level, 0);
+    EXPECT_EQ(info_outer.map_stack_depth, 2);
+
+    auto info_middle = loop_analysis.loop_info(&loop_map_middle);
+    EXPECT_FALSE(info_middle.is_perfectly_parallel);
+    EXPECT_TRUE(info_middle.is_perfectly_nested);
+    EXPECT_FALSE(info_middle.is_elementwise);
+    EXPECT_EQ(info_middle.loop_level, 1);
+    EXPECT_EQ(info_middle.map_stack_depth, 1);
+
+    auto info_inner = loop_analysis.loop_info(&loop_for_inner);
+    EXPECT_FALSE(info_inner.is_perfectly_parallel);
+    EXPECT_TRUE(info_inner.is_perfectly_nested);
+    EXPECT_FALSE(info_inner.is_elementwise);
+    EXPECT_EQ(info_inner.loop_level, 2);
+    EXPECT_EQ(info_inner.map_stack_depth, 0);
+}
+
+TEST(LoopAnalysisInfoTest, SideEffectsInherited) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    builder.add_container("i", types::Scalar(types::PrimitiveType::Int32));
+    builder.add_container("j", types::Scalar(types::PrimitiveType::Int32));
+    builder.add_container("k", types::Scalar(types::PrimitiveType::Int32));
+    builder.add_container("N", types::Scalar(types::PrimitiveType::Int32));
+    types::Scalar scalar_type(types::PrimitiveType::Int32);
+    types::Pointer ptr_type(scalar_type);
+    builder.add_container("ptr", ptr_type);
+
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    // Outer Map
+    auto indvar_i = symbolic::symbol("i");
+    auto update_i = symbolic::add(indvar_i, symbolic::one());
+    auto condition_i = symbolic::Lt(indvar_i, symbolic::symbol("N"));
+    auto init_i = symbolic::zero();
+    auto schedule = structured_control_flow::ScheduleType_Sequential::create();
+    auto& loop_map_outer = builder.add_map(root, indvar_i, condition_i, init_i, update_i, schedule);
+
+    // Middle Map
+    auto indvar_j = symbolic::symbol("j");
+    auto update_j = symbolic::add(indvar_j, symbolic::one());
+    auto condition_j = symbolic::Lt(indvar_j, symbolic::symbol("N"));
+    auto init_j = symbolic::zero();
+    auto& loop_map_middle = builder.add_map(loop_map_outer.root(), indvar_j, condition_j, init_j, update_j, schedule);
+
+    // Inner For
+    auto indvar_k = symbolic::symbol("k");
+    auto update_k = symbolic::add(indvar_k, symbolic::one());
+    auto condition_k = symbolic::Lt(indvar_k, symbolic::symbol("N"));
+    auto init_k = symbolic::zero();
+    auto& loop_map_inner = builder.add_map(loop_map_middle.root(), indvar_k, condition_k, init_k, update_k, schedule);
+
+    auto& inner_block = builder.add_block(loop_map_inner.root());
+    auto& ptr_acc = builder.add_access(inner_block, "ptr");
+    auto& ptr_malloc = builder.add_library_node<stdlib::MallocNode>(inner_block, {}, symbolic::symbol("N"));
+    builder.add_computational_memlet(inner_block, ptr_malloc, "_ret", ptr_acc, {}, ptr_type);
+    EXPECT_TRUE(ptr_malloc.side_effect());
+
+    analysis::AnalysisManager manager(sdfg);
+    auto& loop_analysis = manager.get<analysis::LoopAnalysis>();
+
+    auto info_inner = loop_analysis.loop_info(&loop_map_inner);
+    auto info2_inner = loop_analysis.loop_info_local(&loop_map_inner);
+    EXPECT_TRUE(info2_inner.contains_side_effects);
+    EXPECT_TRUE(info_inner.has_side_effects);
+
+    auto info_middle = loop_analysis.loop_info(&loop_map_middle);
+    auto info2_middle = loop_analysis.loop_info_local(&loop_map_middle);
+    EXPECT_FALSE(info2_middle.contains_side_effects);
+    EXPECT_TRUE(info_middle.has_side_effects);
+
+    auto info_outer = loop_analysis.loop_info(&loop_map_outer);
+    auto info2_outer = loop_analysis.loop_info_local(&loop_map_outer);
+    EXPECT_FALSE(info2_outer.contains_side_effects);
+    EXPECT_TRUE(info_outer.has_side_effects);
+}
+
 
 TEST(LoopAnalysisInfoTest, WhileLoop) {
     builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
@@ -373,6 +514,8 @@ TEST(LoopAnalysisInfoTest, WhileLoop) {
     EXPECT_EQ(info.num_whiles, 1);
     EXPECT_FALSE(info.is_perfectly_parallel);
     EXPECT_FALSE(info.is_elementwise);
+    EXPECT_EQ(info.loop_level, 0);
+    EXPECT_EQ(info.map_stack_depth, 0);
 }
 
 TEST(LoopAnalysisInfoTest, LoopInfoSerialization) {


### PR DESCRIPTION
Reworked LoopAnalysis to cache more data, including loop-children to make analysis more efficient and also expose previously hidden data about partially perfect loop nests (some levels are perfectly parallel and nested, but still contain inner loops that are not).

Preparation to die MapFusion by iteration domain for partial loop hierarchies (Example outer 2maps match by iteration domain, but innermost is for. Can fuse outer 2 loops, leave innermost loops sequential for later processing).