### PR TITLE
Fix cuda rpc

### DIFF
--- a/opt/src/passes/scheduler/loop_scheduling_pass.cpp
+++ b/opt/src/passes/scheduler/loop_scheduling_pass.cpp
@@ -39,19 +39,23 @@ bool LoopSchedulingPass::run_pass_target(
     }
 
     // Filter by compatible types
-    for (int i = 0; i < queue.size(); i++) {
+    size_t num_to_check = queue.size();
+    for (size_t i = 0; i < num_to_check; i++) {
         auto loop = queue.front();
         queue.pop_front();
 
-        auto descendants = loop_analysis.descendants(loop);
-
         bool found_incompatible = false;
-        for (auto descendant : descendants) {
-            if (auto map_node = dynamic_cast<structured_control_flow::Map*>(descendant)) {
-                auto compatible_schedules = scheduler->compatible_types();
-                if (compatible_schedules.find(map_node->schedule_type().category()) == compatible_schedules.end()) {
-                    found_incompatible = true;
-                    break;
+
+        // Check descendants
+        if (!found_incompatible) {
+            auto descendants = loop_analysis.descendants(loop);
+            for (auto descendant : descendants) {
+                if (auto map_node = dynamic_cast<structured_control_flow::Map*>(descendant)) {
+                    auto compatible_schedules = scheduler->compatible_types();
+                    if (compatible_schedules.find(map_node->schedule_type().category()) == compatible_schedules.end()) {
+                        found_incompatible = true;
+                        break;
+                    }
                 }
             }
         }

--- a/opt/src/passes/scheduler/loop_scheduling_pass.cpp
+++ b/opt/src/passes/scheduler/loop_scheduling_pass.cpp
@@ -149,6 +149,9 @@ bool LoopSchedulingPass::run_pass(builder::StructuredSDFGBuilder& builder, analy
     bool applied = false;
     for (const auto& target : targets_) {
         bool target_applied = run_pass_target(builder, analysis_manager, target);
+        if (target_applied) {
+            analysis_manager.invalidate_all();
+        }
         applied = applied || target_applied;
     }
 

--- a/opt/tests/passes/scheduler/cuda_scheduler_test.cpp
+++ b/opt/tests/passes/scheduler/cuda_scheduler_test.cpp
@@ -1,5 +1,7 @@
 #include "sdfg/passes/scheduler/cuda_scheduler.h"
 
+#include "sdfg/analysis/loop_analysis.h"
+#include "sdfg/deepcopy/structured_sdfg_deep_copy.h"
 #include "sdfg/passes/scheduler/loop_scheduling_pass.h"
 #include "sdfg/passes/scheduler/scheduler_registry.h"
 #include "sdfg/structured_control_flow/map.h"
@@ -226,4 +228,310 @@ TEST(CUDASchedulerTest, OuterWhileWithInnerMaps) {
 
     EXPECT_EQ(loop_2.schedule_type().value(), cuda::ScheduleType_CUDA::value());
     EXPECT_EQ(loop_3.schedule_type().value(), cuda::ScheduleType_CUDA::value());
+}
+
+// Regression test: When multiple outermost maps exist and some are already
+// CUDA-scheduled, the compatibility filter must skip ALL of them.
+TEST(CUDASchedulerTest, NoDoubleSchedulingOfAlreadyCUDAMaps) {
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc_2(base_desc);
+
+    types::Pointer opaque_desc;
+    builder.add_container("A", opaque_desc, true);
+    builder.add_container("N", sym_desc, true);
+
+    // Create 5 outermost maps: map_a through map_e
+    // Maps b and d are pre-scheduled as CUDA to simulate prior RPC results
+
+    auto make_map = [&](const std::string& indvar_name,
+                        structured_control_flow::ScheduleType schedule_type) -> structured_control_flow::Map& {
+        builder.add_container(indvar_name, sym_desc);
+        auto indvar = symbolic::symbol(indvar_name);
+        auto& map = builder.add_map(
+            root,
+            indvar,
+            symbolic::Lt(indvar, symbolic::symbol("N")),
+            symbolic::integer(0),
+            symbolic::add(indvar, symbolic::integer(1)),
+            schedule_type
+        );
+        auto& body = map.root();
+        auto& block = builder.add_block(body);
+        auto& a_in = builder.add_access(block, "A");
+        auto& a_out = builder.add_access(block, "A");
+        auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+        builder.add_computational_memlet(block, a_in, tasklet, "_in", {indvar}, desc_2);
+        builder.add_computational_memlet(block, tasklet, "_out", a_out, {indvar}, desc_2);
+        return map;
+    };
+
+    auto& map_a = make_map("a", structured_control_flow::ScheduleType_Sequential::create());
+    auto& map_b = make_map("b", cuda::ScheduleType_CUDA::create());
+    auto& map_c = make_map("c", structured_control_flow::ScheduleType_Sequential::create());
+    auto& map_d = make_map("d", cuda::ScheduleType_CUDA::create());
+    auto& map_e = make_map("e", structured_control_flow::ScheduleType_Sequential::create());
+
+    // Verify preconditions
+    EXPECT_EQ(map_a.schedule_type().category(), structured_control_flow::ScheduleTypeCategory::None);
+    EXPECT_EQ(map_b.schedule_type().category(), structured_control_flow::ScheduleTypeCategory::Offloader);
+    EXPECT_EQ(map_c.schedule_type().category(), structured_control_flow::ScheduleTypeCategory::None);
+    EXPECT_EQ(map_d.schedule_type().category(), structured_control_flow::ScheduleTypeCategory::Offloader);
+    EXPECT_EQ(map_e.schedule_type().category(), structured_control_flow::ScheduleTypeCategory::None);
+
+    analysis::AnalysisManager analysis_manager(builder.subject());
+
+    passes::scheduler::LoopSchedulingPass loop_scheduling_pass({"cuda"}, nullptr);
+    EXPECT_TRUE(loop_scheduling_pass.run(builder, analysis_manager));
+
+    // Maps a, c, e should now be CUDA-scheduled
+    EXPECT_EQ(map_a.schedule_type().value(), cuda::ScheduleType_CUDA::value());
+    EXPECT_EQ(map_c.schedule_type().value(), cuda::ScheduleType_CUDA::value());
+    EXPECT_EQ(map_e.schedule_type().value(), cuda::ScheduleType_CUDA::value());
+
+    // Maps b, d must still have exactly the CUDA schedule type — NOT double-offloaded.
+    // With the old bug, maps b and d would pass through the compatibility filter
+    // (because queue.size() shrank when earlier maps were removed) and get a second
+    // CUDATransform applied, resulting in nested offloading (cudaMemcpy of device ptrs).
+    EXPECT_EQ(map_b.schedule_type().value(), cuda::ScheduleType_CUDA::value());
+    EXPECT_EQ(map_d.schedule_type().value(), cuda::ScheduleType_CUDA::value());
+
+    // Verify no containers with double-prefixed device names exist
+    // (e.g. __daisy_cuda_0___daisy_cuda_821__ would indicate double-offloading)
+    for (auto& container : builder.subject().containers()) {
+        std::string name = container;
+        size_t first = name.find("__daisy_cuda_");
+        if (first != std::string::npos) {
+            size_t second = name.find("__daisy_cuda_", first + 1);
+            EXPECT_EQ(second, std::string::npos)
+                << "Container " << name << " has double CUDA prefix, indicating double-offloading";
+        }
+    }
+}
+
+// Regression test: When running the CUDA scheduler after another scheduler
+// has already CUDA-scheduled some maps, the analysis must reflect the updated
+// schedule types. This simulates the {"rpc", "cuda"} pipeline.
+TEST(CUDASchedulerTest, MultipleTargetsNoDoubleScheduling) {
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc_2(base_desc);
+
+    types::Pointer opaque_desc;
+    builder.add_container("A", opaque_desc, true);
+    builder.add_container("N", sym_desc, true);
+    builder.add_container("i", sym_desc);
+    builder.add_container("j", sym_desc);
+
+    // Create two outermost maps
+    auto& map_1 = builder.add_map(
+        root,
+        symbolic::symbol("i"),
+        symbolic::Lt(symbolic::symbol("i"), symbolic::symbol("N")),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("i"), symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+    {
+        auto& body = map_1.root();
+        auto& block = builder.add_block(body);
+        auto& a_in = builder.add_access(block, "A");
+        auto& a_out = builder.add_access(block, "A");
+        auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+        builder.add_computational_memlet(block, a_in, tasklet, "_in", {symbolic::symbol("i")}, desc_2);
+        builder.add_computational_memlet(block, tasklet, "_out", a_out, {symbolic::symbol("i")}, desc_2);
+    }
+
+    auto& map_2 = builder.add_map(
+        root,
+        symbolic::symbol("j"),
+        symbolic::Lt(symbolic::symbol("j"), symbolic::symbol("N")),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("j"), symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+    {
+        auto& body = map_2.root();
+        auto& block = builder.add_block(body);
+        auto& a_in = builder.add_access(block, "A");
+        auto& a_out = builder.add_access(block, "A");
+        auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+        builder.add_computational_memlet(block, a_in, tasklet, "_in", {symbolic::symbol("j")}, desc_2);
+        builder.add_computational_memlet(block, tasklet, "_out", a_out, {symbolic::symbol("j")}, desc_2);
+    }
+
+    // Manually set map_1 to CUDA to simulate what the first target (rpc) would do
+    builder.update_schedule_type(map_1, cuda::ScheduleType_CUDA::create());
+
+    EXPECT_EQ(map_1.schedule_type().value(), cuda::ScheduleType_CUDA::value());
+    EXPECT_EQ(map_2.schedule_type().value(), "SEQUENTIAL");
+
+    // Run CUDA scheduler — it must see map_1 is already CUDA and skip it
+    analysis::AnalysisManager analysis_manager(builder.subject());
+    passes::scheduler::LoopSchedulingPass loop_scheduling_pass({"cuda"}, nullptr);
+    EXPECT_TRUE(loop_scheduling_pass.run(builder, analysis_manager));
+
+    // map_2 should now be CUDA
+    EXPECT_EQ(map_2.schedule_type().value(), cuda::ScheduleType_CUDA::value());
+
+    // map_1 should still be CUDA (not double-offloaded)
+    EXPECT_EQ(map_1.schedule_type().value(), cuda::ScheduleType_CUDA::value());
+
+    // No double CUDA prefixes in containers
+    for (auto& container : builder.subject().containers()) {
+        std::string name = container;
+        size_t first = name.find("__daisy_cuda_");
+        if (first != std::string::npos) {
+            size_t second = name.find("__daisy_cuda_", first + 1);
+            EXPECT_EQ(second, std::string::npos)
+                << "Container " << name << " has double CUDA prefix, indicating double-offloading";
+        }
+    }
+}
+
+// Regression test: CUDA scheduler must not double-schedule maps that are already
+// CUDA-scheduled (e.g. after RPC scheduling applied CUDATransform).
+TEST(CUDASchedulerTest, NoDoubleSchedulingOfCUDAMaps) {
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc_2(base_desc);
+
+    types::Pointer opaque_desc;
+    builder.add_container("A", opaque_desc, true);
+    builder.add_container("B", opaque_desc, true);
+    builder.add_container("N", sym_desc, true);
+    builder.add_container("i", sym_desc);
+    builder.add_container("j", sym_desc);
+    builder.add_container("k", sym_desc);
+    builder.add_container("l", sym_desc);
+    builder.add_container("m", sym_desc);
+
+    auto bound = symbolic::symbol("N");
+
+    // Create 5 outermost maps: first 3 are already CUDA-scheduled, last 2 are sequential.
+    // This pattern mimics RPC scheduling 3 maps then CUDA scheduler seeing all 5.
+
+    // Map 1 (CUDA)
+    auto& map1 = builder.add_map(
+        root,
+        symbolic::symbol("i"),
+        symbolic::Lt(symbolic::symbol("i"), bound),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("i"), symbolic::integer(1)),
+        cuda::ScheduleType_CUDA::create()
+    );
+    {
+        auto& body = map1.root();
+        auto& block = builder.add_block(body);
+        auto& a_in = builder.add_access(block, "A");
+        auto& a_out = builder.add_access(block, "A");
+        auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+        builder.add_computational_memlet(block, a_in, tasklet, "_in", {symbolic::symbol("i")}, desc_2);
+        builder.add_computational_memlet(block, tasklet, "_out", a_out, {symbolic::symbol("i")}, desc_2);
+    }
+
+    // Map 2 (CUDA)
+    auto& map2 = builder.add_map(
+        root,
+        symbolic::symbol("j"),
+        symbolic::Lt(symbolic::symbol("j"), bound),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("j"), symbolic::integer(1)),
+        cuda::ScheduleType_CUDA::create()
+    );
+    {
+        auto& body = map2.root();
+        auto& block = builder.add_block(body);
+        auto& a_in = builder.add_access(block, "A");
+        auto& a_out = builder.add_access(block, "A");
+        auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+        builder.add_computational_memlet(block, a_in, tasklet, "_in", {symbolic::symbol("j")}, desc_2);
+        builder.add_computational_memlet(block, tasklet, "_out", a_out, {symbolic::symbol("j")}, desc_2);
+    }
+
+    // Map 3 (CUDA)
+    auto& map3 = builder.add_map(
+        root,
+        symbolic::symbol("k"),
+        symbolic::Lt(symbolic::symbol("k"), bound),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("k"), symbolic::integer(1)),
+        cuda::ScheduleType_CUDA::create()
+    );
+    {
+        auto& body = map3.root();
+        auto& block = builder.add_block(body);
+        auto& a_in = builder.add_access(block, "A");
+        auto& a_out = builder.add_access(block, "A");
+        auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+        builder.add_computational_memlet(block, a_in, tasklet, "_in", {symbolic::symbol("k")}, desc_2);
+        builder.add_computational_memlet(block, tasklet, "_out", a_out, {symbolic::symbol("k")}, desc_2);
+    }
+
+    // Map 4 (Sequential - should be scheduled by CUDA)
+    auto& map4 = builder.add_map(
+        root,
+        symbolic::symbol("l"),
+        symbolic::Lt(symbolic::symbol("l"), bound),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("l"), symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+    {
+        auto& body = map4.root();
+        auto& block = builder.add_block(body);
+        auto& b_in = builder.add_access(block, "B");
+        auto& b_out = builder.add_access(block, "B");
+        auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+        builder.add_computational_memlet(block, b_in, tasklet, "_in", {symbolic::symbol("l")}, desc_2);
+        builder.add_computational_memlet(block, tasklet, "_out", b_out, {symbolic::symbol("l")}, desc_2);
+    }
+
+    // Map 5 (Sequential - should be scheduled by CUDA)
+    auto& map5 = builder.add_map(
+        root,
+        symbolic::symbol("m"),
+        symbolic::Lt(symbolic::symbol("m"), bound),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("m"), symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+    {
+        auto& body = map5.root();
+        auto& block = builder.add_block(body);
+        auto& b_in = builder.add_access(block, "B");
+        auto& b_out = builder.add_access(block, "B");
+        auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+        builder.add_computational_memlet(block, b_in, tasklet, "_in", {symbolic::symbol("m")}, desc_2);
+        builder.add_computational_memlet(block, tasklet, "_out", b_out, {symbolic::symbol("m")}, desc_2);
+    }
+
+    analysis::AnalysisManager analysis_manager(builder.subject());
+    passes::scheduler::LoopSchedulingPass loop_scheduling_pass({"cuda"}, nullptr);
+
+    EXPECT_TRUE(loop_scheduling_pass.run(builder, analysis_manager));
+
+    // Maps 1-3 should remain CUDA (not double-scheduled)
+    EXPECT_EQ(map1.schedule_type().value(), cuda::ScheduleType_CUDA::value());
+    EXPECT_EQ(map2.schedule_type().value(), cuda::ScheduleType_CUDA::value());
+    EXPECT_EQ(map3.schedule_type().value(), cuda::ScheduleType_CUDA::value());
+
+    // Maps 4-5 should now be CUDA-scheduled
+    EXPECT_EQ(map4.schedule_type().value(), cuda::ScheduleType_CUDA::value());
+    EXPECT_EQ(map5.schedule_type().value(), cuda::ScheduleType_CUDA::value());
 }

--- a/rpc/src/transformations/rpc_node_transform.cpp
+++ b/rpc/src/transformations/rpc_node_transform.cpp
@@ -225,8 +225,9 @@ void RPCNodeTransform::
 
         // TODO: add transitions from after loop to tmp_scope
 
-        builder.remove_child(*parent_scope, index); // remove old loop
-        builder.move_child(opt.sdfg_result->sdfg->root(), 0, *parent_scope, index); // move optimized loop into place
+        auto num_children = opt.sdfg_result->sdfg->root().size();
+        builder.move_children(opt.sdfg_result->sdfg->root(), *parent_scope, index); // move all optimized children into place
+        builder.remove_child(*parent_scope, index + num_children); // remove old loop
 
         if (opt.sdfg_result->sdfg->element_counter() > builder.subject().element_counter()) {
             builder.set_element_counter(opt.sdfg_result->sdfg->element_counter());

--- a/rpc/src/transformations/rpc_node_transform.cpp
+++ b/rpc/src/transformations/rpc_node_transform.cpp
@@ -226,7 +226,8 @@ void RPCNodeTransform::
         // TODO: add transitions from after loop to tmp_scope
 
         auto num_children = opt.sdfg_result->sdfg->root().size();
-        builder.move_children(opt.sdfg_result->sdfg->root(), *parent_scope, index); // move all optimized children into place
+        builder.move_children(opt.sdfg_result->sdfg->root(), *parent_scope, index); // move all optimized children into
+                                                                                    // place
         builder.remove_child(*parent_scope, index + num_children); // remove old loop
 
         if (opt.sdfg_result->sdfg->element_counter() > builder.subject().element_counter()) {

--- a/rpc/src/transformations/rpc_node_transform.cpp
+++ b/rpc/src/transformations/rpc_node_transform.cpp
@@ -260,7 +260,7 @@ void RPCNodeTransform::
     if (opt.local_replay.has_value()) {
         auto recipe = opt.local_replay.value();
         std::cout << "Applied RPC optimization sequence with speedup " << opt.metadata.speedup
-                  << " and vector distance " << opt.metadata.vector_distance << ":\n";
+                  << " and vector distance " << opt.metadata.vector_distance << " to loopnest " << element_id << ":\n";
 
         if (dump_steps_) {
             print_transformation_sequence(recipe.sequence);

--- a/rpc/src/util/utils_curl.cpp
+++ b/rpc/src/util/utils_curl.cpp
@@ -32,7 +32,8 @@ HttpResult post_json(CURL* curl, const std::string& url, const std::string& payl
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &result.http_status);
 
     if (result.http_status == 401) {
-        result.error_message = "[ERROR] RPC optimization query authentication issue: " + std::to_string(result.http_status) + ", body: " + result.body;
+        result.error_message = "[ERROR] RPC optimization query authentication issue: " +
+                               std::to_string(result.http_status) + ", body: " + result.body;
     } else if (result.http_status < 200 || result.http_status >= 204) {
         result.error_message = "HTTP error: " + std::to_string(result.http_status) + ", body: " + result.body;
     }

--- a/rpc/tests/passes/rpc/rpc_loop_opt_test.cpp
+++ b/rpc/tests/passes/rpc/rpc_loop_opt_test.cpp
@@ -8,7 +8,10 @@
 #include "sdfg/deepcopy/structured_sdfg_deep_copy.h"
 #include "sdfg/passes/rpc/rpc_context.h"
 #include "sdfg/passes/scheduler/loop_scheduling_pass.h"
+#include "sdfg/passes/scheduler/scheduler_registry.h"
+#include "sdfg/serializer/json_serializer.h"
 #include "sdfg/structured_control_flow/map.h"
+#include "sdfg/structured_control_flow/sequence.h"
 #include "sdfg/structured_control_flow/structured_loop.h"
 #include "sdfg/structured_sdfg.h"
 #include "sdfg/transformations/loop_interchange.h"
@@ -196,4 +199,185 @@ TEST_F(RPCLoopOptTest, Double_Matmul) {
     EXPECT_EQ(
         test_loop_analysis.find_loop_by_indvar("i_tile0"), loop_nest_tree[test_loop_analysis.find_loop_by_indvar("i")]
     );
+}
+
+// Regression test: When the RPC server returns an optimized SDFG with multiple
+// children in its root (e.g. H2D + CUDA map + D2H), all children must be moved
+// into the parent scope. Previously only child 0 was moved, losing the rest.
+//
+// This test serializes a multi-child response SDFG to disk and points the
+// transfer server at it via SDFG-Result-Path header, then runs
+// LoopSchedulingPass and verifies all children ended up in the target SDFG.
+class RPCLoopOptMoveChildrenTest : public ::testing::Test {
+protected:
+    std::unique_ptr<builder::StructuredSDFGBuilder> builder_;
+    std::string target_key_ = "rpc_move_children";
+
+    void SetUp() override {
+        // Build the input SDFG (same matmul as RPCLoopOptTest)
+        builder_ = std::make_unique<builder::StructuredSDFGBuilder>("sdfg_test", FunctionType_CPU);
+
+        auto& root = builder_->subject().root();
+        types::Scalar base_desc(types::PrimitiveType::Float);
+        types::Array desc_1(base_desc, symbolic::integer(64));
+        types::Pointer desc_2(desc_1);
+
+        builder_->add_container("A", desc_2, true);
+        builder_->add_container("B", desc_2, true);
+        builder_->add_container("C", desc_2, true);
+
+        types::Scalar sym_desc(types::PrimitiveType::UInt64);
+        builder_->add_container("K", sym_desc, true);
+        builder_->add_container("N", sym_desc, true);
+        builder_->add_container("M", sym_desc, true);
+        builder_->add_container("i", sym_desc);
+        builder_->add_container("j", sym_desc);
+        builder_->add_container("k", sym_desc);
+
+        auto& loop = builder_->add_map(
+            root,
+            symbolic::symbol("i"),
+            symbolic::Lt(symbolic::symbol("i"), symbolic::integer(64)),
+            symbolic::integer(0),
+            symbolic::add(symbolic::symbol("i"), symbolic::integer(1)),
+            structured_control_flow::ScheduleType_Sequential::create()
+        );
+        auto& body = loop.root();
+
+        auto& loop_2 = builder_->add_for(
+            body,
+            symbolic::symbol("j"),
+            symbolic::Lt(symbolic::symbol("j"), symbolic::integer(64)),
+            symbolic::integer(0),
+            symbolic::add(symbolic::symbol("j"), symbolic::integer(1))
+        );
+        auto& body_2 = loop_2.root();
+
+        auto& loop_3 = builder_->add_map(
+            body_2,
+            symbolic::symbol("k"),
+            symbolic::Lt(symbolic::symbol("k"), symbolic::integer(64)),
+            symbolic::integer(0),
+            symbolic::add(symbolic::symbol("k"), symbolic::integer(1)),
+            structured_control_flow::ScheduleType_Sequential::create()
+        );
+        auto& body_3 = loop_3.root();
+
+        auto& block = builder_->add_block(body_3);
+        auto& a_in = builder_->add_access(block, "A");
+        auto& b_in = builder_->add_access(block, "B");
+        auto& c_in = builder_->add_access(block, "C");
+        auto& c_out = builder_->add_access(block, "C");
+
+        auto& tasklet = builder_->add_tasklet(block, data_flow::TaskletCode::fp_fma, "_out", {"_in1", "_in2", "_in3"});
+        builder_->add_computational_memlet(block, a_in, tasklet, "_in1", {symbolic::symbol("i"), symbolic::symbol("j")});
+        builder_->add_computational_memlet(block, b_in, tasklet, "_in2", {symbolic::symbol("j"), symbolic::symbol("k")});
+        builder_->add_computational_memlet(block, c_in, tasklet, "_in3", {symbolic::symbol("i"), symbolic::symbol("k")});
+        builder_
+            ->add_computational_memlet(block, tasklet, "_out", c_out, {symbolic::symbol("i"), symbolic::symbol("k")});
+
+        // Build a response SDFG with 3 children in root (simulating H2D + map + D2H)
+        auto response_sdfg = std::make_unique<StructuredSDFG>("response_sdfg", FunctionType_CPU);
+        {
+            builder::StructuredSDFGBuilder resp_builder(*response_sdfg);
+
+            resp_builder.add_container("A", desc_2, true);
+            resp_builder.add_container("B", desc_2, true);
+            resp_builder.add_container("C", desc_2, true);
+            resp_builder.add_container("K", sym_desc, true);
+            resp_builder.add_container("N", sym_desc, true);
+            resp_builder.add_container("M", sym_desc, true);
+            resp_builder.add_container("i", sym_desc);
+            resp_builder.add_container("j", sym_desc);
+            resp_builder.add_container("k", sym_desc);
+
+            auto& resp_root = resp_builder.subject().root();
+
+            // Child 1: simulated H2D block
+            auto& h2d_block = resp_builder.add_block(resp_root);
+            resp_builder.add_access(h2d_block, "A");
+
+            // Child 2: the optimized map (same structure as input)
+            auto& opt_loop = resp_builder.add_map(
+                resp_root,
+                symbolic::symbol("i"),
+                symbolic::Lt(symbolic::symbol("i"), symbolic::integer(64)),
+                symbolic::integer(0),
+                symbolic::add(symbolic::symbol("i"), symbolic::integer(1)),
+                structured_control_flow::ScheduleType_Sequential::create()
+            );
+            {
+                auto& b = opt_loop.root();
+                auto& l2 = resp_builder.add_for(
+                    b,
+                    symbolic::symbol("j"),
+                    symbolic::Lt(symbolic::symbol("j"), symbolic::integer(64)),
+                    symbolic::integer(0),
+                    symbolic::add(symbolic::symbol("j"), symbolic::integer(1))
+                );
+                auto& b2 = l2.root();
+                auto& l3 = resp_builder.add_map(
+                    b2,
+                    symbolic::symbol("k"),
+                    symbolic::Lt(symbolic::symbol("k"), symbolic::integer(64)),
+                    symbolic::integer(0),
+                    symbolic::add(symbolic::symbol("k"), symbolic::integer(1)),
+                    structured_control_flow::ScheduleType_Sequential::create()
+                );
+                auto& b3 = l3.root();
+                auto& blk = resp_builder.add_block(b3);
+                auto& ai = resp_builder.add_access(blk, "A");
+                auto& bi = resp_builder.add_access(blk, "B");
+                auto& ci = resp_builder.add_access(blk, "C");
+                auto& co = resp_builder.add_access(blk, "C");
+                auto& t = resp_builder.add_tasklet(blk, data_flow::TaskletCode::fp_fma, "_out", {"_in1", "_in2", "_in3"});
+                resp_builder.add_computational_memlet(blk, ai, t, "_in1", {symbolic::symbol("i"), symbolic::symbol("j")});
+                resp_builder.add_computational_memlet(blk, bi, t, "_in2", {symbolic::symbol("j"), symbolic::symbol("k")});
+                resp_builder.add_computational_memlet(blk, ci, t, "_in3", {symbolic::symbol("i"), symbolic::symbol("k")});
+                resp_builder.add_computational_memlet(blk, t, "_out", co, {symbolic::symbol("i"), symbolic::symbol("k")});
+            }
+
+            // Child 3: simulated D2H block
+            auto& d2h_block = resp_builder.add_block(resp_root);
+            resp_builder.add_access(d2h_block, "C");
+        }
+
+        // Serialize the response SDFG and set env var for the local transfer server
+        const std::string sdfg_path = "/tmp/rpc_move_children_test.sdfg.json";
+        serializer::JSONSerializer::writeToFile(*response_sdfg, sdfg_path);
+
+        const std::string header_value = "SDFG-Result-Path:" + sdfg_path;
+        setenv("RPC_HEADER", header_value.c_str(), 1);
+
+        // Build RPC context from env vars (same mechanism as test.cpp main)
+        passes::rpc::SimpleRpcContextBuilder ctx_builder;
+        auto test_ctx = ctx_builder
+                            .initialize_local_default()
+                            .from_env()
+                            .from_header_env()
+                            .build();
+
+        // Register scheduler under a test-specific key
+        passes::scheduler::SchedulerRegistry::instance()
+            .register_loop_scheduler<passes::rpc::RPCScheduler>(
+                target_key_, test_ctx, "sequential", "server", false);
+    }
+
+    void TearDown() override {
+        unsetenv("RPC_HEADER");
+    }
+};
+
+TEST_F(RPCLoopOptMoveChildrenTest, MoveAllChildrenFromRPCResult) {
+    ASSERT_EQ(builder_->subject().root().size(), 1); // just the one map
+
+    // Run the scheduling pass through the full pipeline
+    analysis::AnalysisManager analysis_manager(builder_->subject());
+    passes::scheduler::LoopSchedulingPass loop_scheduling_pass({target_key_}, nullptr);
+    loop_scheduling_pass.run(*builder_, analysis_manager);
+
+    // After the pass: the single map should be replaced by all 3 children from the response
+    EXPECT_EQ(builder_->subject().root().size(), 3)
+        << "All children from the RPC response SDFG must be moved into the target. "
+           "With the old bug (move_child instead of move_children), only 1 child would appear.";
 }

--- a/sdfg/src/visualizer/dot_visualizer.cpp
+++ b/sdfg/src/visualizer/dot_visualizer.cpp
@@ -234,7 +234,7 @@ void DotVisualizer::visualizeMap(const StructuredSDFG& sdfg, const structured_co
     if (show_block_ids) {
         this->stream_ << "#" << map_node.element_id() << " ";
     }
-    this->stream_ << "map: ";
+    this->stream_ << "map [" << map_node.schedule_type().value() << "]: ";
     this->visualizeForBounds(map_node.indvar(), map_node.init(), map_node.condition(), map_node.update());
 
     this->stream_ << "\";" << std::endl << id << " [shape=point,style=invis,label=\"\"];" << std::endl;


### PR DESCRIPTION
- Enables receiving multiple scopes in the rpc scheduler
- Ensures loops with a schedule type get skipped by the next loop scheduler
- Adds the schedule_type to Loops in the DotVisualizer

FYI: It is now a problem for testing that the loop registry is a singleton (just as expected). The context should not be set in stone at start-up/ time of registry (which we saw coming). Future work.