### PR TITLE
MapFusionByDomain

### DIFF
--- a/opt/CMakeLists.txt
+++ b/opt/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SOURCE_FILES
     src/passes/gemm_expansion_pass.cpp
     src/passes/map_fusion_by_domain_pass.cpp
     src/passes/opt_pipeline.cpp
+    src/passes/redundant_load_elimination_pass.cpp
     src/passes/scheduler/cuda_scheduler.cpp
     src/passes/scheduler/rocm_scheduler.cpp
     src/passes/scheduler/vectorize_scheduler.cpp

--- a/opt/CMakeLists.txt
+++ b/opt/CMakeLists.txt
@@ -50,7 +50,7 @@ set(SOURCE_FILES
     src/passes/readonly_transfer_hoisting_pass.cpp
     src/passes/dot_expansion_pass.cpp
     src/passes/gemm_expansion_pass.cpp
-    src/passes/new_map_fusion_pass.cpp
+    src/passes/map_fusion_by_domain_pass.cpp
     src/passes/opt_pipeline.cpp
     src/passes/scheduler/cuda_scheduler.cpp
     src/passes/scheduler/rocm_scheduler.cpp

--- a/opt/CMakeLists.txt
+++ b/opt/CMakeLists.txt
@@ -50,6 +50,7 @@ set(SOURCE_FILES
     src/passes/readonly_transfer_hoisting_pass.cpp
     src/passes/dot_expansion_pass.cpp
     src/passes/gemm_expansion_pass.cpp
+    src/passes/new_map_fusion_pass.cpp
     src/passes/opt_pipeline.cpp
     src/passes/scheduler/cuda_scheduler.cpp
     src/passes/scheduler/rocm_scheduler.cpp

--- a/opt/include/sdfg/passes/map_fusion_by_domain_pass.h
+++ b/opt/include/sdfg/passes/map_fusion_by_domain_pass.h
@@ -138,6 +138,7 @@ public:
     struct InOutCheckResult {
         bool no_conflicts;
         bool overlap = false;
+        bool subset_mismatch = false;
     };
 
 protected:

--- a/opt/include/sdfg/passes/map_fusion_by_domain_pass.h
+++ b/opt/include/sdfg/passes/map_fusion_by_domain_pass.h
@@ -48,10 +48,23 @@ struct FusionCandidatePair {
     FusionCandidate* second;
 };
 
+struct FusionArg {
+    analysis::RegionArgument arg;
+    bool not_understood = false;
+    std::optional<data_flow::Subset> subset;
+
+    FusionArg(const analysis::RegionArgument& arg) : arg(arg) {}
+
+    bool saw_access_locally() const;
+};
+
 struct FusionLoopCandidate {
     StructuredLoop* loop;
     const symbolic::Assumption* indvar_boundaries;
-    const std::map<std::string, analysis::RegionArgument>* args;
+    std::unordered_map<std::string, FusionArg> args;
+    bool incompatible = false;
+
+    void non_indvar_writes();
 };
 
 
@@ -77,21 +90,24 @@ public:
 
 class MapFusionByDomainPass : public sdfg::passes::Pass {
     std::vector<FusionCandidatePair> candidate_pairs_;
+    bool dump_infos = false;
 
 public:
     struct State {
         builder::StructuredSDFGBuilder& builder;
         analysis::AnalysisManager& analysis_manager;
         std::unique_ptr<analysis::LoopAnalysis> loop_analysis;
-        std::unordered_map<analysis::ElementId, FusionLoopCandidate> fuse_candidates;
+        std::unordered_map<analysis::ElementId, std::unique_ptr<FusionLoopCandidate>> fuse_candidates;
         uint32_t fused_count = 0;
 
         FusionLoopCandidate* get_next_level_map_stack(FusionLoopCandidate& current);
+
+        FusionLoopCandidate* get_parent(FusionLoopCandidate& current);
     };
 
     MapFusionByDomainPass() = default;
 
-    std::string name() override { return "NewMapFusionPass"; }
+    std::string name() override { return "MapFusionByDomainPass"; }
 
     bool run_pass(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) override;
 
@@ -111,18 +127,34 @@ public:
 
     PatternHandler::MatchResult match(Map& first, Map& second, bool no_uses_between) override;
 
+    struct InOutCheckResult {
+        bool no_conflicts;
+        bool overlap = false;
+    };
+
 protected:
-    bool no_data_conflicts(const FusionLoopCandidate& first_candidate, const FusionLoopCandidate& second_candidate);
+    InOutCheckResult check_ins_outs(
+        const FusionLoopCandidate& first_candidate,
+        const FusionLoopCandidate& second_candidate,
+        symbolic::ExpressionMapping& canonical_indvars
+    );
 
     void update_fused_seq(Sequence& sequence, const symbolic::ExpressionMapping& replacements);
 
     bool loop_match(FusionLoopCandidate& first, FusionLoopCandidate& second, SymEngine::map_basic_basic& canonical_indvars);
 
+    void update_candidate_state(
+        ControlFlowNode* first_top,
+        FusionLoopCandidate* first_current,
+        FusionLoopCandidate* second_current,
+        const symbolic::ExpressionMapping& canonical_indvars
+    );
+
     PatternHandler::MatchResult fuse_contents(
         ControlFlowNode* first_top,
         FusionLoopCandidate* first_innermost,
         FusionLoopCandidate* second_innermost,
-        SymEngine::map_basic_basic indvar_mapping,
+        const symbolic::ExpressionMapping& indvar_mapping,
         Sequence& target_root,
         bool can_remove_original
     );

--- a/opt/include/sdfg/passes/map_fusion_by_domain_pass.h
+++ b/opt/include/sdfg/passes/map_fusion_by_domain_pass.h
@@ -75,9 +75,8 @@ public:
     bool visit(sdfg::structured_control_flow::Sequence& node) override;
 };
 
-class NewMapFusionPass : public sdfg::passes::Pass {
+class MapFusionByDomainPass : public sdfg::passes::Pass {
     std::vector<FusionCandidatePair> candidate_pairs_;
-    size_t fused_count = 0;
 
 public:
     struct State {
@@ -85,11 +84,12 @@ public:
         analysis::AnalysisManager& analysis_manager;
         std::unique_ptr<analysis::LoopAnalysis> loop_analysis;
         std::unordered_map<analysis::ElementId, FusionLoopCandidate> fuse_candidates;
+        uint32_t fused_count = 0;
 
         FusionLoopCandidate* get_next_level_map_stack(FusionLoopCandidate& current);
     };
 
-    NewMapFusionPass() = default;
+    MapFusionByDomainPass() = default;
 
     std::string name() override { return "NewMapFusionPass"; }
 
@@ -104,17 +104,10 @@ protected:
 };
 
 class MapFusionHandler : public PatternHandler {
-    NewMapFusionPass::State& state_;
+    MapFusionByDomainPass::State& state_;
 
 public:
-    MapFusionHandler(NewMapFusionPass::State& state);
-
-    bool fuse_contents(
-        FusionLoopCandidate* first_current,
-        FusionLoopCandidate* second_current,
-        SymEngine::map_basic_basic indvar_mapping,
-        Sequence& target_root
-    );
+    MapFusionHandler(MapFusionByDomainPass::State& state);
 
     PatternHandler::MatchResult match(Map& first, Map& second, bool no_uses_between) override;
 
@@ -124,6 +117,15 @@ protected:
     void update_fused_seq(Sequence& sequence, const symbolic::ExpressionMapping& replacements);
 
     bool loop_match(FusionLoopCandidate& first, FusionLoopCandidate& second, SymEngine::map_basic_basic& canonical_indvars);
+
+    PatternHandler::MatchResult fuse_contents(
+        ControlFlowNode* first_top,
+        FusionLoopCandidate* first_innermost,
+        FusionLoopCandidate* second_innermost,
+        SymEngine::map_basic_basic indvar_mapping,
+        Sequence& target_root,
+        bool can_remove_original
+    );
 };
 
 } // namespace sdfg::passes

--- a/opt/include/sdfg/passes/map_fusion_by_domain_pass.h
+++ b/opt/include/sdfg/passes/map_fusion_by_domain_pass.h
@@ -65,6 +65,8 @@ struct FusionLoopCandidate {
     bool incompatible = false;
 
     void non_indvar_writes();
+
+    void replace(const symbolic::ExpressionMapping& mapping);
 };
 
 
@@ -77,6 +79,9 @@ public:
     };
 
     virtual MatchResult match(Map& map, Map& second, bool no_uses_between) = 0;
+
+    virtual bool
+    check_no_overlap(const Map& map, const Map& second, const std::unordered_set<std::string>& skipped_containers) = 0;
 };
 
 class NeighboringPatternVisitor : public sdfg::visitor::ActualStructuredSDFGVisitor {
@@ -127,6 +132,9 @@ public:
 
     PatternHandler::MatchResult match(Map& first, Map& second, bool no_uses_between) override;
 
+    bool check_no_overlap(const Map& map, const Map& second, const std::unordered_set<std::string>& skipped_containers)
+        override;
+
     struct InOutCheckResult {
         bool no_conflicts;
         bool overlap = false;
@@ -142,6 +150,8 @@ protected:
     void update_fused_seq(Sequence& sequence, const symbolic::ExpressionMapping& replacements);
 
     bool loop_match(FusionLoopCandidate& first, FusionLoopCandidate& second, SymEngine::map_basic_basic& canonical_indvars);
+
+    void update_child_candidate_states(FusionLoopCandidate* top, const symbolic::ExpressionMapping& replace);
 
     void update_candidate_state(
         ControlFlowNode* first_top,

--- a/opt/include/sdfg/passes/new_map_fusion_pass.h
+++ b/opt/include/sdfg/passes/new_map_fusion_pass.h
@@ -1,0 +1,129 @@
+#pragma once
+
+#include "sdfg/analysis/arguments_analysis.h"
+#include "sdfg/analysis/loop_analysis.h"
+#include "sdfg/analysis/structured_data_flow_analysis.h"
+#include "sdfg/passes/pass.h"
+#include "sdfg/visitor/structured_sdfg_visitor.h"
+
+namespace sdfg::passes {
+
+struct FusionCandidate {};
+
+struct FusionContainerRef {
+    FusionCandidate* candidate;
+};
+
+struct MapFusionExposed {
+    /**
+     * Anything not understood fully, like aliasing ptrs etc. will be collected in execution order
+     */
+    std::unordered_map<std::string, std::string> ineligible_containers;
+    /**
+     * Index of the variables involved in fusion_candidates to quickly match them against kill lists
+     */
+    std::unordered_map<std::string, FusionContainerRef> tracked_var_refs;
+    std::unordered_map<analysis::ElementId, std::unique_ptr<FusionCandidate>> fusion_candidates;
+};
+
+class MapFusionState : public analysis::DataFlowState<MapFusionExposed> {
+    bool ran_ = false;
+    MapFusionExposed incoming_;
+    MapFusionExposed forward_exposed_;
+
+public:
+    bool ran_at_least_once() const override { return ran_; }
+
+    bool update(const MapFusionExposed& exposed) override;
+
+    bool update_incoming(const MapFusionExposed& incoming) override;
+
+    bool update_forward_exposed(const MapFusionExposed& forward_exposed) override;
+
+    const MapFusionExposed& forward_exposed() const override { return forward_exposed_; }
+};
+
+struct FusionCandidatePair {
+    FusionCandidate* first;
+    FusionCandidate* second;
+};
+
+struct FusionLoopCandidate {
+    StructuredLoop* loop;
+    const symbolic::Assumption* indvar_boundaries;
+    const std::map<std::string, analysis::RegionArgument>* args;
+};
+
+
+class PatternHandler {
+public:
+    struct MatchResult {
+        bool removed_first = false;
+        bool visit_second_body = false;
+        ControlFlowNode* second_root_replacement = nullptr;
+    };
+
+    virtual MatchResult match(Map& map, Map& second, bool no_uses_between) = 0;
+};
+
+class NeighboringPatternVisitor : public sdfg::visitor::ActualStructuredSDFGVisitor {
+    PatternHandler& handler_;
+
+public:
+    NeighboringPatternVisitor(PatternHandler& handler);
+
+    bool visit(sdfg::structured_control_flow::Sequence& node) override;
+};
+
+class NewMapFusionPass : public sdfg::passes::Pass {
+    std::vector<FusionCandidatePair> candidate_pairs_;
+    size_t fused_count = 0;
+
+public:
+    struct State {
+        builder::StructuredSDFGBuilder& builder;
+        analysis::AnalysisManager& analysis_manager;
+        std::unique_ptr<analysis::LoopAnalysis> loop_analysis;
+        std::unordered_map<analysis::ElementId, FusionLoopCandidate> fuse_candidates;
+
+        FusionLoopCandidate* get_next_level_map_stack(FusionLoopCandidate& current);
+    };
+
+    NewMapFusionPass() = default;
+
+    std::string name() override { return "NewMapFusionPass"; }
+
+    bool run_pass(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) override;
+
+protected:
+    const symbolic::Assumption*
+    find_indvar_boundaries(const symbolic::Symbol& indvar, const symbolic::Assumptions& assumptions);
+
+    // std::unique_ptr<MapFusionState> create_initial_state(const structured_control_flow::ControlFlowNode& node)
+    // override;
+};
+
+class MapFusionHandler : public PatternHandler {
+    NewMapFusionPass::State& state_;
+
+public:
+    MapFusionHandler(NewMapFusionPass::State& state);
+
+    bool fuse_contents(
+        FusionLoopCandidate* first_current,
+        FusionLoopCandidate* second_current,
+        SymEngine::map_basic_basic indvar_mapping,
+        Sequence& target_root
+    );
+
+    PatternHandler::MatchResult match(Map& first, Map& second, bool no_uses_between) override;
+
+protected:
+    bool no_data_conflicts(const FusionLoopCandidate& first_candidate, const FusionLoopCandidate& second_candidate);
+
+    void update_fused_seq(Sequence& sequence, const symbolic::ExpressionMapping& replacements);
+
+    bool loop_match(FusionLoopCandidate& first, FusionLoopCandidate& second, SymEngine::map_basic_basic& canonical_indvars);
+};
+
+} // namespace sdfg::passes

--- a/opt/include/sdfg/passes/redundant_load_elimination_pass.h
+++ b/opt/include/sdfg/passes/redundant_load_elimination_pass.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "sdfg/analysis/arguments_analysis.h"
+#include "sdfg/analysis/loop_analysis.h"
+#include "sdfg/analysis/structured_data_flow_analysis.h"
+#include "sdfg/passes/pass.h"
+#include "sdfg/visitor/structured_sdfg_visitor.h"
+
+namespace sdfg::passes {
+
+
+class RedundantLoadEliminationPass : public sdfg::passes::Pass {
+public:
+    struct State {
+        size_t optimized = 0;
+    };
+
+    std::string name() override { return "MemoryDependency"; }
+
+    bool run_pass(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) override;
+};
+
+class RedundantLoadVisitor : public sdfg::visitor::ActualStructuredSDFGVisitor {
+    builder::StructuredSDFGBuilder& builder_;
+    RedundantLoadEliminationPass::State& state_;
+
+public:
+    RedundantLoadVisitor(builder::StructuredSDFGBuilder& builder, RedundantLoadEliminationPass::State& state);
+
+    bool visit(sdfg::structured_control_flow::Block& block) override;
+};
+
+} // namespace sdfg::passes

--- a/opt/src/passes/map_fusion_by_domain_pass.cpp
+++ b/opt/src/passes/map_fusion_by_domain_pass.cpp
@@ -1,4 +1,4 @@
-#include "sdfg/passes/new_map_fusion_pass.h"
+#include "sdfg/passes/map_fusion_by_domain_pass.h"
 
 #include "sdfg/analysis/assumptions_analysis.h"
 #include "sdfg/data_flow/library_nodes/stdlib/malloc.h"
@@ -8,7 +8,7 @@
 
 namespace sdfg::passes {
 
-FusionLoopCandidate* NewMapFusionPass::State::get_next_level_map_stack(FusionLoopCandidate& current) {
+FusionLoopCandidate* MapFusionByDomainPass::State::get_next_level_map_stack(FusionLoopCandidate& current) {
     auto& children = loop_analysis->children(current.loop);
     if (children.empty()) {
         return nullptr;
@@ -18,9 +18,7 @@ FusionLoopCandidate* NewMapFusionPass::State::get_next_level_map_stack(FusionLoo
     return &fuse_candidates.at(next->element_id());
 }
 
-bool NewMapFusionPass::run_pass(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {
-    fused_count = 0;
-
+bool MapFusionByDomainPass::run_pass(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {
     auto loop_ana = std::make_unique<analysis::LoopAnalysis>(builder.subject());
     loop_ana->run(analysis_manager);
 
@@ -45,15 +43,24 @@ bool NewMapFusionPass::run_pass(builder::StructuredSDFGBuilder& builder, analysi
         }
     }
 
+    auto dir = builder.subject().metadata_if_exists("output_dir");
+    if (dir) {
+        state.loop_analysis->dump_to_file(std::filesystem::path(*dir) / "loop_infos.pre-fusion.json");
+    }
+
     MapFusionHandler handler(state);
 
     NeighboringPatternVisitor v(handler);
     v.dispatch(builder.subject().root());
 
-    return fused_count;
+    if (dir) {
+        state.loop_analysis->dump_to_file(std::filesystem::path(*dir) / "loop_infos.post-fusion.json");
+    }
+
+    return state.fused_count;
 }
 
-const symbolic::Assumption* NewMapFusionPass::
+const symbolic::Assumption* MapFusionByDomainPass::
     find_indvar_boundaries(const symbolic::Symbol& indvar, const symbolic::Assumptions& assumptions) {
     auto it = assumptions.find(indvar);
     if (it != assumptions.end()) {
@@ -63,23 +70,33 @@ const symbolic::Assumption* NewMapFusionPass::
     return nullptr;
 }
 
-MapFusionHandler::MapFusionHandler(NewMapFusionPass::State& state) : state_(state) {}
+MapFusionHandler::MapFusionHandler(MapFusionByDomainPass::State& state) : state_(state) {}
 
-bool MapFusionHandler::fuse_contents(
+PatternHandler::MatchResult MapFusionHandler::fuse_contents(
+    ControlFlowNode* first_top,
     FusionLoopCandidate* first_current,
-    FusionLoopCandidate* second_current,
+    FusionLoopCandidate* second_innermost,
     SymEngine::map_basic_basic indvar_mapping,
-    Sequence& target_root
+    Sequence& target_root,
+    bool can_remove_original
 ) {
     Sequence* append_root = nullptr;
     if (target_root.size() == 0) {
+        // target seq is empty, so we can just append to it
         append_root = &target_root;
-    } else { // there currently is no way to prepend or limit replace, so add to new sequence, then move
+    } else {
+        // there currently is no way to prepend-copy with replace, so add to new sequence,
+        // replace on it, then flatten it into the existing
         append_root = &state_.builder.add_sequence_before(target_root, target_root.at(0).first, {}, {});
     }
 
-    deepcopy::StructuredSDFGDeepCopy copier(state_.builder, *append_root, first_current->loop->root());
-    auto copy_mapping = copier.insert();
+    std::optional<std::unordered_map<const ControlFlowNode*, const ControlFlowNode*>> copy_mapping;
+    if (can_remove_original) {
+        state_.builder.move_children(first_current->loop->root(), *append_root);
+    } else {
+        deepcopy::StructuredSDFGDeepCopy copier(state_.builder, *append_root, first_current->loop->root());
+        copy_mapping = copier.insert();
+    }
 
     update_fused_seq(*append_root, indvar_mapping);
 
@@ -88,18 +105,34 @@ bool MapFusionHandler::fuse_contents(
     }
 
     auto& first_children = state_.loop_analysis->children(first_current->loop);
-    bool keep_visiting_second = !state_.loop_analysis->children(second_current->loop).empty() ||
+    bool keep_visiting_second = !state_.loop_analysis->children(second_innermost->loop).empty() ||
                                 !first_children.empty();
     if (!first_children.empty()) {
-        for (auto& child : first_children) {
-            state_.loop_analysis->copied_loop(
-                child,
-                second_current->loop,
-                const_cast<structured_control_flow::ControlFlowNode*>(copy_mapping.at(child))
-            );
+        if (can_remove_original) {
+            for (auto& child : first_children) {
+                state_.loop_analysis->moved_loop(child, second_innermost->loop);
+            }
+        } else {
+            for (auto& child : first_children) {
+                state_.loop_analysis->copied_loop(
+                    child,
+                    second_innermost->loop,
+                    const_cast<structured_control_flow::ControlFlowNode*>(copy_mapping->at(child))
+                );
+            }
         }
     }
-    return keep_visiting_second;
+    bool removed_first = false;
+    if (can_remove_original) {
+        state_.loop_analysis->removed_loop(first_top);
+        state_.builder.remove_from_parent(*first_top);
+        removed_first = true;
+    }
+
+    state_.fused_count++;
+
+    // if there are further loops inside the now fused body, visit those as well
+    return {.removed_first = removed_first, .visit_second_body = keep_visiting_second};
 }
 
 PatternHandler::MatchResult MapFusionHandler::match(Map& first, Map& second, bool no_uses_between) {
@@ -153,11 +186,7 @@ PatternHandler::MatchResult MapFusionHandler::match(Map& first, Map& second, boo
         );
 
         auto& target_root = second_current->loop->root();
-        bool keep_visiting_second =
-            fuse_contents(first_current, second_current, indvar_mapping, target_root, no_uses_between);
-
-        // if there are further loops inside the now fused body, visit those as well
-        return {.removed_first = false, .visit_second_body = keep_visiting_second};
+        return fuse_contents(&first, first_current, second_current, indvar_mapping, target_root, no_uses_between);
     }
 
     return {};
@@ -232,7 +261,7 @@ bool NeighboringPatternVisitor::visit(sdfg::structured_control_flow::Sequence& n
                 continue;
             }
 
-            auto result = handler_.match(*first, *second, TODO);
+            auto result = handler_.match(*first, *second, true);
 
             if (!result.removed_first) {
                 dispatch(child_node);

--- a/opt/src/passes/map_fusion_by_domain_pass.cpp
+++ b/opt/src/passes/map_fusion_by_domain_pass.cpp
@@ -391,6 +391,11 @@ PatternHandler::MatchResult MapFusionHandler::match(Map& first, Map& second, boo
             if (uneven && !res.overlap) { // heuristic: do not fuse if there is no memory shared between them
                 return {};
             }
+            if (res.subset_mismatch) { // heuristic: if we see the actual accesses having a subset conflict, we abort,
+                                       // instead of trying to fuse outer maps
+                // this also likely prevents some incorrect fusings
+                return {};
+            }
         }
         bool go_deeper = false;
         if (level_match) {
@@ -550,14 +555,14 @@ MapFusionHandler::InOutCheckResult MapFusionHandler::check_ins_outs(
             } else if (prod_meta.arg.is_output && cons_meta.arg.is_input) {
                 overlap = true;
                 if (prod_meta.not_understood || cons_meta.not_understood) {
-                    return {false, overlap};
+                    return {false, overlap, true};
                 }
 
                 if (prod_meta.subset.has_value() && cons_meta.subset.has_value()) {
                     if (!symbolic::vectors_of_expressions_match(
                             prod_meta.subset.value(), cons_meta.subset.value(), canonical_indvars
                         )) {
-                        return {false, overlap};
+                        return {false, overlap, true};
                     }
                 }
             }

--- a/opt/src/passes/map_fusion_by_domain_pass.cpp
+++ b/opt/src/passes/map_fusion_by_domain_pass.cpp
@@ -1,12 +1,128 @@
 #include "sdfg/passes/map_fusion_by_domain_pass.h"
 
 #include "sdfg/analysis/assumptions_analysis.h"
+#include "sdfg/analysis/base_user_visitor.h"
 #include "sdfg/data_flow/library_nodes/stdlib/malloc.h"
 #include "sdfg/deepcopy/structured_sdfg_deep_copy.h"
+#include "sdfg/symbolic/utils.h"
 #include "sdfg/visitor/structured_sdfg_visitor.h"
 #include "symengine/subs.h"
 
 namespace sdfg::passes {
+
+class LoopIndirectAccessFinder : public analysis::BaseUserVisitor {
+    analysis::LoopAnalysis& loop_analysis_;
+    std::unordered_map<analysis::ElementId, std::unique_ptr<FusionLoopCandidate>>& fuse_candidates_;
+    struct LoopEntry {
+        ControlFlowNode* loop;
+        analysis::LocalLoopInfo::LoopType type;
+        std::unordered_set<std::string> indvars;
+    };
+    std::deque<LoopEntry> loop_stack_;
+
+    LoopEntry* get_current_loop() {
+        if (loop_stack_.empty()) {
+            return nullptr;
+        }
+        return &loop_stack_.back();
+    }
+
+public:
+    LoopIndirectAccessFinder(
+        analysis::LoopAnalysis& loops,
+        std::unordered_map<analysis::ElementId, std::unique_ptr<FusionLoopCandidate>>& fuse_candidates
+    )
+        : loop_analysis_(loops), fuse_candidates_(fuse_candidates) {}
+
+    bool visit(sdfg::structured_control_flow::For& node) override {
+        loop_stack_.emplace_back(&node, analysis::LocalLoopInfo::LoopType::For);
+        loop_stack_.back().indvars.emplace(node.indvar()->get_name());
+        auto res = ActualStructuredSDFGVisitor::visit(node);
+        loop_stack_.pop_back();
+        return res;
+    }
+
+    bool visit(sdfg::structured_control_flow::While& node) override {
+        loop_stack_.emplace_back(&node, analysis::LocalLoopInfo::LoopType::For);
+        auto res = ActualStructuredSDFGVisitor::visit(node);
+        loop_stack_.pop_back();
+        return res;
+    }
+
+    bool visit(sdfg::structured_control_flow::Map& node) override {
+        loop_stack_.emplace_back(&node, analysis::LocalLoopInfo::LoopType::For);
+        loop_stack_.back().indvars.emplace(node.indvar()->get_name());
+        auto res = ActualStructuredSDFGVisitor::visit(node);
+        loop_stack_.pop_back();
+        return res;
+    }
+
+    void use_as_symbol_read(
+        const std::string& container,
+        const ControlFlowNode* node,
+        const Element* user,
+        SymbolReadLocation loc,
+        int loc_index,
+        symbolic::Expression expr
+    ) override {}
+
+    void use_as_dst_node(
+        const std::string& container,
+        const data_flow::AccessNode& node,
+        const data_flow::Memlet& edge,
+        const Block& block
+    ) override {
+        auto current = get_current_loop();
+        if (current && edge.is_dst_pointed_to_write()) {
+            auto cand_it = fuse_candidates_.find(current->loop->element_id());
+            if (cand_it != fuse_candidates_.end()) {
+                auto& cand = *cand_it->second;
+                auto arg_it = cand.args.find(container);
+                if (arg_it != cand.args.end()) {
+                    auto& fusion_arg = arg_it->second;
+                    if (fusion_arg.subset.has_value() &&
+                        !symbolic::vectors_of_expressions_match(fusion_arg.subset.value(), edge.subset())) {
+                        fusion_arg.not_understood = true;
+                    } else if (!fusion_arg.subset.has_value() && !fusion_arg.not_understood) {
+                        fusion_arg.subset = edge.subset();
+                    }
+                }
+            }
+        }
+    }
+    void use_as_return_src(const std::string& container, const Return& ret) override {}
+    /**
+     * Dangerous, if somebody builds a value derived from indvar and then uses that for addressing we would not notice.
+     * But normally those should be folded into the accesses
+     */
+    void use_as_src_node(
+        const std::string& container,
+        const data_flow::AccessNode& node,
+        const data_flow::Memlet& edge,
+        const Block& block
+    ) override {
+        auto current = get_current_loop();
+        if (current && edge.is_src_pointed_to_read()) {
+            auto cand_it = fuse_candidates_.find(current->loop->element_id());
+            if (cand_it != fuse_candidates_.end()) {
+                auto& cand = *cand_it->second;
+                auto arg_it = cand.args.find(container);
+                if (arg_it != cand.args.end()) {
+                    auto& fusion_arg = arg_it->second;
+                    if (fusion_arg.subset.has_value() &&
+                        !symbolic::vectors_of_expressions_match(fusion_arg.subset.value(), edge.subset())) {
+                        fusion_arg.not_understood = true;
+                    } else if (!fusion_arg.subset.has_value() && !fusion_arg.not_understood) {
+                        fusion_arg.subset = edge.subset();
+                    }
+                }
+            }
+        }
+    }
+    void use_as_symbol_write(
+        const symbolic::Symbol& container, const ControlFlowNode* node, const Element* user, SymbolWriteLocation loc
+    ) override {}
+};
 
 FusionLoopCandidate* MapFusionByDomainPass::State::get_next_level_map_stack(FusionLoopCandidate& current) {
     auto& children = loop_analysis->children(current.loop);
@@ -15,7 +131,20 @@ FusionLoopCandidate* MapFusionByDomainPass::State::get_next_level_map_stack(Fusi
     }
 
     auto* next = children.at(0);
-    return &fuse_candidates.at(next->element_id());
+    return fuse_candidates.at(next->element_id()).get();
+}
+
+FusionLoopCandidate* MapFusionByDomainPass::State::get_parent(FusionLoopCandidate& current) {
+    auto* parent = loop_analysis->parent_loop(current.loop);
+    if (!parent) {
+        return nullptr;
+    }
+    auto it = fuse_candidates.find(parent->element_id());
+    if (it != fuse_candidates.end()) {
+        return it->second.get();
+    } else {
+        return nullptr;
+    }
 }
 
 bool MapFusionByDomainPass::run_pass(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {
@@ -27,8 +156,6 @@ bool MapFusionByDomainPass::run_pass(builder::StructuredSDFGBuilder& builder, an
     auto& assumption_analysis = analysis_manager.get<analysis::AssumptionsAnalysis>();
     auto& arguments_analysis = analysis_manager.get<analysis::ArgumentsAnalysis>();
 
-    auto outermost = state.loop_analysis->outermost_loops();
-
     for (auto* control_flow_node : state.loop_analysis->loops()) {
         if (auto* map = dynamic_cast<Map*>(control_flow_node)) {
             auto& indvar = map->indvar();
@@ -38,14 +165,24 @@ bool MapFusionByDomainPass::run_pass(builder::StructuredSDFGBuilder& builder, an
             if (indvar_boundaries && !indvar_boundaries->tight_lower_bound().is_null() &&
                 !indvar_boundaries->tight_upper_bound().is_null() && !indvar_boundaries->map().is_null()) {
                 auto& args = arguments_analysis.arguments(analysis_manager, *map);
-                state.fuse_candidates[control_flow_node->element_id()] = {map, indvar_boundaries, &args};
+                auto cand = std::make_unique<FusionLoopCandidate>(map, indvar_boundaries);
+                for (auto [name, arg] : args) {
+                    cand->args.emplace(name, arg);
+                }
+                state.fuse_candidates[control_flow_node->element_id()] = std::move(cand);
             }
         }
     }
 
-    auto dir = builder.subject().metadata_if_exists("output_dir");
-    if (dir) {
-        state.loop_analysis->dump_to_file(std::filesystem::path(*dir) / "loop_infos.pre-fusion.json");
+    LoopIndirectAccessFinder indirect_access_finder(*state.loop_analysis, state.fuse_candidates);
+    indirect_access_finder.dispatch(builder.subject().root());
+
+    const std::string* dir = nullptr;
+    if (dump_infos) {
+        dir = builder.subject().metadata_if_exists("output_dir");
+        if (dir) {
+            state.loop_analysis->dump_to_file(std::filesystem::path(*dir) / "loop_infos.pre-fusion.json");
+        }
     }
 
     MapFusionHandler handler(state);
@@ -76,7 +213,7 @@ PatternHandler::MatchResult MapFusionHandler::fuse_contents(
     ControlFlowNode* first_top,
     FusionLoopCandidate* first_current,
     FusionLoopCandidate* second_innermost,
-    SymEngine::map_basic_basic indvar_mapping,
+    const symbolic::ExpressionMapping& indvar_mapping,
     Sequence& target_root,
     bool can_remove_original
 ) {
@@ -102,26 +239,37 @@ PatternHandler::MatchResult MapFusionHandler::fuse_contents(
 
     if (append_root != &target_root) { // need to fixup / flatten the copied sequence into the target sequence
         state_.builder.move_children(*append_root, target_root, 0);
+        state_.builder.remove_from_parent(*append_root);
+        append_root = nullptr;
     }
+
+    update_candidate_state(first_top, first_current, second_innermost, indvar_mapping);
 
     auto& first_children = state_.loop_analysis->children(first_current->loop);
     bool keep_visiting_second = !state_.loop_analysis->children(second_innermost->loop).empty() ||
                                 !first_children.empty();
-    if (!first_children.empty()) {
-        if (can_remove_original) {
-            for (auto& child : first_children) {
-                state_.loop_analysis->moved_loop(child, second_innermost->loop);
-            }
-        } else {
-            for (auto& child : first_children) {
-                state_.loop_analysis->copied_loop(
-                    child,
-                    second_innermost->loop,
-                    const_cast<structured_control_flow::ControlFlowNode*>(copy_mapping->at(child))
-                );
-            }
+    auto& prev_local_info = state_.loop_analysis->loop_info_local(first_current->loop);
+    if (can_remove_original) {
+        for (auto& child : first_children) {
+            state_.loop_analysis->moved_loop(child, second_innermost->loop, true);
         }
+        state_.loop_analysis->added_local_contents(
+            second_innermost->loop, prev_local_info.contains_side_effects, prev_local_info.contains_non_perfectly_nested
+        );
+    } else {
+        for (auto& child : first_children) {
+            state_.loop_analysis->copied_loop(
+                child,
+                second_innermost->loop,
+                const_cast<structured_control_flow::ControlFlowNode*>(copy_mapping->at(child)),
+                true
+            );
+        }
+        state_.loop_analysis->added_local_contents(
+            second_innermost->loop, prev_local_info.contains_side_effects, prev_local_info.contains_non_perfectly_nested
+        );
     }
+
     bool removed_first = false;
     if (can_remove_original) {
         state_.loop_analysis->removed_loop(first_top);
@@ -140,49 +288,60 @@ PatternHandler::MatchResult MapFusionHandler::match(Map& first, Map& second, boo
     if (first_it == state_.fuse_candidates.end()) {
         return {};
     }
-    auto* first_current = &first_it->second;
+    FusionLoopCandidate* first_current = nullptr;
+    FusionLoopCandidate* first_next = first_it->second.get();
 
     auto second_it = state_.fuse_candidates.find(second.element_id());
     if (second_it == state_.fuse_candidates.end()) {
         return {};
     }
-    auto* second_current = &second_it->second;
-
-    bool no_data_conflicts = this->no_data_conflicts(*first_current, *second_current);
-    if (!no_data_conflicts) {
-        return {};
-    }
+    FusionLoopCandidate* second_current = nullptr;
+    FusionLoopCandidate* second_next = second_it->second.get();
 
     SymEngine::map_basic_basic indvar_mapping;
     bool level_match;
     int current_level = -1;
     int last_matched_level = -1;
     auto second_loop_info = state_.loop_analysis->loop_info(&second);
-    auto max_map_stack_depth =
-        std::min(state_.loop_analysis->loop_info(&first).map_stack_depth, second_loop_info.map_stack_depth) - 1;
-    bool keep_looking;
+    auto first_map_stack_depth = state_.loop_analysis->loop_info(&first).map_stack_depth;
+    auto max_map_stack_depth = std::min(first_map_stack_depth, second_loop_info.map_stack_depth) - 1;
+    bool uneven = first_map_stack_depth != second_loop_info.map_stack_depth;
 
     do {
-        keep_looking = false;
         ++current_level;
-        indvar_mapping[first_current->loop->indvar()] = second_current->loop->indvar();
+        indvar_mapping[first_next->loop->indvar()] = second_next->loop->indvar();
 
-        level_match = this->loop_match(*first_current, *second_current, indvar_mapping);
+        level_match = this->loop_match(*first_next, *second_next, indvar_mapping);
         if (level_match) {
-            last_matched_level = current_level;
-            if (current_level < max_map_stack_depth) {
-                keep_looking = true;
-                first_current = state_.get_next_level_map_stack(*first_current);
-                second_current = state_.get_next_level_map_stack(*second_current);
+            auto res = this->check_ins_outs(*first_next, *second_next, indvar_mapping);
+            level_match = res.no_conflicts;
+            if (uneven && !res.overlap) { // heuristic: do not fuse if there is no memory shared between them
+                return {};
             }
         }
-    } while (keep_looking);
+        bool go_deeper = false;
+        if (level_match) {
+            last_matched_level = current_level;
+            first_current = first_next;
+            second_current = second_next;
+            if (current_level < max_map_stack_depth) {
+                go_deeper = true;
+            }
+        }
+        if (go_deeper) {
+            first_next = state_.get_next_level_map_stack(*first_next);
+            second_next = state_.get_next_level_map_stack(*second_next);
+        } else {
+            first_next = nullptr;
+            second_next = nullptr;
+        }
+    } while (first_next && second_next);
 
     if (last_matched_level >= 0) {
         DEBUG_PRINTLN(
-            "Can fuse map stack (" << last_matched_level + 1 << " lvls): #" << first.element_id() << " | #"
-                                   << first_current->loop->element_id() << ", #" << second.element_id() << " | #"
-                                   << second_current->loop->element_id()
+            "Fusing map stack (" << last_matched_level + 1 << " lvls): #" << first.element_id() << " | #"
+                                 << first_current->loop->element_id() << ", #" << second.element_id() << " | #"
+                                 << second_current->loop->element_id()
         );
 
         auto& target_root = second_current->loop->root();
@@ -194,6 +353,10 @@ PatternHandler::MatchResult MapFusionHandler::match(Map& first, Map& second, boo
 
 bool MapFusionHandler::
     loop_match(FusionLoopCandidate& first, FusionLoopCandidate& second, SymEngine::map_basic_basic& canonical_indvars) {
+    // if (first.incompatible || second.incompatible) {
+    //     return false;
+    // }
+
     bool lower_match =
         symbolic::eq(first.indvar_boundaries->tight_lower_bound(), second.indvar_boundaries->tight_lower_bound());
     if (!lower_match) {
@@ -213,25 +376,102 @@ bool MapFusionHandler::
     return true;
 }
 
-bool MapFusionHandler::
-    no_data_conflicts(const FusionLoopCandidate& first_candidate, const FusionLoopCandidate& second_candidate) {
-    auto& first_args = *first_candidate.args;
-    auto& second_args = *second_candidate.args;
+data_flow::Subset updated_subset(const data_flow::Subset& subset, const symbolic::ExpressionMapping& canonical_indvars) {
+    std::vector<symbolic::Expression> updated_subset(subset.size());
+    for (auto i = 0; i < subset.size(); i++) {
+        updated_subset[i] = symbolic::subs(subset[i], canonical_indvars);
+    }
+    return std::move(updated_subset);
+}
+
+void MapFusionHandler::update_candidate_state(
+    ControlFlowNode* first_top,
+    FusionLoopCandidate* first_current,
+    FusionLoopCandidate* second_current,
+    const symbolic::ExpressionMapping& canonical_indvars
+) {
+    auto terminate_at = state_.loop_analysis->parent_loop(first_top);
+    do {
+        auto& second_args = second_current->args;
+        for (auto& [name, arg] : first_current->args) {
+            if (first_current->loop->indvar()->get_name() == name) {
+                // skip the induction variable, we already know those match and they would not be useful to track for
+                // the next levels up
+                continue;
+            }
+            auto it = second_args.find(name);
+            if (it != second_args.end()) {
+                auto& second_arg = it->second;
+                if (second_arg.subset.has_value() && arg.subset.has_value() &&
+                    !symbolic::vectors_of_expressions_match(
+                        second_arg.subset.value(), arg.subset.value(), canonical_indvars
+                    )) {
+                    second_arg.not_understood = true;
+                } else if (!second_arg.subset.has_value() && arg.subset.has_value()) {
+                    second_arg.subset = updated_subset(arg.subset.value(), canonical_indvars);
+                }
+                second_arg.not_understood |= arg.not_understood;
+                second_arg.arg.merge(arg.arg);
+            } else {
+                auto [it, fresh] = second_args.emplace(name, arg.arg);
+                if (arg.subset.has_value()) {
+                    it->second.subset = updated_subset(arg.subset.value(), canonical_indvars);
+                    it->second.not_understood = arg.not_understood;
+                }
+            }
+        }
+        first_current = state_.get_parent(*first_current);
+        second_current = state_.get_parent(*second_current);
+    } while (first_current && first_current->loop != terminate_at);
+}
+
+MapFusionHandler::InOutCheckResult MapFusionHandler::check_ins_outs(
+    const FusionLoopCandidate& first_candidate,
+    const FusionLoopCandidate& second_candidate,
+    symbolic::ExpressionMapping& canonical_indvars
+) {
+    auto& first_args = first_candidate.args;
+    auto& second_args = second_candidate.args;
+
+    bool overlap = false;
+
     for (auto& [name, prod_meta] : first_args) {
-        auto cons_it = second_candidate.args->find(name);
+        auto cons_it = second_args.find(name);
         if (cons_it != second_args.end()) {
-            // argument appears in both
             auto& cons_meta = cons_it->second;
-            // any potential conflicts to check if both are maps?
+            if (prod_meta.arg.is_input &&
+                cons_meta.arg.is_output /* && (!prod_meta.saw_access_locally() || cons_meta.saw_access_locally())*/) {
+                // possibly consumer influencing producer in unsafe ways
+                // if producer does not write the arg itself, this level should still be fine, the conflict would be
+                // deeper down
+                return {false, overlap};
+            } else if (prod_meta.arg.is_output && cons_meta.arg.is_input) {
+                overlap = true;
+                if (prod_meta.not_understood || cons_meta.not_understood) {
+                    return {false, overlap};
+                }
+
+                if (prod_meta.subset.has_value() && cons_meta.subset.has_value()) {
+                    if (!symbolic::vectors_of_expressions_match(
+                            prod_meta.subset.value(), cons_meta.subset.value(), canonical_indvars
+                        )) {
+                        return {false, overlap};
+                    }
+                }
+            }
         }
     }
 
-    return true;
+    return {true, overlap};
 }
 
 void MapFusionHandler::update_fused_seq(Sequence& sequence, const symbolic::ExpressionMapping& replacements) {
     sequence.replace(replacements);
 }
+
+bool FusionArg::saw_access_locally() const { return not_understood || subset.has_value(); }
+
+void FusionLoopCandidate::non_indvar_writes() { this->incompatible = true; }
 
 NeighboringPatternVisitor::NeighboringPatternVisitor(PatternHandler& handler) : handler_(handler) {}
 
@@ -269,6 +509,10 @@ bool NeighboringPatternVisitor::visit(sdfg::structured_control_flow::Sequence& n
             if (result.visit_second_body) {
                 auto* second_updated_child = result.second_root_replacement ? result.second_root_replacement : second;
                 dispatch(*second_updated_child);
+            }
+            if (result.removed_first) {
+                // do not increment i, we can use at as next firs
+                continue;
             }
         } else if (i + 2 < node.size()) {
             auto* mid_block = dynamic_cast<structured_control_flow::Block*>(&node.at(i + 1).first);

--- a/opt/src/passes/map_fusion_by_domain_pass.cpp
+++ b/opt/src/passes/map_fusion_by_domain_pass.cpp
@@ -344,14 +344,6 @@ PatternHandler::MatchResult MapFusionHandler::fuse_contents(
 
     state_.fused_count++;
 
-    static auto count = 0;
-    std::filesystem::path dir = state_.builder.subject().metadata("output_dir");
-    visualizer::DotVisualizer::writeToFile(
-        state_.builder.subject(),
-        dir /
-            ("map_fusion_by_domain_pass_dump_" + std::to_string(count++) + "_" + std::to_string(first_elem_id) + ".dot")
-    );
-
     // if there are further loops inside the now fused body, visit those as well
     return {.removed_first = removed_first, .visit_second_body = keep_visiting_second};
 }

--- a/opt/src/passes/map_fusion_by_domain_pass.cpp
+++ b/opt/src/passes/map_fusion_by_domain_pass.cpp
@@ -425,6 +425,18 @@ PatternHandler::MatchResult MapFusionHandler::match(Map& first, Map& second, boo
 }
 
 bool MapFusionHandler::
+    check_no_overlap(const Map& map, const Map& second, const std::unordered_set<std::string>& skipped_containers) {
+    auto& first_cand = *state_.fuse_candidates.at(map.element_id());
+    auto& second_cand = *state_.fuse_candidates.at(second.element_id());
+    for (auto& arg : first_cand.args) {
+        if (skipped_containers.contains(arg.first)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool MapFusionHandler::
     loop_match(FusionLoopCandidate& first, FusionLoopCandidate& second, SymEngine::map_basic_basic& canonical_indvars) {
     // if (first.incompatible || second.incompatible) {
     //     return false;
@@ -449,6 +461,21 @@ bool MapFusionHandler::
     return true;
 }
 
+void MapFusionHandler::update_child_candidate_states(FusionLoopCandidate* top, const symbolic::ExpressionMapping& replace) {
+    auto& info = state_.loop_analysis->loop_info_local(top->loop);
+    auto& candidates = state_.fuse_candidates;
+
+    auto& by_id = state_.loop_analysis->loops_in_pre_order();
+    for (auto i = info.loop_id; i <= info.last_child_id; ++i) {
+        auto* child_loop = by_id.at(i);
+        auto cand_it = candidates.find(child_loop->element_id());
+        if (cand_it != candidates.end()) {
+            auto& child_cand = *cand_it->second;
+            child_cand.replace(replace);
+        }
+    }
+}
+
 data_flow::Subset updated_subset(const data_flow::Subset& subset, const symbolic::ExpressionMapping& canonical_indvars) {
     std::vector<symbolic::Expression> updated_subset(subset.size());
     for (auto i = 0; i < subset.size(); i++) {
@@ -463,6 +490,8 @@ void MapFusionHandler::update_candidate_state(
     FusionLoopCandidate* second_current,
     const symbolic::ExpressionMapping& canonical_indvars
 ) {
+    update_child_candidate_states(first_current, canonical_indvars);
+
     auto terminate_at = state_.loop_analysis->parent_loop(first_top);
     do {
         auto& second_args = second_current->args;
@@ -546,6 +575,14 @@ bool FusionArg::saw_access_locally() const { return not_understood || subset.has
 
 void FusionLoopCandidate::non_indvar_writes() { this->incompatible = true; }
 
+void FusionLoopCandidate::replace(const symbolic::ExpressionMapping& mapping) {
+    for (auto& [name, arg] : args) {
+        if (arg.subset.has_value()) {
+            arg.subset = updated_subset(arg.subset.value(), mapping);
+        }
+    }
+}
+
 NeighboringPatternVisitor::NeighboringPatternVisitor(PatternHandler& handler) : handler_(handler) {}
 
 bool NeighboringPatternVisitor::visit(sdfg::structured_control_flow::Sequence& node) {
@@ -569,8 +606,11 @@ bool NeighboringPatternVisitor::visit(sdfg::structured_control_flow::Sequence& n
             continue;
         }
 
+        Map* second = nullptr;
+
         if (i + 1 < node.size()) {
-            if (auto* second = dynamic_cast<structured_control_flow::Map*>(&node.at(i + 1).first)) {
+            second = dynamic_cast<structured_control_flow::Map*>(&node.at(i + 1).first);
+            if (second) {
                 if (second->root().size() == 0) {
                     i++;
                     continue;
@@ -592,30 +632,55 @@ bool NeighboringPatternVisitor::visit(sdfg::structured_control_flow::Sequence& n
                 }
             } else if (i + 2 < node.size()) {
                 auto* mid_block = dynamic_cast<structured_control_flow::Block*>(&node.at(i + 1).first);
-                if (mid_block && mid_block->is_a_library_node<stdlib::MallocNode>()) {
-                    if (auto* second = dynamic_cast<structured_control_flow::Map*>(&node.at(i + 2).first)) {
+                bool skippable = false;
+                std::unordered_set<std::string> skipped_containers;
+                if (mid_block) {
+                    if (mid_block->dataflow().nodes().empty()) {
+                        skippable = true;
+                    } else if (mid_block->is_a_library_node<stdlib::MallocNode>()) {
+                        for (auto& data_flow_node : mid_block->dataflow().nodes()) {
+                            if (auto* container = dynamic_cast<data_flow::AccessNode*>(&data_flow_node)) {
+                                skipped_containers.emplace(container->data());
+                            }
+                        }
+                        skippable = true;
+                    }
+                }
+                if (skippable) {
+                    second = dynamic_cast<structured_control_flow::Map*>(&node.at(i + 2).first);
+                    if (second) {
                         if (second->root().size() == 0) {
-                            i++;
+                            i += 2;
                             continue;
                         }
 
-                        // until we support matching this, just keep visiting
-                        dispatch(child_node);
-                        dispatch(*second);
-                        // transformations::MapFusion transformation(*first, *second, false);
-                        // if (transformation.can_be_applied(builder_, analysis_manager_)) {
-                        //     auto first_name = first->indvar()->get_name();
-                        //     auto second_name = second->indvar()->get_name();
-                        //     transformation.apply(builder_, analysis_manager_);
-                        //     DEBUG_PRINTLN(
-                        //         "Applied MapFusion to map " + first_name + " and loop " + second_name +
-                        //         " with intermediate malloc block"
-                        //     );
-                        //     applied = true;
-                        //
-                        //     i = i + 2; // Skip over the newly moved malloc block and the second loop that was just
-                        //     fused continue;
-                        // }
+                        if (!handler_.check_no_overlap(*first, *second, skipped_containers)) {
+                            i += 2;
+                            continue;
+                        }
+
+                        auto result = handler_.match(*first, *second, true);
+
+                        if (!result.removed_first) {
+                            dispatch(child_node);
+                        }
+                        if (result.visit_second_body) {
+                            auto* second_updated_child = result.second_root_replacement ? result.second_root_replacement
+                                                                                        : second;
+                            dispatch(*second_updated_child);
+                        }
+                        if (result.removed_first) {
+                            i += 1; // skip the block, retry with second as next first
+                            continue;
+                        }
+                        // we visited [first, skipped, second] successfully, without shifting indices, move to second as
+                        // new first
+                        i += 2;
+                        continue;
+                    } else {
+                        // we know i+1 is worthless, so skip it
+                        i += 2;
+                        continue;
                     }
                 }
             }

--- a/opt/src/passes/map_fusion_by_domain_pass.cpp
+++ b/opt/src/passes/map_fusion_by_domain_pass.cpp
@@ -19,6 +19,7 @@ class LoopIndirectAccessFinder : public analysis::BaseUserVisitor {
     struct LoopEntry {
         ControlFlowNode* loop;
         analysis::LocalLoopInfo::LoopType type;
+        FusionLoopCandidate& fusion_candidate;
         std::unordered_set<std::string> indvars;
     };
     std::deque<LoopEntry> loop_stack_;
@@ -73,25 +74,38 @@ public:
         : loop_analysis_(loops), fuse_candidates_(fuse_candidates) {}
 
     bool visit(sdfg::structured_control_flow::For& node) override {
-        loop_stack_.emplace_back(&node, analysis::LocalLoopInfo::LoopType::For);
-        loop_stack_.back().indvars.emplace(node.indvar()->get_name());
+        auto cand_it = fuse_candidates_.find(node.element_id());
+        bool is_relevant_loop = cand_it != fuse_candidates_.end();
+        if (is_relevant_loop) {
+            loop_stack_.emplace_back(&node, analysis::LocalLoopInfo::LoopType::For, *cand_it->second.get());
+            loop_stack_.back().indvars.emplace(node.indvar()->get_name());
+        }
         auto res = ActualStructuredSDFGVisitor::visit(node);
-        loop_stack_.pop_back();
+
+        if (is_relevant_loop) {
+            loop_stack_.pop_back();
+        }
+
         return res;
     }
 
     bool visit(sdfg::structured_control_flow::While& node) override {
-        loop_stack_.emplace_back(&node, analysis::LocalLoopInfo::LoopType::For);
+        // far from being supported as fuse candidates, so do the normal stuff
         auto res = ActualStructuredSDFGVisitor::visit(node);
-        loop_stack_.pop_back();
         return res;
     }
 
     bool visit(sdfg::structured_control_flow::Map& node) override {
-        loop_stack_.emplace_back(&node, analysis::LocalLoopInfo::LoopType::For);
-        loop_stack_.back().indvars.emplace(node.indvar()->get_name());
+        auto cand_it = fuse_candidates_.find(node.element_id());
+        bool is_relevant_loop = cand_it != fuse_candidates_.end();
+        if (is_relevant_loop) {
+            loop_stack_.emplace_back(&node, analysis::LocalLoopInfo::LoopType::Map, *cand_it->second.get());
+            loop_stack_.back().indvars.emplace(node.indvar()->get_name());
+        }
         auto res = ActualStructuredSDFGVisitor::visit(node);
-        loop_stack_.pop_back();
+        if (is_relevant_loop) {
+            loop_stack_.pop_back();
+        }
         return res;
     }
 
@@ -107,16 +121,13 @@ public:
     void found_indirect_arg_access(
         const std::string& container, const data_flow::Memlet& edge, LoopEntry* current, bool is_write
     ) {
-        auto cand_it = fuse_candidates_.find(current->loop->element_id());
-        if (cand_it != fuse_candidates_.end()) {
-            auto& cand = *cand_it->second;
-            auto arg_it = cand.args.find(container);
-            if (arg_it != cand.args.end()) {
-                auto& fusion_arg = arg_it->second;
-                merge_fusion_arg_props_into(fusion_arg, edge.subset(), false, symbolic::ExpressionMapping());
-                // propagate_arg_up(current, container, fusion_arg); // may include lower level indvars, in which case
-                // it will block everything
-            }
+        auto& cand = current->fusion_candidate;
+        auto arg_it = cand.args.find(container);
+        if (arg_it != cand.args.end()) {
+            auto& fusion_arg = arg_it->second;
+            merge_fusion_arg_props_into(fusion_arg, edge.subset(), false, symbolic::ExpressionMapping());
+            // propagate_arg_up(current, container, fusion_arg); // may include lower level indvars, in which case
+            // it will block everything
         }
     }
 
@@ -344,6 +355,15 @@ PatternHandler::MatchResult MapFusionHandler::fuse_contents(
 
     state_.fused_count++;
 
+    // static auto count = 0;
+    // std::filesystem::path dir = state_.builder.subject().metadata("output_dir");
+    // visualizer::DotVisualizer::writeToFile(
+    //     state_.builder.subject(),
+    //     dir /
+    //         ("map_fusion_by_domain_pass_dump_" + std::to_string(count++) + "_" + std::to_string(first_elem_id) +
+    //         ".dot")
+    // );
+
     // if there are further loops inside the now fused body, visit those as well
     return {.removed_first = removed_first, .visit_second_body = keep_visiting_second};
 }
@@ -364,48 +384,60 @@ PatternHandler::MatchResult MapFusionHandler::match(Map& first, Map& second, boo
     FusionLoopCandidate* second_next = second_it->second.get();
 
     SymEngine::map_basic_basic indvar_mapping;
-    bool level_match;
     int current_level = -1;
     int last_matched_level = -1;
-    auto second_loop_info = state_.loop_analysis->loop_info(&second);
-    auto first_map_stack_depth = state_.loop_analysis->loop_info(&first).map_stack_depth;
-    auto max_map_stack_depth = std::min(first_map_stack_depth, second_loop_info.map_stack_depth) - 1;
-    bool uneven = first_map_stack_depth != second_loop_info.map_stack_depth;
+    auto first_max_stack_depth = state_.loop_analysis->loop_info(&first).map_stack_depth - 1;
+    auto second_max_stack_depth = state_.loop_analysis->loop_info(&second).map_stack_depth - 1;
+    bool more_first = true;
+    bool more_second = true;
+    bool fusing_option = true;
+    bool data_fusible;
+
+    // descend the map stacks down. Last level on which everything matches is the one we can fuse
+    // if one map stack ends, but the other one keeps going, we still need to descend the one that keeps going.
+    // at this point, these are no longer candidates for fusing, but we can only fuse the last level we found,
+    // if we find no subset conflicts. Because if not all subsets of the same structures match,
+    // we cannot guarantee correctness
 
     do {
         ++current_level;
-        indvar_mapping[first_next->loop->indvar()] = second_next->loop->indvar();
-
-        level_match = this->loop_match(*first_next, *second_next, indvar_mapping);
-        if (level_match) {
-            auto res = this->check_ins_outs(*first_next, *second_next, indvar_mapping);
-            level_match = res.no_conflicts;
-            if (uneven && !res.overlap) { // heuristic: do not fuse if there is no memory shared between them
-                return {};
-            }
-            if (res.subset_mismatch) { // heuristic: if we see the actual accesses having a subset conflict, we abort,
-                                       // instead of trying to fuse outer maps
-                // this also likely prevents some incorrect fusings
-                return {};
-            }
+        bool uneven = !more_first || !more_second;
+        if (fusing_option) {
+            indvar_mapping[first_next->loop->indvar()] = second_next->loop->indvar();
+            fusing_option = this->loop_match(*first_next, *second_next, indvar_mapping);
         }
-        bool go_deeper = false;
-        if (level_match) {
+        auto res = this->check_ins_outs(*first_next, *second_next, indvar_mapping);
+        if (!res.no_conflicts) {
+            // will occur on data-dependencies (from consumer to producer) or on subset mismatches
+            fusing_option = false;
+        }
+        if (first_max_stack_depth != second_max_stack_depth && !res.overlap) { // heuristic: do not fuse if there is no
+                                                                               // memory shared between uneven
+                                                                               // candidates
+            return {};
+        }
+        if (res.subset_mismatch) { // If subsets mismatch on any level, we cannot guarantee correctness without much
+                                   // more
+            // extensive checks, like done by the existing map_fusion
+            // Future work: let the previous map_fusion check if it can prove non-conflicting on a more granular level
+            return {};
+        }
+
+        if (fusing_option) {
             last_matched_level = current_level;
             first_current = first_next;
             second_current = second_next;
-            if (current_level < max_map_stack_depth) {
-                go_deeper = true;
-            }
         }
-        if (go_deeper) {
+        more_first = current_level < first_max_stack_depth;
+        more_second = current_level < second_max_stack_depth;
+        if (more_first) {
             first_next = state_.get_next_level_map_stack(*first_next);
-            second_next = state_.get_next_level_map_stack(*second_next);
-        } else {
-            first_next = nullptr;
-            second_next = nullptr;
         }
-    } while (first_next && second_next);
+        if (more_second) {
+            second_next = state_.get_next_level_map_stack(*second_next);
+        }
+        fusing_option &= more_first && more_second;
+    } while (more_first || more_second);
 
     if (last_matched_level >= 0) {
         DEBUG_PRINTLN(
@@ -538,11 +570,10 @@ MapFusionHandler::InOutCheckResult MapFusionHandler::check_ins_outs(
         auto cons_it = second_args.find(name);
         if (cons_it != second_args.end()) {
             auto& cons_meta = cons_it->second;
-            if (prod_meta.arg.is_input &&
-                cons_meta.arg.is_output /* && (!prod_meta.saw_access_locally() || cons_meta.saw_access_locally())*/) {
-                // possibly consumer influencing producer in unsafe ways
-                // if producer does not write the arg itself, this level should still be fine, the conflict would be
-                // deeper down
+            if (prod_meta.arg.is_input && cons_meta.arg.is_output) {
+                // there could be conflicts here. So for now, abort.
+                // Future Work: if both were to strictly match indvars (or never match other iterations),
+                // it would never be a conflict
                 return {false, overlap};
             } else if (prod_meta.arg.is_output && cons_meta.arg.is_input) {
                 overlap = true;

--- a/opt/src/passes/map_fusion_by_domain_pass.cpp
+++ b/opt/src/passes/map_fusion_by_domain_pass.cpp
@@ -6,9 +6,12 @@
 #include "sdfg/deepcopy/structured_sdfg_deep_copy.h"
 #include "sdfg/symbolic/utils.h"
 #include "sdfg/visitor/structured_sdfg_visitor.h"
+#include "sdfg/visualizer/dot_visualizer.h"
 #include "symengine/subs.h"
 
 namespace sdfg::passes {
+
+static const symbolic::Symbol lower_indvar_placeholder = symbolic::symbol("__lower_it");
 
 class LoopIndirectAccessFinder : public analysis::BaseUserVisitor {
     analysis::LoopAnalysis& loop_analysis_;
@@ -25,6 +28,41 @@ class LoopIndirectAccessFinder : public analysis::BaseUserVisitor {
             return nullptr;
         }
         return &loop_stack_.back();
+    }
+
+    /**
+     * Merge a newly observed access (its `subset` and `not_understood` flag) into the FusionArg `into`.
+     * If `into` already tracks a different subset, we can no longer describe the access with a single
+     * subset and mark it not_understood. Returns true if `into` was modified.
+     */
+    static bool merge_fusion_arg_props_into(
+        FusionArg& into,
+        const std::optional<data_flow::Subset>& subset,
+        bool not_understood,
+        const symbolic::ExpressionMapping& lower_indvars
+    ) {
+        bool updated = false;
+        if (into.subset.has_value() && subset.has_value() &&
+            !symbolic::vectors_of_expressions_match(into.subset.value(), subset.value(), lower_indvars)) {
+            if (!into.not_understood) {
+                into.not_understood = true;
+                updated = true;
+            }
+        } else if (!into.subset.has_value() && subset.has_value() && !into.not_understood) {
+            into.subset = subset.value();
+            updated = true;
+        }
+        if (not_understood && !into.not_understood) {
+            into.not_understood = true;
+            updated = true;
+        }
+        return updated;
+    }
+
+    static bool merge_fusion_arg_props_into(
+        FusionArg& into, const FusionArg& from, const symbolic::ExpressionMapping& lower_indvars
+    ) {
+        return merge_fusion_arg_props_into(into, from.subset, from.not_understood, lower_indvars);
     }
 
 public:
@@ -66,6 +104,57 @@ public:
         symbolic::Expression expr
     ) override {}
 
+    void found_indirect_arg_access(
+        const std::string& container, const data_flow::Memlet& edge, LoopEntry* current, bool is_write
+    ) {
+        auto cand_it = fuse_candidates_.find(current->loop->element_id());
+        if (cand_it != fuse_candidates_.end()) {
+            auto& cand = *cand_it->second;
+            auto arg_it = cand.args.find(container);
+            if (arg_it != cand.args.end()) {
+                auto& fusion_arg = arg_it->second;
+                merge_fusion_arg_props_into(fusion_arg, edge.subset(), false, symbolic::ExpressionMapping());
+                // propagate_arg_up(current, container, fusion_arg); // may include lower level indvars, in which case
+                // it will block everything
+            }
+        }
+    }
+
+    /**
+     * Push an access change observed at the innermost loop (back of `loop_stack_`) up through its
+     * enclosing loops, merging it into every ancestor that still tracks `arg`. Stops once the root
+     * (front of the stack) is reached or a loop no longer contains the arg.
+     */
+    void propagate_arg_up(LoopEntry* start, const std::string& arg, FusionArg& changes) {
+        if (loop_stack_.size() < 2) {
+            return; // no enclosing loops above the current one
+        }
+
+        symbolic::ExpressionMapping lower_indvars;
+        for (auto& indvar : start->indvars) {
+            lower_indvars[symbolic::symbol(indvar)] = lower_indvar_placeholder;
+        }
+
+        // Start at the direct parent of the current (innermost) loop and walk toward the root.
+        for (auto it = loop_stack_.end() - 2;; --it) {
+            auto cand_it = fuse_candidates_.find(it->loop->element_id());
+            if (cand_it == fuse_candidates_.end()) {
+                break; // loop is not a tracked candidate, fusing will never cross that boundary anyway
+            }
+            auto& args = cand_it->second->args;
+            auto arg_it = args.find(arg);
+            if (arg_it == args.end()) {
+                break; // arg does not reach this loop -> nothing higher up needs it either
+            }
+
+            merge_fusion_arg_props_into(arg_it->second, changes, lower_indvars);
+
+            if (it == loop_stack_.begin()) {
+                break; // reached the root of the stack
+            }
+        }
+    }
+
     void use_as_dst_node(
         const std::string& container,
         const data_flow::AccessNode& node,
@@ -74,20 +163,7 @@ public:
     ) override {
         auto current = get_current_loop();
         if (current && edge.is_dst_pointed_to_write()) {
-            auto cand_it = fuse_candidates_.find(current->loop->element_id());
-            if (cand_it != fuse_candidates_.end()) {
-                auto& cand = *cand_it->second;
-                auto arg_it = cand.args.find(container);
-                if (arg_it != cand.args.end()) {
-                    auto& fusion_arg = arg_it->second;
-                    if (fusion_arg.subset.has_value() &&
-                        !symbolic::vectors_of_expressions_match(fusion_arg.subset.value(), edge.subset())) {
-                        fusion_arg.not_understood = true;
-                    } else if (!fusion_arg.subset.has_value() && !fusion_arg.not_understood) {
-                        fusion_arg.subset = edge.subset();
-                    }
-                }
-            }
+            found_indirect_arg_access(container, edge, current, true);
         }
     }
     void use_as_return_src(const std::string& container, const Return& ret) override {}
@@ -103,20 +179,7 @@ public:
     ) override {
         auto current = get_current_loop();
         if (current && edge.is_src_pointed_to_read()) {
-            auto cand_it = fuse_candidates_.find(current->loop->element_id());
-            if (cand_it != fuse_candidates_.end()) {
-                auto& cand = *cand_it->second;
-                auto arg_it = cand.args.find(container);
-                if (arg_it != cand.args.end()) {
-                    auto& fusion_arg = arg_it->second;
-                    if (fusion_arg.subset.has_value() &&
-                        !symbolic::vectors_of_expressions_match(fusion_arg.subset.value(), edge.subset())) {
-                        fusion_arg.not_understood = true;
-                    } else if (!fusion_arg.subset.has_value() && !fusion_arg.not_understood) {
-                        fusion_arg.subset = edge.subset();
-                    }
-                }
-            }
+            found_indirect_arg_access(container, edge, current, false);
         }
     }
     void use_as_symbol_write(
@@ -217,6 +280,8 @@ PatternHandler::MatchResult MapFusionHandler::fuse_contents(
     Sequence& target_root,
     bool can_remove_original
 ) {
+    auto first_elem_id = first_current->loop->element_id();
+
     Sequence* append_root = nullptr;
     if (target_root.size() == 0) {
         // target seq is empty, so we can just append to it
@@ -278,6 +343,14 @@ PatternHandler::MatchResult MapFusionHandler::fuse_contents(
     }
 
     state_.fused_count++;
+
+    static auto count = 0;
+    std::filesystem::path dir = state_.builder.subject().metadata("output_dir");
+    visualizer::DotVisualizer::writeToFile(
+        state_.builder.subject(),
+        dir /
+            ("map_fusion_by_domain_pass_dump_" + std::to_string(count++) + "_" + std::to_string(first_elem_id) + ".dot")
+    );
 
     // if there are further loops inside the now fused body, visit those as well
     return {.removed_first = removed_first, .visit_second_body = keep_visiting_second};
@@ -482,7 +555,8 @@ bool NeighboringPatternVisitor::visit(sdfg::structured_control_flow::Sequence& n
 
     // Iterate over sequence looking for consecutive (Map, StructuredLoop) pairs
     size_t i = 0;
-    while (i + 1 < node.size()) {
+    structured_control_flow::ControlFlowNode* override_last = nullptr;
+    while (i < node.size()) {
         auto& child_node = node.at(i).first;
         auto* first = dynamic_cast<structured_control_flow::Map*>(&child_node);
         if (!first) {
@@ -495,53 +569,58 @@ bool NeighboringPatternVisitor::visit(sdfg::structured_control_flow::Sequence& n
             continue;
         }
 
-        if (auto* second = dynamic_cast<structured_control_flow::Map*>(&node.at(i + 1).first)) {
-            if (second->root().size() == 0) {
-                i++;
-                continue;
-            }
+        if (i + 1 < node.size()) {
+            if (auto* second = dynamic_cast<structured_control_flow::Map*>(&node.at(i + 1).first)) {
+                if (second->root().size() == 0) {
+                    i++;
+                    continue;
+                }
 
-            auto result = handler_.match(*first, *second, true);
+                auto result = handler_.match(*first, *second, true);
 
-            if (!result.removed_first) {
-                dispatch(child_node);
-            }
-            if (result.visit_second_body) {
-                auto* second_updated_child = result.second_root_replacement ? result.second_root_replacement : second;
-                dispatch(*second_updated_child);
-            }
-            if (result.removed_first) {
-                // do not increment i, we can use at as next firs
-                continue;
-            }
-        } else if (i + 2 < node.size()) {
-            auto* mid_block = dynamic_cast<structured_control_flow::Block*>(&node.at(i + 1).first);
-            if (mid_block && mid_block->is_a_library_node<stdlib::MallocNode>()) {
-                if (auto* second = dynamic_cast<structured_control_flow::Map*>(&node.at(i + 2).first)) {
-                    if (second->root().size() == 0) {
-                        i++;
-                        continue;
-                    }
-
-                    // until we support matching this, just keep visiting
+                if (!result.removed_first) {
                     dispatch(child_node);
-                    dispatch(*second);
-                    // transformations::MapFusion transformation(*first, *second, false);
-                    // if (transformation.can_be_applied(builder_, analysis_manager_)) {
-                    //     auto first_name = first->indvar()->get_name();
-                    //     auto second_name = second->indvar()->get_name();
-                    //     transformation.apply(builder_, analysis_manager_);
-                    //     DEBUG_PRINTLN(
-                    //         "Applied MapFusion to map " + first_name + " and loop " + second_name +
-                    //         " with intermediate malloc block"
-                    //     );
-                    //     applied = true;
-                    //
-                    //     i = i + 2; // Skip over the newly moved malloc block and the second loop that was just fused
-                    //     continue;
-                    // }
+                }
+                if (result.visit_second_body) {
+                    auto* second_updated_child = result.second_root_replacement ? result.second_root_replacement
+                                                                                : second;
+                    dispatch(*second_updated_child);
+                }
+                if (result.removed_first) {
+                    // do not increment i, we can use at as next firs
+                    continue;
+                }
+            } else if (i + 2 < node.size()) {
+                auto* mid_block = dynamic_cast<structured_control_flow::Block*>(&node.at(i + 1).first);
+                if (mid_block && mid_block->is_a_library_node<stdlib::MallocNode>()) {
+                    if (auto* second = dynamic_cast<structured_control_flow::Map*>(&node.at(i + 2).first)) {
+                        if (second->root().size() == 0) {
+                            i++;
+                            continue;
+                        }
+
+                        // until we support matching this, just keep visiting
+                        dispatch(child_node);
+                        dispatch(*second);
+                        // transformations::MapFusion transformation(*first, *second, false);
+                        // if (transformation.can_be_applied(builder_, analysis_manager_)) {
+                        //     auto first_name = first->indvar()->get_name();
+                        //     auto second_name = second->indvar()->get_name();
+                        //     transformation.apply(builder_, analysis_manager_);
+                        //     DEBUG_PRINTLN(
+                        //         "Applied MapFusion to map " + first_name + " and loop " + second_name +
+                        //         " with intermediate malloc block"
+                        //     );
+                        //     applied = true;
+                        //
+                        //     i = i + 2; // Skip over the newly moved malloc block and the second loop that was just
+                        //     fused continue;
+                        // }
+                    }
                 }
             }
+        } else {
+            dispatch(child_node);
         }
         i++;
     }

--- a/opt/src/passes/new_map_fusion_pass.cpp
+++ b/opt/src/passes/new_map_fusion_pass.cpp
@@ -1,0 +1,279 @@
+#include "sdfg/passes/new_map_fusion_pass.h"
+
+#include "sdfg/analysis/assumptions_analysis.h"
+#include "sdfg/data_flow/library_nodes/stdlib/malloc.h"
+#include "sdfg/deepcopy/structured_sdfg_deep_copy.h"
+#include "sdfg/visitor/structured_sdfg_visitor.h"
+#include "symengine/subs.h"
+
+namespace sdfg::passes {
+
+FusionLoopCandidate* NewMapFusionPass::State::get_next_level_map_stack(FusionLoopCandidate& current) {
+    auto& children = loop_analysis->children(current.loop);
+    if (children.empty()) {
+        return nullptr;
+    }
+
+    auto* next = children.at(0);
+    return &fuse_candidates.at(next->element_id());
+}
+
+bool NewMapFusionPass::run_pass(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {
+    fused_count = 0;
+
+    auto loop_ana = std::make_unique<analysis::LoopAnalysis>(builder.subject());
+    loop_ana->run(analysis_manager);
+
+    State state(builder, analysis_manager, std::move(loop_ana));
+
+    auto& assumption_analysis = analysis_manager.get<analysis::AssumptionsAnalysis>();
+    auto& arguments_analysis = analysis_manager.get<analysis::ArgumentsAnalysis>();
+
+    auto outermost = state.loop_analysis->outermost_loops();
+
+    for (auto* control_flow_node : state.loop_analysis->loops()) {
+        if (auto* map = dynamic_cast<Map*>(control_flow_node)) {
+            auto& indvar = map->indvar();
+            auto& assumpts = assumption_analysis.get(map->root(), true);
+            auto* indvar_boundaries = find_indvar_boundaries(indvar, assumpts);
+
+            if (indvar_boundaries && !indvar_boundaries->tight_lower_bound().is_null() &&
+                !indvar_boundaries->tight_upper_bound().is_null() && !indvar_boundaries->map().is_null()) {
+                auto& args = arguments_analysis.arguments(analysis_manager, *map);
+                state.fuse_candidates[control_flow_node->element_id()] = {map, indvar_boundaries, &args};
+            }
+        }
+    }
+
+    MapFusionHandler handler(state);
+
+    NeighboringPatternVisitor v(handler);
+    v.dispatch(builder.subject().root());
+
+    return fused_count;
+}
+
+const symbolic::Assumption* NewMapFusionPass::
+    find_indvar_boundaries(const symbolic::Symbol& indvar, const symbolic::Assumptions& assumptions) {
+    auto it = assumptions.find(indvar);
+    if (it != assumptions.end()) {
+        return &it->second;
+    }
+
+    return nullptr;
+}
+
+MapFusionHandler::MapFusionHandler(NewMapFusionPass::State& state) : state_(state) {}
+
+bool MapFusionHandler::fuse_contents(
+    FusionLoopCandidate* first_current,
+    FusionLoopCandidate* second_current,
+    SymEngine::map_basic_basic indvar_mapping,
+    Sequence& target_root
+) {
+    Sequence* append_root = nullptr;
+    if (target_root.size() == 0) {
+        append_root = &target_root;
+    } else { // there currently is no way to prepend or limit replace, so add to new sequence, then move
+        append_root = &state_.builder.add_sequence_before(target_root, target_root.at(0).first, {}, {});
+    }
+
+    deepcopy::StructuredSDFGDeepCopy copier(state_.builder, *append_root, first_current->loop->root());
+    auto copy_mapping = copier.insert();
+
+    update_fused_seq(*append_root, indvar_mapping);
+
+    if (append_root != &target_root) { // need to fixup / flatten the copied sequence into the target sequence
+        state_.builder.move_children(*append_root, target_root, 0);
+    }
+
+    auto& first_children = state_.loop_analysis->children(first_current->loop);
+    bool keep_visiting_second = !state_.loop_analysis->children(second_current->loop).empty() ||
+                                !first_children.empty();
+    if (!first_children.empty()) {
+        for (auto& child : first_children) {
+            state_.loop_analysis->copied_loop(
+                child,
+                second_current->loop,
+                const_cast<structured_control_flow::ControlFlowNode*>(copy_mapping.at(child))
+            );
+        }
+    }
+    return keep_visiting_second;
+}
+
+PatternHandler::MatchResult MapFusionHandler::match(Map& first, Map& second, bool no_uses_between) {
+    auto first_it = state_.fuse_candidates.find(first.element_id());
+    if (first_it == state_.fuse_candidates.end()) {
+        return {};
+    }
+    auto* first_current = &first_it->second;
+
+    auto second_it = state_.fuse_candidates.find(second.element_id());
+    if (second_it == state_.fuse_candidates.end()) {
+        return {};
+    }
+    auto* second_current = &second_it->second;
+
+    bool no_data_conflicts = this->no_data_conflicts(*first_current, *second_current);
+    if (!no_data_conflicts) {
+        return {};
+    }
+
+    SymEngine::map_basic_basic indvar_mapping;
+    bool level_match;
+    int current_level = -1;
+    int last_matched_level = -1;
+    auto second_loop_info = state_.loop_analysis->loop_info(&second);
+    auto max_map_stack_depth =
+        std::min(state_.loop_analysis->loop_info(&first).map_stack_depth, second_loop_info.map_stack_depth) - 1;
+    bool keep_looking;
+
+    do {
+        keep_looking = false;
+        ++current_level;
+        indvar_mapping[first_current->loop->indvar()] = second_current->loop->indvar();
+
+        level_match = this->loop_match(*first_current, *second_current, indvar_mapping);
+        if (level_match) {
+            last_matched_level = current_level;
+            if (current_level < max_map_stack_depth) {
+                keep_looking = true;
+                first_current = state_.get_next_level_map_stack(*first_current);
+                second_current = state_.get_next_level_map_stack(*second_current);
+            }
+        }
+    } while (keep_looking);
+
+    if (last_matched_level >= 0) {
+        DEBUG_PRINTLN(
+            "Can fuse map stack (" << last_matched_level + 1 << " lvls): #" << first.element_id() << " | #"
+                                   << first_current->loop->element_id() << ", #" << second.element_id() << " | #"
+                                   << second_current->loop->element_id()
+        );
+
+        auto& target_root = second_current->loop->root();
+        bool keep_visiting_second =
+            fuse_contents(first_current, second_current, indvar_mapping, target_root, no_uses_between);
+
+        // if there are further loops inside the now fused body, visit those as well
+        return {.removed_first = false, .visit_second_body = keep_visiting_second};
+    }
+
+    return {};
+}
+
+bool MapFusionHandler::
+    loop_match(FusionLoopCandidate& first, FusionLoopCandidate& second, SymEngine::map_basic_basic& canonical_indvars) {
+    bool lower_match =
+        symbolic::eq(first.indvar_boundaries->tight_lower_bound(), second.indvar_boundaries->tight_lower_bound());
+    if (!lower_match) {
+        return false;
+    }
+    bool upper_match =
+        symbolic::eq(first.indvar_boundaries->tight_upper_bound(), second.indvar_boundaries->tight_upper_bound());
+    if (!upper_match) {
+        return false;
+    }
+    auto first_canonicalized_map = SymEngine::subs(first.indvar_boundaries->map(), canonical_indvars);
+    bool map_match = symbolic::eq(first_canonicalized_map, second.indvar_boundaries->map());
+    if (!map_match) {
+        return false;
+    }
+
+    return true;
+}
+
+bool MapFusionHandler::
+    no_data_conflicts(const FusionLoopCandidate& first_candidate, const FusionLoopCandidate& second_candidate) {
+    auto& first_args = *first_candidate.args;
+    auto& second_args = *second_candidate.args;
+    for (auto& [name, prod_meta] : first_args) {
+        auto cons_it = second_candidate.args->find(name);
+        if (cons_it != second_args.end()) {
+            // argument appears in both
+            auto& cons_meta = cons_it->second;
+            // any potential conflicts to check if both are maps?
+        }
+    }
+
+    return true;
+}
+
+void MapFusionHandler::update_fused_seq(Sequence& sequence, const symbolic::ExpressionMapping& replacements) {
+    sequence.replace(replacements);
+}
+
+NeighboringPatternVisitor::NeighboringPatternVisitor(PatternHandler& handler) : handler_(handler) {}
+
+bool NeighboringPatternVisitor::visit(sdfg::structured_control_flow::Sequence& node) {
+    if (node.size() < 2) { // impossible to find a match, just descend into it
+        return ActualStructuredSDFGVisitor::visit(node);
+    }
+
+    // Iterate over sequence looking for consecutive (Map, StructuredLoop) pairs
+    size_t i = 0;
+    while (i + 1 < node.size()) {
+        auto& child_node = node.at(i).first;
+        auto* first = dynamic_cast<structured_control_flow::Map*>(&child_node);
+        if (!first) {
+            i++;
+            dispatch(child_node);
+            continue;
+        }
+        if (first->root().size() == 0) {
+            i++;
+            continue;
+        }
+
+        if (auto* second = dynamic_cast<structured_control_flow::Map*>(&node.at(i + 1).first)) {
+            if (second->root().size() == 0) {
+                i++;
+                continue;
+            }
+
+            auto result = handler_.match(*first, *second, TODO);
+
+            if (!result.removed_first) {
+                dispatch(child_node);
+            }
+            if (result.visit_second_body) {
+                auto* second_updated_child = result.second_root_replacement ? result.second_root_replacement : second;
+                dispatch(*second_updated_child);
+            }
+        } else if (i + 2 < node.size()) {
+            auto* mid_block = dynamic_cast<structured_control_flow::Block*>(&node.at(i + 1).first);
+            if (mid_block && mid_block->is_a_library_node<stdlib::MallocNode>()) {
+                if (auto* second = dynamic_cast<structured_control_flow::Map*>(&node.at(i + 2).first)) {
+                    if (second->root().size() == 0) {
+                        i++;
+                        continue;
+                    }
+
+                    // until we support matching this, just keep visiting
+                    dispatch(child_node);
+                    dispatch(*second);
+                    // transformations::MapFusion transformation(*first, *second, false);
+                    // if (transformation.can_be_applied(builder_, analysis_manager_)) {
+                    //     auto first_name = first->indvar()->get_name();
+                    //     auto second_name = second->indvar()->get_name();
+                    //     transformation.apply(builder_, analysis_manager_);
+                    //     DEBUG_PRINTLN(
+                    //         "Applied MapFusion to map " + first_name + " and loop " + second_name +
+                    //         " with intermediate malloc block"
+                    //     );
+                    //     applied = true;
+                    //
+                    //     i = i + 2; // Skip over the newly moved malloc block and the second loop that was just fused
+                    //     continue;
+                    // }
+                }
+            }
+        }
+        i++;
+    }
+
+    return true;
+}
+
+} // namespace sdfg::passes

--- a/opt/src/passes/redundant_load_elimination_pass.cpp
+++ b/opt/src/passes/redundant_load_elimination_pass.cpp
@@ -40,7 +40,7 @@ bool RedundantLoadVisitor::visit(sdfg::structured_control_flow::Block& block) {
 
                 const data_flow::Subset* write_subset = nullptr;
                 const types::IType* write_type = nullptr;
-                auto* in_edge = dflow.in_edge(*access_node);
+                auto* in_edge = dflow.in_edge_if_single(*access_node); // not supported for multiple input edges
                 if (in_edge && in_edge->is_dst_pointed_to_write()) {
                     auto* src_node = dynamic_cast<const data_flow::CodeNode*>(&in_edge->src());
                     if (src_node) {

--- a/opt/src/passes/redundant_load_elimination_pass.cpp
+++ b/opt/src/passes/redundant_load_elimination_pass.cpp
@@ -14,85 +14,138 @@ RedundantLoadVisitor::
     RedundantLoadVisitor(builder::StructuredSDFGBuilder& builder, RedundantLoadEliminationPass::State& state)
     : builder_(builder), state_(state) {}
 
+struct RedundantCandidate {
+    data_flow::AccessNode* access_node;
+    const data_flow::Memlet* in_edge;
+    std::vector<data_flow::Memlet*> out_edges;
+    bool write_redundant = false;
+    bool too_complex = false;
+};
+
 bool RedundantLoadVisitor::visit(sdfg::structured_control_flow::Block& block) {
     auto& dflow = block.dataflow();
-    for (auto* access_node : dflow.data_nodes()) {
-        if (dynamic_cast<data_flow::ConstantNode*>(access_node) == nullptr) {
-            auto* in_edge = dflow.in_edge(*access_node);
-            if (!in_edge) {
-                continue;
-            }
-            auto* src_node = dynamic_cast<const data_flow::CodeNode*>(&in_edge->src());
-            if (!src_node) {
-                continue;
-            }
-            auto& type_to_match = in_edge->base_type();
-            auto& subset_to_match = in_edge->subset();
-            if (subset_to_match.empty()) {
-                continue;
-            }
+    auto topo = dflow.topological_sort();
 
-            auto out_edges = dflow.out_edges(*access_node);
+    std::vector<std::unique_ptr<RedundantCandidate>> candidates;
+    std::unordered_map<std::string, RedundantCandidate*> by_container;
 
-            bool matches = true;
-            for (auto& edge : out_edges) {
-                if (edge.base_type() != type_to_match) {
-                    matches = false;
-                    break;
+    for (auto* node : topo) {
+        if (auto* access_node = dynamic_cast<data_flow::AccessNode*>(node)) {
+            if (dynamic_cast<data_flow::ConstantNode*>(access_node) == nullptr) {
+                auto it = by_container.find(access_node->data());
+                RedundantCandidate* existing_candidate = nullptr;
+                if (it != by_container.end()) {
+                    existing_candidate = it->second;
                 }
 
-                if (!symbolic::vectors_of_expressions_match(edge.subset(), subset_to_match)) {
-                    matches = false;
-                    break;
-                }
-            }
-            if (matches) {
-                // redirect the write to a scalar temp. Then write into original access_node (indirect)
-                // replace all reads of the same index with reads of the temp
-                auto bypass_name = builder_.find_new_name();
-                auto bypass_type = in_edge->result_type(builder_.subject());
-                builder_.add_container(bypass_name, *bypass_type);
-                auto& bypass_access = builder_.add_access(block, bypass_name);
-                builder_.add_computational_memlet(
-                    block,
-                    *const_cast<data_flow::CodeNode*>(src_node),
-                    in_edge->src_conn(),
-                    bypass_access,
-                    {},
-                    *bypass_type,
-                    {}
-                );
-                auto& copy_tasklet = builder_.add_tasklet(block, data_flow::assign, "out", {"in"});
-                builder_.add_computational_memlet(block, bypass_access, copy_tasklet, "in", {}, *bypass_type);
-                builder_.add_computational_memlet(
-                    block, copy_tasklet, "out", *access_node, subset_to_match, type_to_match, in_edge->debug_info()
-                );
-
-                std::vector<data_flow::Memlet*> to_remove;
-                for (auto& replace : out_edges) {
-                    to_remove.push_back(&replace);
-                    builder_.add_memlet(
-                        block,
-                        bypass_access,
-                        "void",
-                        replace.dst(),
-                        replace.dst_conn(),
-                        {},
-                        *bypass_type,
-                        replace.debug_info()
-                    );
+                const data_flow::Subset* write_subset = nullptr;
+                const types::IType* write_type = nullptr;
+                auto* in_edge = dflow.in_edge(*access_node);
+                if (in_edge && in_edge->is_dst_pointed_to_write()) {
+                    auto* src_node = dynamic_cast<const data_flow::CodeNode*>(&in_edge->src());
+                    if (src_node) {
+                        write_subset = &in_edge->subset();
+                        write_type = &in_edge->base_type();
+                    }
                 }
 
-                builder_.remove_memlet(block, *in_edge);
-                in_edge = nullptr;
-                for (auto* memlet : to_remove) {
-                    builder_.remove_memlet(block, *memlet);
-                }
+                if (existing_candidate && write_subset) {
+                    if (symbolic::vectors_of_expressions_match(*write_subset, existing_candidate->in_edge->subset())) {
+                        existing_candidate->write_redundant = true;
+                        continue;
+                    } else {
+                        existing_candidate->too_complex = true;
+                        continue;
+                    }
+                } else if (!existing_candidate && write_subset) {
+                    auto out_edges = dflow.out_edges(*access_node);
 
-                state_.optimized++;
+                    bool any_reads = false;
+                    bool reads_match_write_edge = true;
+                    for (auto& edge : out_edges) {
+                        any_reads = true;
+                        if (edge.base_type() != *write_type || !edge.is_src_pointed_to_read()) {
+                            reads_match_write_edge = false;
+                            break;
+                        }
+
+                        if (!symbolic::vectors_of_expressions_match(edge.subset(), *write_subset)) {
+                            reads_match_write_edge = false;
+                            break;
+                        }
+                    }
+
+                    if (any_reads && reads_match_write_edge) {
+                        auto& candidate = candidates.emplace_back(std::make_unique<RedundantCandidate>());
+                        candidate->access_node = access_node;
+                        candidate->in_edge = in_edge;
+                        std::ranges::transform(out_edges, std::back_inserter(candidate->out_edges), [](auto& edge) {
+                            return &edge;
+                        });
+                        by_container[access_node->data()] = candidate.get();
+                    }
+                }
             }
         }
     }
+
+    for (auto& candidate : candidates) {
+        if (!candidate->too_complex) {
+            // redirect the write to a scalar temp. Then write into original access_node (indirect)
+            // replace all reads of the same index with reads of the temp
+            auto& access_node = *candidate->access_node;
+            auto& in_edge = *candidate->in_edge;
+            auto& out_edges = candidate->out_edges;
+
+            auto bypass_name = builder_.find_new_name("rle_");
+            auto bypass_type = in_edge.result_type(builder_.subject());
+            builder_.add_container(bypass_name, *bypass_type);
+            auto& bypass_access = builder_.add_access(block, bypass_name);
+            builder_.add_computational_memlet(
+                block,
+                const_cast<data_flow::CodeNode&>(static_cast<const data_flow::CodeNode&>(in_edge.src())),
+                in_edge.src_conn(),
+                bypass_access,
+                {},
+                *bypass_type,
+                {}
+            );
+            if (!candidate->write_redundant) {
+                auto& copy_tasklet = builder_.add_tasklet(block, data_flow::assign, "out", {"in"});
+                builder_.add_computational_memlet(block, bypass_access, copy_tasklet, "in", {}, *bypass_type);
+                builder_.add_computational_memlet(
+                    block,
+                    copy_tasklet,
+                    "out",
+                    *candidate->access_node,
+                    in_edge.subset(),
+                    in_edge.base_type(),
+                    in_edge.debug_info()
+                );
+            }
+
+            for (auto* replace : out_edges) {
+                builder_.add_memlet(
+                    block,
+                    bypass_access,
+                    "void",
+                    replace->dst(),
+                    replace->dst_conn(),
+                    {},
+                    *bypass_type,
+                    replace->debug_info()
+                );
+            }
+
+            builder_.remove_memlet(block, in_edge);
+            for (auto* memlet : out_edges) {
+                builder_.remove_memlet(block, *memlet);
+            }
+
+            state_.optimized++;
+        }
+    }
+
     return true;
 }
 

--- a/opt/src/passes/redundant_load_elimination_pass.cpp
+++ b/opt/src/passes/redundant_load_elimination_pass.cpp
@@ -1,0 +1,109 @@
+#include "sdfg/passes/redundant_load_elimination_pass.h"
+
+#include "sdfg/analysis/assumptions_analysis.h"
+#include "sdfg/analysis/base_user_visitor.h"
+#include "sdfg/data_flow/library_nodes/stdlib/malloc.h"
+#include "sdfg/deepcopy/structured_sdfg_deep_copy.h"
+#include "sdfg/symbolic/utils.h"
+#include "sdfg/visitor/structured_sdfg_visitor.h"
+#include "symengine/subs.h"
+
+namespace sdfg::passes {
+
+RedundantLoadVisitor::
+    RedundantLoadVisitor(builder::StructuredSDFGBuilder& builder, RedundantLoadEliminationPass::State& state)
+    : builder_(builder), state_(state) {}
+
+bool RedundantLoadVisitor::visit(sdfg::structured_control_flow::Block& block) {
+    auto& dflow = block.dataflow();
+    for (auto* access_node : dflow.data_nodes()) {
+        if (dynamic_cast<data_flow::ConstantNode*>(access_node) == nullptr) {
+            auto* in_edge = dflow.in_edge(*access_node);
+            if (!in_edge) {
+                continue;
+            }
+            auto* src_node = dynamic_cast<const data_flow::CodeNode*>(&in_edge->src());
+            if (!src_node) {
+                continue;
+            }
+            auto& type_to_match = in_edge->base_type();
+            auto& subset_to_match = in_edge->subset();
+            if (subset_to_match.empty()) {
+                continue;
+            }
+
+            auto out_edges = dflow.out_edges(*access_node);
+
+            bool matches = true;
+            for (auto& edge : out_edges) {
+                if (edge.base_type() != type_to_match) {
+                    matches = false;
+                    break;
+                }
+
+                if (!symbolic::vectors_of_expressions_match(edge.subset(), subset_to_match)) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) {
+                // redirect the write to a scalar temp. Then write into original access_node (indirect)
+                // replace all reads of the same index with reads of the temp
+                auto bypass_name = builder_.find_new_name();
+                auto bypass_type = in_edge->result_type(builder_.subject());
+                builder_.add_container(bypass_name, *bypass_type);
+                auto& bypass_access = builder_.add_access(block, bypass_name);
+                builder_.add_computational_memlet(
+                    block,
+                    *const_cast<data_flow::CodeNode*>(src_node),
+                    in_edge->src_conn(),
+                    bypass_access,
+                    {},
+                    *bypass_type,
+                    {}
+                );
+                auto& copy_tasklet = builder_.add_tasklet(block, data_flow::assign, "out", {"in"});
+                builder_.add_computational_memlet(block, bypass_access, copy_tasklet, "in", {}, *bypass_type);
+                builder_.add_computational_memlet(
+                    block, copy_tasklet, "out", *access_node, subset_to_match, type_to_match, in_edge->debug_info()
+                );
+
+                std::vector<data_flow::Memlet*> to_remove;
+                for (auto& replace : out_edges) {
+                    to_remove.push_back(&replace);
+                    builder_.add_memlet(
+                        block,
+                        bypass_access,
+                        "void",
+                        replace.dst(),
+                        replace.dst_conn(),
+                        {},
+                        *bypass_type,
+                        replace.debug_info()
+                    );
+                }
+
+                builder_.remove_memlet(block, *in_edge);
+                in_edge = nullptr;
+                for (auto* memlet : to_remove) {
+                    builder_.remove_memlet(block, *memlet);
+                }
+
+                state_.optimized++;
+            }
+        }
+    }
+    return true;
+}
+
+bool RedundantLoadEliminationPass::
+    run_pass(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {
+    State state;
+
+    RedundantLoadVisitor v(builder, state);
+    v.dispatch(builder.subject().root());
+
+    return state.optimized > 0;
+}
+
+} // namespace sdfg::passes

--- a/opt/src/targets/cuda/cuda_map_dispatcher.cpp
+++ b/opt/src/targets/cuda/cuda_map_dispatcher.cpp
@@ -348,6 +348,8 @@ void CUDAMapDispatcher::dispatch_kernel_preamble(
     auto y_maps = gpu::get_gpu_maps<ScheduleType_CUDA>(node_, analysis_manager, CUDADimension::Y);
     auto z_maps = gpu::get_gpu_maps<ScheduleType_CUDA>(node_, analysis_manager, CUDADimension::Z);
 
+    std::unordered_map<std::string, symbolic::Expression> indvars;
+
     auto emit_indvar = [&](structured_control_flow::Map* map, const std::string& flat_id_var) {
         symbolic::Expression value = symbolic::symbol(flat_id_var);
         auto stride = map->stride();
@@ -358,8 +360,21 @@ void CUDAMapDispatcher::dispatch_kernel_preamble(
         if (!symbolic::eq(init, symbolic::zero())) {
             value = symbolic::add(init, value);
         }
-        library_stream << "int " << map->indvar()->get_name() << " = " << this->language_extension_.expression(value)
-                       << ";" << std::endl;
+        auto indvar_name = map->indvar()->get_name();
+        auto it = indvars.find(indvar_name);
+        if (it != indvars.end()) {
+            if (!symbolic::eq(it->second, value)) {
+                throw InvalidSDFGException(
+                    "Conflicting expressions for Map #" + std::to_string(node_.element_id()) + " indvar " +
+                    map->indvar()->get_name() + ": " + this->language_extension_.expression(it->second) + " vs " +
+                    this->language_extension_.expression(value)
+                );
+            }
+        } else {
+            library_stream << "int " << indvar_name << " = " << this->language_extension_.expression(value) << ";"
+                           << std::endl;
+            indvars.emplace(indvar_name, value);
+        }
     };
 
     for (auto* map : x_maps) {

--- a/opt/tests/CMakeLists.txt
+++ b/opt/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(TEST_FILES
     optimizations/diamond_tiling_test.cpp
     optimizations/blocking_test.cpp
     optimizations/gpu_kernels_test.cpp
+    passes/map_fusion_by_domain_pass_test.cpp
     passes/offloading/cuda_library_node_transfer_extraction_pass_test.cpp
     passes/offloading/cuda_library_node_expand_tests.cpp
     passes/offloading/rocm_library_node_expand_tests.cpp

--- a/opt/tests/CMakeLists.txt
+++ b/opt/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ set(TEST_FILES
     optimizations/blocking_test.cpp
     optimizations/gpu_kernels_test.cpp
     passes/map_fusion_by_domain_pass_test.cpp
+    passes/redundant_load_elimination_pass_test.cpp
     passes/offloading/cuda_library_node_transfer_extraction_pass_test.cpp
     passes/offloading/cuda_library_node_expand_tests.cpp
     passes/offloading/rocm_library_node_expand_tests.cpp

--- a/opt/tests/loop_info_debug_dump.h
+++ b/opt/tests/loop_info_debug_dump.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <sdfg/analysis/analysis.h>
+
+void dump_loop_info(const sdfg::analysis::LoopAnalysis& analysis, const std::string& step);

--- a/opt/tests/passes/map_fusion_by_domain_pass_test.cpp
+++ b/opt/tests/passes/map_fusion_by_domain_pass_test.cpp
@@ -1,0 +1,169 @@
+#include "sdfg/passes/map_fusion_by_domain_pass.h"
+
+#include <gtest/gtest.h>
+
+#include "loop_info_debug_dump.h"
+#include "sdfg/analysis/assumptions_analysis.h"
+#include "sdfg/analysis/loop_analysis.h"
+#include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/data_flow/library_nodes/stdlib/malloc.h"
+#include "sdfg/passes/dataflow/tasklet_fusion.h"
+#include "sdfg/passes/pipeline.h"
+#include "sdfg/passes/redundant_load_elimination_pass.h"
+#include "sdfg/structured_control_flow/map.h"
+#include "sdfg/structured_control_flow/structured_loop.h"
+#include "sdfg_debug_dump.h"
+
+using namespace sdfg;
+using namespace sdfg::passes;
+
+class MultiNestBuilder {
+public:
+    builder::StructuredSDFGBuilder& builder;
+    MultiNestBuilder(builder::StructuredSDFGBuilder& builder) : builder(builder) {}
+
+    ScheduleType sched_ = ScheduleType_Sequential::create();
+    Sequence& root = builder.subject().root();
+
+    Map& add_map(Sequence& parent, const std::string& iv) {
+        builder.add_container(iv, types::Scalar(types::PrimitiveType::Int32));
+        auto sym = symbolic::symbol(iv);
+        return builder.add_map(
+            parent,
+            sym,
+            symbolic::Lt(sym, symbolic::symbol("N")),
+            symbolic::zero(),
+            symbolic::add(sym, symbolic::one()),
+            sched_
+        );
+    }
+    For& add_for(Sequence& parent, const std::string& iv) {
+        builder.add_container(iv, types::Scalar(types::PrimitiveType::Int32));
+        auto sym = symbolic::symbol(iv);
+        return builder.add_for(
+            parent, sym, symbolic::Lt(sym, symbolic::symbol("N")), symbolic::zero(), symbolic::add(sym, symbolic::one())
+        );
+    }
+};
+
+TEST(MapFusionByDomainTest, FuseMultipleStacks) {
+    builder::StructuredSDFGBuilder builder("map_fuse_stacks", FunctionType_CPU);
+    MultiNestBuilder m(builder);
+
+    types::Scalar scalar(types::PrimitiveType::Float);
+    types::Pointer ptr(scalar);
+    types::Scalar itype(types::PrimitiveType::Int32);
+
+    builder.add_container("N", scalar, true);
+    builder.add_container("A", ptr, true);
+    builder.add_container("_tmp_15", ptr, false);
+    builder.add_container("B", ptr, true);
+    builder.add_container("C", ptr, true);
+    builder.add_container("ret", ptr, true);
+
+    auto& malloc_tmp = builder.add_block(m.root);
+    {
+        auto& acc_tmp = builder.add_access(malloc_tmp, "_tmp_15");
+        auto& malloc_node =
+            builder.add_library_node<stdlib::MallocNode>(malloc_tmp, DebugInfo(), symbolic::parse("N*N*N*4"));
+        builder.add_computational_memlet(malloc_tmp, malloc_node, "_ret", acc_tmp, {}, ptr);
+    }
+
+    auto& a0 = m.add_map(m.root, "a_i");
+    auto& a1 = m.add_map(a0.root(), "a_j");
+    auto& a2 = m.add_map(a1.root(), "a_k");
+    auto& a2_block = builder.add_block(a2.root());
+    {
+        auto& acc_B = builder.add_access(a2_block, "B");
+        auto& acc_const = builder.add_constant(a2_block, "2.0", scalar);
+        auto& acc_out = builder.add_access(a2_block, "_tmp_15");
+        auto& tasklet = builder.add_tasklet(a2_block, data_flow::TaskletCode::fp_add, {"_out"}, {"_in1", "_in2"});
+        builder.add_computational_memlet(a2_block, acc_B, tasklet, "_in1", {symbolic::parse("a_k+a_j*N+a_i*N*N")}, ptr);
+        builder.add_computational_memlet(a2_block, acc_const, tasklet, "_in2", {}, scalar);
+        builder
+            .add_computational_memlet(a2_block, tasklet, "_out", acc_out, {symbolic::parse("a_k+a_j*N+a_i*N*N")}, ptr);
+    }
+
+    auto& b0 = m.add_map(m.root, "b_i");
+    auto& b1 = m.add_map(b0.root(), "b_j");
+    auto& b2 = m.add_map(b1.root(), "b_k");
+    auto& b2_block = builder.add_block(b2.root());
+    {
+        auto& acc_tmp = builder.add_access(b2_block, "_tmp_15");
+        auto& acc_out = builder.add_access(b2_block, "A");
+        auto& tasklet = builder.add_tasklet(b2_block, data_flow::TaskletCode::assign, {"_out"}, {"_in"});
+        builder.add_computational_memlet(b2_block, acc_tmp, tasklet, "_in", {symbolic::parse("b_k+b_j*N+b_i*N*N")}, ptr);
+        builder
+            .add_computational_memlet(b2_block, tasklet, "_out", acc_out, {symbolic::parse("b_k+b_j*N+(b_i-5)*N*N")}, ptr);
+    }
+
+    auto& c0 = m.add_map(m.root, "c_i");
+    auto& c1 = m.add_map(c0.root(), "c_j");
+    auto& c2 = m.add_map(c1.root(), "c_k");
+    auto& c2_block = builder.add_block(c2.root());
+    {
+        auto& acc_A = builder.add_access(c2_block, "A");
+        auto& acc_const = builder.add_constant(c2_block, "1.0", scalar);
+        auto& acc_out = builder.add_access(c2_block, "ret");
+        auto& tasklet = builder.add_tasklet(c2_block, data_flow::TaskletCode::fp_add, {"_out"}, {"_in1", "_in2"});
+        builder
+            .add_computational_memlet(c2_block, acc_A, tasklet, "_in1", {symbolic::parse("c_k+c_j*N+(c_i-5)*N*N")}, ptr);
+        builder.add_computational_memlet(c2_block, acc_const, tasklet, "_in2", {}, scalar);
+        builder
+            .add_computational_memlet(c2_block, tasklet, "_out", acc_out, {symbolic::parse("c_k+c_j*N+c_i*N*N")}, ptr);
+    }
+
+    auto& d0 = m.add_map(m.root, "d_i");
+    auto& d1 = m.add_map(d0.root(), "d_j");
+    auto& d2 = m.add_map(d1.root(), "d_k");
+    auto& d2_block = builder.add_block(d2.root());
+    {
+        auto& acc_B = builder.add_access(d2_block, "B");
+        auto& acc_const = builder.add_access(d2_block, "_tmp_15");
+        auto& acc_out = builder.add_access(d2_block, "C");
+        auto& tasklet = builder.add_tasklet(d2_block, data_flow::TaskletCode::fp_add, {"_out"}, {"_in1", "_in2"});
+        builder
+            .add_computational_memlet(d2_block, acc_B, tasklet, "_in1", {symbolic::parse("10+a_k+a_j*N+a_i*N*N")}, ptr);
+        builder
+            .add_computational_memlet(d2_block, acc_const, tasklet, "_in2", {symbolic::parse("-5+a_k+a_j*N+a_i*N*N")}, ptr);
+        builder
+            .add_computational_memlet(d2_block, tasklet, "_out", acc_out, {symbolic::parse("c_k+c_j*N+c_i*N*N")}, ptr);
+    }
+
+    analysis::AnalysisManager analysis_manager(builder.subject());
+    auto& loops = analysis_manager.get<analysis::LoopAnalysis>();
+
+    builder.subject().add_metadata("output_dir", "test_outputs/MapFusionByDomainTest/FuseMultipleStacks");
+
+    dump_loop_info(loops, "0.init");
+    dump_sdfg(builder.subject(), "0.init");
+
+    builder.subject().validate();
+    analysis_manager.invalidate_all();
+
+    MapFusionByDomainPass pass;
+    pass.run_pass(builder, analysis_manager);
+
+    auto& loops2 = analysis_manager.get<analysis::LoopAnalysis>();
+    dump_loop_info(loops2, "1.fused");
+    analysis_manager.invalidate_all();
+    dump_sdfg(builder.subject(), "1.fused");
+
+    sdfg::passes::DeadDataElimination dde;
+    dde.run(builder, analysis_manager);
+    sdfg::passes::Pipeline dce = sdfg::passes::Pipeline::dead_code_elimination();
+    dce.run(builder, analysis_manager);
+    sdfg::passes::Pipeline block_fusion("BlockFusion");
+    block_fusion.register_pass<sdfg::passes::BlockFusionPass>();
+    block_fusion.run(builder, analysis_manager);
+
+    dump_sdfg(builder.subject(), "2.cleanup");
+
+    sdfg::passes::RedundantLoadEliminationPass rle;
+    rle.run(builder, analysis_manager);
+    dde.run(builder, analysis_manager);
+    sdfg::passes::TaskletFusionPass task_fuse_pass;
+    task_fuse_pass.run(builder, analysis_manager);
+
+    dump_sdfg(builder.subject(), "3.rle");
+}

--- a/opt/tests/passes/map_fusion_by_domain_pass_test.cpp
+++ b/opt/tests/passes/map_fusion_by_domain_pass_test.cpp
@@ -72,6 +72,7 @@ TEST(MapFusionByDomainTest, FuseMultipleStacks) {
     auto& a0 = m.add_map(m.root, "a_i");
     auto& a1 = m.add_map(a0.root(), "a_j");
     auto& a2 = m.add_map(a1.root(), "a_k");
+    std::vector<ElementId> a_org_ids{a0.element_id(), a1.element_id(), a2.element_id()};
     auto& a2_block = builder.add_block(a2.root());
     {
         auto& acc_B = builder.add_access(a2_block, "B");
@@ -100,6 +101,7 @@ TEST(MapFusionByDomainTest, FuseMultipleStacks) {
     auto& c0 = m.add_map(m.root, "c_i");
     auto& c1 = m.add_map(c0.root(), "c_j");
     auto& c2 = m.add_map(c1.root(), "c_k");
+    std::vector<ElementId> c_org_ids{c0.element_id(), c1.element_id(), c2.element_id()};
     auto& c2_block = builder.add_block(c2.root());
     {
         auto& acc_A = builder.add_access(c2_block, "A");
@@ -113,9 +115,11 @@ TEST(MapFusionByDomainTest, FuseMultipleStacks) {
             .add_computational_memlet(c2_block, tasklet, "_out", acc_out, {symbolic::parse("c_k+c_j*N+c_i*N*N")}, ptr);
     }
 
+    // 4th stack, to have conflicts with the fused result of stack a-c on _tmp
     auto& d0 = m.add_map(m.root, "d_i");
     auto& d1 = m.add_map(d0.root(), "d_j");
     auto& d2 = m.add_map(d1.root(), "d_k");
+    std::vector<ElementId> d_org_ids{d0.element_id(), d1.element_id(), d2.element_id()};
     auto& d2_block = builder.add_block(d2.root());
     {
         auto& acc_B = builder.add_access(d2_block, "B");
@@ -146,8 +150,38 @@ TEST(MapFusionByDomainTest, FuseMultipleStacks) {
 
     auto& loops2 = analysis_manager.get<analysis::LoopAnalysis>();
     dump_loop_info(loops2, "1.fused");
-    analysis_manager.invalidate_all();
     dump_sdfg(builder.subject(), "1.fused");
+
+    auto& root = builder.subject().root();
+    EXPECT_EQ(root.size(), 3);
+    EXPECT_EQ(&root.at(0).first, &malloc_tmp);
+    EXPECT_EQ(loops2.children(nullptr).size(), 2); // root loops
+
+    EXPECT_FALSE(builder.find_element_by_id(a_org_ids.at(0))); // a0 no longer in the SDFG
+
+    EXPECT_EQ(root.at(1).first.element_id(), c_org_ids.at(0));
+    auto& c_outer = dynamic_cast<Map&>(root.at(1).first);
+    EXPECT_EQ(c_outer.root().size(), 1);
+    EXPECT_EQ(loops2.children(&c_outer).size(), 1);
+    EXPECT_TRUE(loops2.loop_info(&c_outer).is_perfectly_nested);
+    EXPECT_TRUE(loops2.loop_info(&c_outer).is_perfectly_parallel);
+    EXPECT_EQ(c_outer.root().at(0).first.element_id(), c_org_ids.at(1));
+    auto& c_middle = dynamic_cast<Map&>(c_outer.root().at(0).first);
+    EXPECT_EQ(c_middle.root().size(), 1);
+    EXPECT_EQ(c_middle.root().at(0).first.element_id(), c_org_ids.at(2));
+
+    EXPECT_EQ(root.at(2).first.element_id(), d_org_ids.at(0));
+    auto& d_outer = dynamic_cast<Map&>(root.at(2).first);
+    EXPECT_EQ(d_outer.root().size(), 1);
+    EXPECT_EQ(loops2.children(&d_outer).size(), 1);
+    EXPECT_TRUE(loops2.loop_info(&d_outer).is_perfectly_nested);
+    EXPECT_TRUE(loops2.loop_info(&d_outer).is_perfectly_parallel);
+    EXPECT_EQ(d_outer.root().at(0).first.element_id(), d_org_ids.at(1));
+    auto& d_middle = dynamic_cast<Map&>(d_outer.root().at(0).first);
+    EXPECT_EQ(d_middle.root().size(), 1);
+    EXPECT_EQ(d_middle.root().at(0).first.element_id(), d_org_ids.at(2));
+
+    analysis_manager.invalidate_all();
 
     sdfg::passes::DeadDataElimination dde;
     dde.run(builder, analysis_manager);

--- a/opt/tests/passes/redundant_load_elimination_pass_test.cpp
+++ b/opt/tests/passes/redundant_load_elimination_pass_test.cpp
@@ -1,0 +1,228 @@
+#include "sdfg/passes/redundant_load_elimination_pass.h"
+
+#include <gtest/gtest.h>
+
+#include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg_debug_dump.h"
+
+using namespace sdfg;
+
+// A tasklet computes a value, the result is stored into A[0] (an indirect /
+// pointed-to write) and then immediately read back from A[0]. The pass must
+// reroute the read directly from the producing tasklet (via a scalar bypass)
+// while keeping the original write intact.
+TEST(RedundantLoadEliminationPassTest, RedundantLoad_ReroutesReadAndKeepsWrite) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+
+    types::Scalar desc_element(types::PrimitiveType::Double);
+    types::Pointer desc_pointer(desc_element);
+    builder.add_container("A", desc_pointer);
+    builder.add_container("B", desc_pointer);
+
+    auto& root = builder.subject().root();
+    auto& block = builder.add_block(root, control_flow::Assignments{});
+
+    // tasklet computing A[0] = 1.0 + 2.0
+    auto& one_node = builder.add_constant(block, "1", desc_element);
+    auto& two_node = builder.add_constant(block, "2", desc_element);
+    auto& acc_a = builder.add_access(block, "A");
+    auto& tasklet_write = builder.add_tasklet(block, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+    builder.add_computational_memlet(block, one_node, tasklet_write, "_in1", {});
+    builder.add_computational_memlet(block, two_node, tasklet_write, "_in2", {});
+    builder.add_computational_memlet(block, tasklet_write, "_out", acc_a, {symbolic::integer(0)}, desc_pointer);
+
+    // immediate read of A[0] forwarded into B[0]
+    auto& acc_b = builder.add_access(block, "B");
+    auto& tasklet_read = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(block, acc_a, tasklet_read, "_in", {symbolic::integer(0)}, desc_pointer);
+    builder.add_computational_memlet(block, tasklet_read, "_out", acc_b, {symbolic::integer(0)}, desc_pointer);
+
+    dump_sdfg(builder.subject(), "0.init");
+
+    auto sdfg = builder.move();
+    EXPECT_EQ(sdfg->root().size(), 1);
+
+    builder::StructuredSDFGBuilder builder_opt(sdfg);
+    analysis::AnalysisManager analysis_manager(builder_opt.subject());
+    passes::RedundantLoadEliminationPass pass;
+    EXPECT_TRUE(pass.run_pass(builder_opt, analysis_manager));
+
+    sdfg = builder_opt.move();
+    dump_sdfg(*sdfg, "1.rle");
+    EXPECT_EQ(sdfg->root().size(), 1);
+
+    // A scalar bypass container must have been introduced.
+    bool found_bypass = false;
+    for (auto& name : sdfg->containers()) {
+        if (name.rfind("rle_", 0) == 0) {
+            found_bypass = true;
+        }
+    }
+    EXPECT_TRUE(found_bypass);
+
+    auto* result_block = dynamic_cast<const structured_control_flow::Block*>(&sdfg->root().at(0).first);
+    ASSERT_NE(result_block, nullptr);
+    auto& dataflow = result_block->dataflow();
+
+    // Original 6 nodes + bypass access + copy tasklet = 8 nodes.
+    EXPECT_EQ(dataflow.nodes().size(), 8);
+    // Original 5 edges become 7 (write split into producer->bypass->copy->A, plus rerouted read).
+    EXPECT_EQ(dataflow.edges().size(), 7);
+
+    // The indirect write into A is preserved: A still receives exactly one write.
+    size_t a_writes = 0;
+    for (auto& node : dataflow.nodes()) {
+        if (auto* an = dynamic_cast<const data_flow::AccessNode*>(&node)) {
+            if (dynamic_cast<const data_flow::ConstantNode*>(an) == nullptr && an->data() == "A") {
+                a_writes += dataflow.in_degree(*an);
+            }
+        }
+    }
+    EXPECT_EQ(a_writes, 1);
+}
+
+// Two writes to the very same index A[0] appear in one block, with a read of
+// A[0] in between. Because the graph has no order-dependency edges, the first
+// (redundant) write is simply removed since it would be overwritten by the
+// second write anyway. The first access node is left without any incident
+// edges, the second write is kept.
+TEST(RedundantLoadEliminationPassTest, ConsecutiveWriteSameIndex_RemovesFirstWrite) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+
+    types::Scalar desc_element(types::PrimitiveType::Double);
+    types::Pointer desc_pointer(desc_element);
+    builder.add_container("A", desc_pointer);
+    builder.add_container("s", desc_element);
+
+    auto& root = builder.subject().root();
+    auto& block = builder.add_block(root, control_flow::Assignments{});
+
+    // First write: A[0] = 1.0
+    auto& const0 = builder.add_constant(block, "1", desc_element);
+    auto& acc_a1 = builder.add_access(block, "A");
+    auto& tasklet_w1 = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(block, const0, tasklet_w1, "_in", {});
+    builder.add_computational_memlet(block, tasklet_w1, "_out", acc_a1, {symbolic::integer(0)}, desc_pointer);
+
+    // Read of A[0] into scalar s (forces an ordering A1 -> ... -> A2 in topo sort).
+    auto& acc_s = builder.add_access(block, "s");
+    auto& tasklet_read = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(block, acc_a1, tasklet_read, "_in", {symbolic::integer(0)}, desc_pointer);
+    builder.add_computational_memlet(block, tasklet_read, "_out", acc_s, {});
+
+    // Second write to the same index: A[0] = s
+    auto& acc_a2 = builder.add_access(block, "A");
+    auto& tasklet_w2 = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(block, acc_s, tasklet_w2, "_in", {});
+    builder.add_computational_memlet(block, tasklet_w2, "_out", acc_a2, {symbolic::integer(0)}, desc_pointer);
+
+    dump_sdfg(builder.subject(), "0.init");
+
+    auto sdfg = builder.move();
+
+    builder::StructuredSDFGBuilder builder_opt(sdfg);
+    analysis::AnalysisManager analysis_manager(builder_opt.subject());
+    passes::RedundantLoadEliminationPass pass;
+    EXPECT_TRUE(pass.run_pass(builder_opt, analysis_manager));
+
+    sdfg = builder_opt.move();
+    dump_sdfg(*sdfg, "1.rle");
+    EXPECT_EQ(sdfg->root().size(), 1);
+
+    auto* result_block = dynamic_cast<const structured_control_flow::Block*>(&sdfg->root().at(0).first);
+    ASSERT_NE(result_block, nullptr);
+    auto& dataflow = result_block->dataflow();
+
+    // Of the two access nodes for "A", exactly one is fully disconnected (the
+    // removed redundant write) and exactly one still carries the kept write.
+    size_t disconnected_a = 0;
+    size_t written_a = 0;
+    for (auto& node : dataflow.nodes()) {
+        if (auto* an = dynamic_cast<const data_flow::AccessNode*>(&node)) {
+            if (dynamic_cast<const data_flow::ConstantNode*>(an) == nullptr && an->data() == "A") {
+                if (dataflow.in_degree(*an) == 0 && dataflow.out_degree(*an) == 0) {
+                    disconnected_a++;
+                } else if (dataflow.in_degree(*an) == 1) {
+                    written_a++;
+                }
+            }
+        }
+    }
+    EXPECT_EQ(disconnected_a, 1);
+    EXPECT_EQ(written_a, 1);
+
+    // No copy-back tasklet is generated for a redundant write, so the bypass is
+    // wired directly; the original first write is gone.
+    bool found_bypass = false;
+    for (auto& name : sdfg->containers()) {
+        if (name.rfind("rle_", 0) == 0) {
+            found_bypass = true;
+        }
+    }
+    EXPECT_TRUE(found_bypass);
+}
+
+// Regression test: an access node with more than one incoming write edge (here
+// two writes at different offsets A[0] and A[1]) must neither match the
+// redundant-load criteria nor crash the pass. Such an access node only shares
+// the base pointer between independent writes at distinct subsets.
+TEST(RedundantLoadEliminationPassTest, DoesNotCrashOn_MultiInputAccessNode) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+
+    types::Scalar desc_element(types::PrimitiveType::Double);
+    types::Pointer desc_pointer(desc_element);
+    builder.add_container("A", desc_pointer);
+    builder.add_container("B", desc_pointer);
+
+    auto& root = builder.subject().root();
+    auto& block = builder.add_block(root, control_flow::Assignments{});
+
+    auto& acc_a = builder.add_access(block, "A");
+
+    // Write A[0] = 1.0
+    auto& const0 = builder.add_constant(block, "1", desc_element);
+    auto& tasklet_w0 = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(block, const0, tasklet_w0, "_in", {});
+    builder.add_computational_memlet(block, tasklet_w0, "_out", acc_a, {symbolic::integer(0)}, desc_pointer);
+
+    // Write A[1] = 2.0 (different offset, same base pointer)
+    auto& const1 = builder.add_constant(block, "2", desc_element);
+    auto& tasklet_w1 = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(block, const1, tasklet_w1, "_in", {});
+    builder.add_computational_memlet(block, tasklet_w1, "_out", acc_a, {symbolic::integer(1)}, desc_pointer);
+
+    // Read A[0] into B[0]
+    auto& acc_b = builder.add_access(block, "B");
+    auto& tasklet_read = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(block, acc_a, tasklet_read, "_in", {symbolic::integer(0)}, desc_pointer);
+    builder.add_computational_memlet(block, tasklet_read, "_out", acc_b, {symbolic::integer(0)}, desc_pointer);
+
+    dump_sdfg(builder.subject(), "0.init");
+
+    auto sdfg = builder.move();
+
+    builder::StructuredSDFGBuilder builder_opt(sdfg);
+    analysis::AnalysisManager analysis_manager(builder_opt.subject());
+    passes::RedundantLoadEliminationPass pass;
+    // Multiple input edges disqualify the access node: no optimization, no crash.
+    EXPECT_FALSE(pass.run_pass(builder_opt, analysis_manager));
+
+    sdfg = builder_opt.move();
+    dump_sdfg(*sdfg, "1.rle");
+    EXPECT_EQ(sdfg->root().size(), 1);
+
+    auto* result_block = dynamic_cast<const structured_control_flow::Block*>(&sdfg->root().at(0).first);
+    ASSERT_NE(result_block, nullptr);
+    auto& dataflow = result_block->dataflow();
+
+    // Both writes to A are still present.
+    size_t a_writes = 0;
+    for (auto& node : dataflow.nodes()) {
+        if (auto* an = dynamic_cast<const data_flow::AccessNode*>(&node)) {
+            if (dynamic_cast<const data_flow::ConstantNode*>(an) == nullptr && an->data() == "A") {
+                a_writes += dataflow.in_degree(*an);
+            }
+        }
+    }
+    EXPECT_EQ(a_writes, 2);
+}

--- a/opt/tests/test.cpp
+++ b/opt/tests/test.cpp
@@ -42,3 +42,13 @@ void dump_sdfg(const sdfg::StructuredSDFG& sdfg, const std::string& step) {
         sdfg::visualizer::DotVisualizer::writeToFile(sdfg, base_path / (sdfg.name() + "." + step + ".sdfg.dot"));
     }
 }
+
+void dump_loop_info(const sdfg::analysis::LoopAnalysis& analysis, const std::string& step) {
+    if (test_output_dir) {
+        auto info = ::testing::UnitTest::GetInstance()->current_test_info();
+        auto suite_name = info->test_suite_name();
+        auto test_name = info->name();
+        auto base_path = test_output_dir.value() / suite_name / test_name;
+        analysis.dump_to_file(base_path / (step + ".loop_info.json"));
+    }
+}

--- a/opt/tests/test.cpp
+++ b/opt/tests/test.cpp
@@ -8,6 +8,8 @@
 #include "sdfg/targets/vectorize/plugin.h"
 #include "sdfg/visualizer/dot_visualizer.h"
 
+#include "sdfg_debug_dump.h"
+
 static std::optional<std::filesystem::path> test_output_dir;
 
 int main(int argc, char** argv) {

--- a/python/benchmarks/npbench/cavity_flow/test_cavity_flow.py
+++ b/python/benchmarks/npbench/cavity_flow/test_cavity_flow.py
@@ -133,20 +133,20 @@ def test_cavity_flow(target):
     verifier = None
     if target == "none":
         verifier = SDFGVerification(
-            verification={"MAP": 76, "SEQUENTIAL": 76, "FOR": 80}
+            verification={"MAP": 61, "SEQUENTIAL": 61, "FOR": 65}
         )
     elif target == "sequential":
         verifier = SDFGVerification(
-            verification={"VECTORIZE": 43, "MAP": 76, "SEQUENTIAL": 33, "FOR": 80}
+            verification={"VECTORIZE": 35, "MAP": 61, "SEQUENTIAL": 26, "FOR": 65}
         )
     elif target == "openmp":
         verifier = SDFGVerification(
             verification={
-                "VECTORIZE": 10,
-                "CPU_PARALLEL": 33,
-                "MAP": 51,
-                "SEQUENTIAL": 8,
-                "FOR": 55,
+                "VECTORIZE": 9,
+                "CPU_PARALLEL": 26,
+                "MAP": 42,
+                "SEQUENTIAL": 7,
+                "FOR": 46,
             }
         )
     elif target == "cuda":

--- a/python/benchmarks/npbench/deep_learning/mlp/test_mlp.py
+++ b/python/benchmarks/npbench/deep_learning/mlp/test_mlp.py
@@ -60,9 +60,9 @@ def test_mlp(target):
     if target == "none":
         verifier = SDFGVerification(
             verification={
-                "SEQUENTIAL": 18,
-                "FOR": 20,
-                "MAP": 18,
+                "SEQUENTIAL": 15,
+                "FOR": 17,
+                "MAP": 15,
                 "GEMM": 3,
             }
         )

--- a/python/benchmarks/npbench/deep_learning/softmax/test_softmax.py
+++ b/python/benchmarks/npbench/deep_learning/softmax/test_softmax.py
@@ -43,9 +43,9 @@ def test_softmax(target):
     if target == "none":
         verifier = SDFGVerification(
             verification={
-                "SEQUENTIAL": 20,
-                "FOR": 22,
-                "MAP": 20,
+                "SEQUENTIAL": 14,
+                "FOR": 16,
+                "MAP": 14,
             }
         )
     elif target == "sequential":

--- a/python/benchmarks/npbench/deep_learning/softmax/test_softmax.py
+++ b/python/benchmarks/npbench/deep_learning/softmax/test_softmax.py
@@ -43,9 +43,9 @@ def test_softmax(target):
     if target == "none":
         verifier = SDFGVerification(
             verification={
-                "SEQUENTIAL": 14,
-                "FOR": 16,
-                "MAP": 14,
+                "SEQUENTIAL": 11,
+                "FOR": 13,
+                "MAP": 11,
             }
         )
     elif target == "sequential":

--- a/python/benchmarks/npbench/harness.py
+++ b/python/benchmarks/npbench/harness.py
@@ -351,7 +351,6 @@ def run_pytest(
             test_sub = target
     else:
         test_case = f"unknown"
-    verifier.verify(stats, test_case, test_sub, device_resident=device_resident)
 
     # Validate return values if they exist
     if res_ref is not None:
@@ -371,3 +370,5 @@ def run_pytest(
             np.testing.assert_allclose(
                 inputs_docc[i], inputs_ref[i], rtol=verifier.rtol, atol=verifier.atol
             )
+
+    verifier.verify(stats, test_case, test_sub, device_resident=device_resident)

--- a/python/benchmarks/npbench/polybench/test_adi.py
+++ b/python/benchmarks/npbench/polybench/test_adi.py
@@ -87,9 +87,9 @@ def test_adi(target):
         verifier = SDFGVerification(
             verification={
                 "Free": 3,
-                "MAP": 24,
-                "SEQUENTIAL": 24,
-                "FOR": 29,
+                "MAP": 21,
+                "SEQUENTIAL": 21,
+                "FOR": 26,
                 "Malloc": 11,
             }
         )
@@ -97,10 +97,10 @@ def test_adi(target):
         verifier = SDFGVerification(
             verification={
                 "Free": 3,
-                "VECTORIZE": 23,
-                "MAP": 24,
+                "VECTORIZE": 20,
+                "MAP": 21,
                 "SEQUENTIAL": 1,
-                "FOR": 29,
+                "FOR": 26,
                 "Malloc": 11,
             }
         )
@@ -109,9 +109,9 @@ def test_adi(target):
             verification={
                 "Free": 3,
                 "CPU_PARALLEL": 1,
-                "VECTORIZE": 22,
-                "MAP": 23,
-                "FOR": 28,
+                "VECTORIZE": 19,
+                "MAP": 20,
+                "FOR": 25,
                 "Malloc": 11,
             }
         )
@@ -121,9 +121,9 @@ def test_adi(target):
                 "Free": 3,
                 "CUDA": 2,
                 "CUDAOffloading": 4,
-                "MAP": 24,
-                "SEQUENTIAL": 22,
-                "FOR": 29,
+                "MAP": 21,
+                "SEQUENTIAL": 19,
+                "FOR": 26,
                 "Malloc": 11,
             }
         )
@@ -133,9 +133,9 @@ def test_adi(target):
                 "Free": 3,
                 "ROCM": 2,
                 "ROCMOffloading": 4,
-                "MAP": 24,
-                "SEQUENTIAL": 22,
-                "FOR": 29,
+                "MAP": 21,
+                "SEQUENTIAL": 19,
+                "FOR": 26,
                 "Malloc": 11,
             }
         )

--- a/python/benchmarks/npbench/polybench/test_covariance.py
+++ b/python/benchmarks/npbench/polybench/test_covariance.py
@@ -61,7 +61,7 @@ def test_covariance(target):
     elif target == "openmp":
         verifier = SDFGVerification(
             verification={
-                "VECTORIZE": 3,
+                "VECTORIZE": 2,
                 "GEMM": 1,
                 "CPU_PARALLEL": 5,
                 "MAP": 8,

--- a/python/benchmarks/npbench/polybench/test_covariance.py
+++ b/python/benchmarks/npbench/polybench/test_covariance.py
@@ -43,19 +43,19 @@ def test_covariance(target):
         verifier = SDFGVerification(
             verification={
                 "GEMM": 1,
-                "MAP": 12,
-                "SEQUENTIAL": 12,
-                "FOR": 14,
+                "MAP": 11,
+                "SEQUENTIAL": 11,
+                "FOR": 13,
             }
         )
     elif target == "sequential":
         verifier = SDFGVerification(
             verification={
                 "GEMM": 1,
-                "VECTORIZE": 7,
-                "MAP": 11,
+                "VECTORIZE": 6,
+                "MAP": 10,
                 "SEQUENTIAL": 4,
-                "FOR": 13,
+                "FOR": 12,
             }
         )
     elif target == "openmp":
@@ -64,8 +64,8 @@ def test_covariance(target):
                 "VECTORIZE": 2,
                 "GEMM": 1,
                 "CPU_PARALLEL": 5,
-                "MAP": 8,
-                "FOR": 10,
+                "MAP": 7,
+                "FOR": 9,
             }
         )
     elif target == "cuda":

--- a/python/benchmarks/npbench/polybench/test_deriche.py
+++ b/python/benchmarks/npbench/polybench/test_deriche.py
@@ -96,35 +96,35 @@ def test_deriche(target):
     if target == "none":
         verifier = SDFGVerification(
             verification={
-                "Free": 10,
-                "SEQUENTIAL": 27,
-                "FOR": 31,
-                "MAP": 27,
+                "Free": 9,
+                "SEQUENTIAL": 24,
+                "FOR": 28,
+                "MAP": 24,
                 "CMath": 9,
-                "Malloc": 10,
+                "Malloc": 9,
             }
         )
     elif target == "sequential":
         verifier = SDFGVerification(
             verification={
-                "Free": 10,
-                "VECTORIZE": 22,
-                "SEQUENTIAL": 5,
-                "FOR": 31,
-                "MAP": 27,
+                "Free": 9,
+                "VECTORIZE": 20,
+                "SEQUENTIAL": 4,
+                "FOR": 28,
+                "MAP": 24,
                 "CMath": 9,
-                "Malloc": 10,
+                "Malloc": 9,
             }
         )
     elif target == "openmp":
         verifier = SDFGVerification(
             verification={
-                "Free": 10,
-                "FOR": 26,
-                "MAP": 22,
-                "CPU_PARALLEL": 22,
+                "Free": 9,
+                "FOR": 24,
+                "MAP": 20,
+                "CPU_PARALLEL": 20,
                 "CMath": 9,
-                "Malloc": 10,
+                "Malloc": 9,
             }
         )
     elif target == "cuda":

--- a/python/benchmarks/npbench/polybench/test_gemver.py
+++ b/python/benchmarks/npbench/polybench/test_gemver.py
@@ -56,18 +56,18 @@ def test_gemver(target):
     elif target == "cuda":
         verifier = SDFGVerification(
             verification={
-                "CUDA": 5,
-                "FOR": 9,
-                "MAP": 5,
+                "CUDA": 8,
+                "FOR": 12,
+                "MAP": 8,
                 "CUDAOffloading": 6,
             },
         )
     elif target == "rocm":
         verifier = SDFGVerification(
             verification={
-                "ROCM": 5,
-                "FOR": 9,
-                "MAP": 5,
+                "ROCM": 8,
+                "FOR": 12,
+                "MAP": 8,
                 "ROCMOffloading": 6,
             },
         )

--- a/python/benchmarks/npbench/polybench/test_gemver.py
+++ b/python/benchmarks/npbench/polybench/test_gemver.py
@@ -56,9 +56,9 @@ def test_gemver(target):
     elif target == "cuda":
         verifier = SDFGVerification(
             verification={
-                "CUDA": 8,
-                "FOR": 12,
-                "MAP": 8,
+                "CUDA": 5,
+                "FOR": 9,
+                "MAP": 5,
                 "CUDAOffloading": 6,
             },
         )

--- a/python/benchmarks/npbench/polybench/test_gemver.py
+++ b/python/benchmarks/npbench/polybench/test_gemver.py
@@ -65,9 +65,9 @@ def test_gemver(target):
     elif target == "rocm":
         verifier = SDFGVerification(
             verification={
-                "ROCM": 8,
-                "FOR": 12,
-                "MAP": 8,
+                "ROCM": 5,
+                "FOR": 9,
+                "MAP": 5,
                 "ROCMOffloading": 6,
             },
         )

--- a/python/benchmarks/npbench/polybench/test_heat_3d.py
+++ b/python/benchmarks/npbench/polybench/test_heat_3d.py
@@ -52,21 +52,21 @@ def kernel(TSTEPS, A, B):
 def test_heat_3d(target):
     if target == "none":
         verifier = SDFGVerification(
-            verification={"MAP": 15, "SEQUENTIAL": 15, "FOR": 16, "Malloc": 3}
+            verification={"MAP": 6, "SEQUENTIAL": 6, "FOR": 7, "Malloc": 0}
         )
     elif target == "sequential":
         verifier = SDFGVerification(
             verification={
-                "VECTORIZE": 5,
-                "MAP": 15,
-                "SEQUENTIAL": 10,
-                "FOR": 16,
-                "Malloc": 3,
+                "VECTORIZE": 2,
+                "MAP": 6,
+                "SEQUENTIAL": 4,
+                "FOR": 7,
+                "Malloc": 0,
             }
         )
     elif target == "openmp":
         verifier = SDFGVerification(
-            verification={"CPU_PARALLEL": 5, "MAP": 5, "FOR": 6, "Malloc": 3}
+            verification={"CPU_PARALLEL": 2, "MAP": 2, "FOR": 3, "Malloc": 0}
         )
     elif target == "cuda":
         verifier = SDFGVerification(

--- a/python/benchmarks/npbench/polybench/test_ludcmp.py
+++ b/python/benchmarks/npbench/polybench/test_ludcmp.py
@@ -89,7 +89,7 @@ def test_ludcmp(target):
         verifier = SDFGVerification(
             verification={
                 "ROCM": 1,
-                "MAP": 23,
+                "MAP": 2,
                 "SEQUENTIAL": 1,
                 "ROCMOffloading": 12,
                 "FOR": 10,

--- a/python/benchmarks/npbench/polybench/test_ludcmp.py
+++ b/python/benchmarks/npbench/polybench/test_ludcmp.py
@@ -46,9 +46,9 @@ def test_ludcmp(target):
     if target == "none":
         verifier = SDFGVerification(
             verification={
-                "MAP": 3,
-                "SEQUENTIAL": 3,
-                "FOR": 11,
+                "MAP": 2,
+                "SEQUENTIAL": 2,
+                "FOR": 10,
                 "Memset": 2,
                 "Malloc": 2,
             }
@@ -56,10 +56,10 @@ def test_ludcmp(target):
     elif target == "sequential":
         verifier = SDFGVerification(
             verification={
-                "VECTORIZE": 2,
-                "MAP": 3,
+                "VECTORIZE": 1,
+                "MAP": 2,
                 "SEQUENTIAL": 1,
-                "FOR": 11,
+                "FOR": 10,
                 "Memset": 2,
                 "Malloc": 2,
             }
@@ -67,10 +67,10 @@ def test_ludcmp(target):
     elif target == "openmp":
         verifier = SDFGVerification(
             verification={
-                "CPU_PARALLEL": 2,
-                "MAP": 3,
+                "CPU_PARALLEL": 1,
+                "MAP": 2,
                 "SEQUENTIAL": 1,
-                "FOR": 11,
+                "FOR": 10,
                 "Memset": 2,
                 "Malloc": 2,
             }
@@ -78,21 +78,21 @@ def test_ludcmp(target):
     elif target == "cuda":
         verifier = SDFGVerification(
             verification={
-                "CUDA": 2,
-                "MAP": 3,
+                "CUDA": 1,
+                "MAP": 2,
                 "SEQUENTIAL": 1,
                 "CUDAOffloading": 12,
-                "FOR": 11,
+                "FOR": 10,
             }
         )
     elif target == "rocm":
         verifier = SDFGVerification(
             verification={
-                "ROCM": 2,
-                "MAP": 3,
+                "ROCM": 1,
+                "MAP": 23,
                 "SEQUENTIAL": 1,
                 "ROCMOffloading": 12,
-                "FOR": 11,
+                "FOR": 10,
             }
         )
     run_pytest(initialize, kernel, PARAMETERS, target, verifier=verifier)

--- a/python/benchmarks/npbench/polybench/test_mvt.py
+++ b/python/benchmarks/npbench/polybench/test_mvt.py
@@ -70,17 +70,17 @@ def test_mvt(target):
     elif target == "cuda":
         verifier = SDFGVerification(
             verification={
-                "FOR": 4,
-                "MAP": 2,
-                "CUDA": 2,
+                "FOR": 3,
+                "MAP": 1,
+                "CUDA": 1,
             },
         )
     elif target == "rocm":
         verifier = SDFGVerification(
             verification={
-                "FOR": 4,
-                "MAP": 2,
-                "ROCM": 2,
+                "FOR": 3,
+                "MAP": 1,
+                "ROCM": 1,
             },
         )
     run_pytest(initialize, kernel, PARAMETERS, target, verifier=verifier)

--- a/python/benchmarks/npbench/polybench/test_trmm.py
+++ b/python/benchmarks/npbench/polybench/test_trmm.py
@@ -67,20 +67,20 @@ def test_trmm(target):
     elif target == "cuda":
         verifier = SDFGVerification(
             verification={
-                "FOR": 3,
-                "MAP": 2,
-                "CUDA": 2,
-                "CUDAOffloading": 0,
+                "FOR": 5,
+                "MAP": 4,
+                "CUDA": 4,
+                "CUDAOffloading": 2,
             },
             rtol=5 - 1,
         )
     elif target == "rocm":
         verifier = SDFGVerification(
             verification={
-                "FOR": 3,
-                "MAP": 2,
-                "ROCM": 2,
-                "ROCMOffloading": 0,
+                "FOR": 5,
+                "MAP": 4,
+                "ROCM": 4,
+                "ROCMOffloading": 2,
             },
             rtol=5 - 1,
         )

--- a/python/benchmarks/npbench/polybench/test_trmm.py
+++ b/python/benchmarks/npbench/polybench/test_trmm.py
@@ -67,20 +67,20 @@ def test_trmm(target):
     elif target == "cuda":
         verifier = SDFGVerification(
             verification={
-                "FOR": 5,
-                "MAP": 4,
-                "CUDA": 4,
-                "CUDAOffloading": 2,
+                "FOR": 3,
+                "MAP": 2,
+                "CUDA": 2,
+                "CUDAOffloading": 0,
             },
             rtol=5 - 1,
         )
     elif target == "rocm":
         verifier = SDFGVerification(
             verification={
-                "FOR": 5,
-                "MAP": 4,
-                "ROCM": 4,
-                "ROCMOffloading": 2,
+                "FOR": 3,
+                "MAP": 2,
+                "ROCM": 2,
+                "ROCMOffloading": 0,
             },
             rtol=5 - 1,
         )

--- a/python/benchmarks/npbench/weather_stencils/test_hdiff.py
+++ b/python/benchmarks/npbench/weather_stencils/test_hdiff.py
@@ -67,40 +67,40 @@ def test_hdiff(target):
     verifier = None
     if target == "none":
         verifier = SDFGVerification(
-            verification={"SEQUENTIAL": 30, "FOR": 30, "MAP": 30, "Malloc": 9}
+            verification={"SEQUENTIAL": 17, "FOR": 17, "MAP": 17, "Malloc": 7}
         )
     elif target == "sequential":
         verifier = SDFGVerification(
             verification={
-                "VECTORIZE": 10,
-                "SEQUENTIAL": 20,
-                "FOR": 30,
-                "MAP": 30,
-                "Malloc": 9,
+                "VECTORIZE": 6,
+                "SEQUENTIAL": 12,
+                "FOR": 18,
+                "MAP": 18,
+                "Malloc": 7,
             }
         )
     elif target == "openmp":
         verifier = SDFGVerification(
-            verification={"CPU_PARALLEL": 10, "FOR": 10, "MAP": 10, "Malloc": 9}
+            verification={"CPU_PARALLEL": 6, "FOR": 6, "MAP": 6, "Malloc": 7}
         )
     elif target == "cuda":
         verifier = SDFGVerification(
             verification={
-                "CUDA": 6,
-                "SEQUENTIAL": 14,
-                "FOR": 20,
-                "CUDAOffloading": 14,
-                "MAP": 20,
+                "CUDA": 4,
+                "SEQUENTIAL": 8,
+                "FOR": 12,
+                "CUDAOffloading": 12,
+                "MAP": 12,
             }
         )
     elif target == "rocm":
         verifier = SDFGVerification(
             verification={
-                "ROCM": 6,
-                "SEQUENTIAL": 14,
-                "FOR": 20,
-                "ROCMOffloading": 14,
-                "MAP": 20,
+                "ROCM": 4,
+                "SEQUENTIAL": 8,
+                "FOR": 12,
+                "ROCMOffloading": 12,
+                "MAP": 12,
             }
         )
     run_pytest(initialize, kernel, PARAMETERS, target, verifier=verifier)

--- a/python/benchmarks/npbench/weather_stencils/test_vadv.py
+++ b/python/benchmarks/npbench/weather_stencils/test_vadv.py
@@ -127,43 +127,43 @@ def test_vadv(target):
     verifier = None
     if target == "none":
         verifier = SDFGVerification(
-            verification={"MAP": 100, "SEQUENTIAL": 100, "FOR": 107, "Malloc": 40}
+            verification={"MAP": 66, "SEQUENTIAL": 66, "FOR": 73, "Malloc": 42}
         )
     elif target == "sequential":
         verifier = SDFGVerification(
             verification={
-                "VECTORIZE": 50,
-                "MAP": 100,
-                "SEQUENTIAL": 50,
-                "FOR": 107,
-                "Malloc": 40,
+                "VECTORIZE": 34,
+                "MAP": 66,
+                "SEQUENTIAL": 32,
+                "FOR": 73,
+                "Malloc": 42,
             }
         )
     elif target == "openmp":
         verifier = SDFGVerification(
             verification={
-                "CPU_PARALLEL": 1,
-                "VECTORIZE": 50,
-                "MAP": 99,
-                "SEQUENTIAL": 48,
-                "FOR": 106,
-                "Malloc": 40,
+                "CPU_PARALLEL": 0,
+                "VECTORIZE": 34,
+                "MAP": 66,
+                "SEQUENTIAL": 32,
+                "FOR": 73,
+                "Malloc": 42,
             }
         )
     elif target == "cuda":
         verifier = SDFGVerification(
             verification={
-                "MAP": 100,
-                "SEQUENTIAL": 100,
-                "FOR": 107,
+                "MAP": 66,
+                "SEQUENTIAL": 66,
+                "FOR": 73,
             }
         )
     elif target == "rocm":
         verifier = SDFGVerification(
             verification={
-                "MAP": 100,
-                "SEQUENTIAL": 100,
-                "FOR": 107,
+                "MAP": 66,
+                "SEQUENTIAL": 66,
+                "FOR": 73,
             }
         )
     run_pytest(initialize, kernel, PARAMETERS, target, verifier=verifier)

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -264,6 +264,12 @@ PYBIND11_MODULE(_sdfg, m) {
             py::arg("threads") = 0 // means hardware-threads
         )
         .def("metadata", &PyStructuredSDFG::metadata, py::arg("key"), "Get metadata value")
+        .def_property(
+            "output_dir",
+            [](PyStructuredSDFG* self) { return self->metadata("output_dir"); },
+            [](PyStructuredSDFG* self, const std::string& path) { self->set_output_dir(path); },
+            "Get or set the output directory metadata"
+        )
         .def("loop_report", &PyStructuredSDFG::loop_report, "Get loop statistics from the SDFG")
         .def("to_json", &PyStructuredSDFG::to_json, "Serialize the SDFG to a JSON string")
         .def("to_dot", &PyStructuredSDFG::to_dot, "Serialize the SDFG to a DOT graph string")

--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -398,6 +398,24 @@ void PyStructuredSDFG::normalize() {
     // Fuse maps (final run: allow init-into-reduction hoisting now that distribution is done)
     auto map_fusion_hoist = sdfg::passes::normalization::map_fusion(true);
     map_fusion_hoist.run(builder, analysis_manager);
+
+    sdfg::passes::MapFusionByDomainPass map_fusion_by_domain_pass;
+    map_fusion_by_domain_pass.run(builder, analysis_manager);
+    sdfg::passes::DeadDataElimination dde;
+    sdfg::passes::Pipeline dce = sdfg::passes::Pipeline::dead_code_elimination();
+
+    // Cleanup of artifacts of MapFusion
+    dde.run(builder, analysis_manager);
+    dce.run(builder, analysis_manager);
+    sdfg::passes::Pipeline block_fusion("BlockFusion");
+    block_fusion.register_pass<sdfg::passes::BlockFusionPass>();
+    block_fusion.run(builder, analysis_manager);
+
+    sdfg::passes::RedundantLoadEliminationPass rle;
+    rle.run(builder, analysis_manager);
+    dde.run(builder, analysis_manager);
+    sdfg::passes::TaskletFusionPass task_fuse_pass;
+    task_fuse_pass.run(builder, analysis_manager);
 }
 
 void PyStructuredSDFG::schedule(const std::string& target, const std::string& category, bool remote_tuning) {

--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -321,21 +321,8 @@ void PyStructuredSDFG::simplify() {
     dce.run(builder_opt, analysis_manager);
     dataflow_simplification.run(builder_opt, analysis_manager);
 
-    // New Map Fusion, simpler than previous, but what it can do should be cheaper to do
-    sdfg::passes::MapFusionByDomainPass map_fusion_by_domain_pass;
-    map_fusion_by_domain_pass.run(builder_opt, analysis_manager);
-    // Cleanup of artifacts of MapFusion
-    dde.run(builder_opt, analysis_manager);
-    dce.run(builder_opt, analysis_manager);
-    sdfg::passes::Pipeline block_fusion("BlockFusion");
-    block_fusion.register_pass<sdfg::passes::BlockFusionPass>();
-    block_fusion.run(builder_opt, analysis_manager);
-    sdfg::passes::RedundantLoadEliminationPass rle;
-    rle.run(builder_opt, analysis_manager);
-    dde.run(builder_opt, analysis_manager);
-    sdfg::passes::TaskletFusionPass task_fuse_pass;
-    task_fuse_pass.run(builder_opt, analysis_manager);
     if (use_new_fusion_in_simplify_) {
+        // New Map Fusion, simpler than previous, but what it can do should be cheaper to do
         sdfg::passes::MapFusionByDomainPass map_fusion_by_domain_pass;
         map_fusion_by_domain_pass.run(builder_opt, analysis_manager);
 
@@ -417,10 +404,6 @@ void PyStructuredSDFG::normalize() {
     auto map_fusion_hoist = sdfg::passes::normalization::map_fusion(true);
     map_fusion_hoist.run(builder, analysis_manager);
 
-    sdfg::passes::MapFusionByDomainPass map_fusion_by_domain_pass;
-    map_fusion_by_domain_pass.run(builder, analysis_manager);
-    sdfg::passes::DeadDataElimination dde;
-    sdfg::passes::Pipeline dce = sdfg::passes::Pipeline::dead_code_elimination();
     if (use_new_fusion_in_normalize_) {
         sdfg::passes::MapFusionByDomainPass map_fusion_by_domain_pass;
         map_fusion_by_domain_pass.run(builder, analysis_manager);

--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -55,6 +55,7 @@
 #include "docc/compile/src_file_compiler.h"
 #include "docc/compile/src_file_compiler_builder.h"
 #include "docc/util/docc_paths.h"
+#include "sdfg/passes/map_fusion_by_domain_pass.h"
 #include "sdfg/passes/offloading/code_motion/block_hoisting.h"
 #include "sdfg/passes/offloading/code_motion/block_sorting.h"
 #include "sdfg/passes/offloading/cuda_library_node_expansion_pass.h"
@@ -113,6 +114,10 @@ PyStructuredSDFG PyStructuredSDFG::from_sdfg(sdfg::plugins::Context& ctx, std::u
 }
 
 std::string PyStructuredSDFG::name() const { return sdfg_->name(); }
+
+void PyStructuredSDFG::set_output_dir(const std::filesystem::path& dir) {
+    sdfg_->add_metadata("output_dir", dir.string());
+}
 
 sdfg::plugins::Context& PyStructuredSDFG::docc_context() const { return docc_context_; }
 

--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -55,12 +55,14 @@
 #include "docc/compile/src_file_compiler.h"
 #include "docc/compile/src_file_compiler_builder.h"
 #include "docc/util/docc_paths.h"
+#include "sdfg/passes/dataflow/tasklet_fusion.h"
 #include "sdfg/passes/map_fusion_by_domain_pass.h"
 #include "sdfg/passes/offloading/code_motion/block_hoisting.h"
 #include "sdfg/passes/offloading/code_motion/block_sorting.h"
 #include "sdfg/passes/offloading/cuda_library_node_expansion_pass.h"
 #include "sdfg/passes/offloading/data_transfer_minimization_pass.h"
 #include "sdfg/passes/offloading/rocm_library_node_expansion_pass.h"
+#include "sdfg/passes/redundant_load_elimination_pass.h"
 #include "sdfg/passes/rpc/daisytuner_rpc_context.h"
 #include "sdfg/passes/rpc/rpc_context.h"
 #include "sdfg/passes/rpc/rpc_scheduler.h"
@@ -317,6 +319,21 @@ void PyStructuredSDFG::simplify() {
     dde.run(builder_opt, analysis_manager);
     dce.run(builder_opt, analysis_manager);
     dataflow_simplification.run(builder_opt, analysis_manager);
+
+    // New Map Fusion, simpler than previous, but what it can do should be cheaper to do
+    sdfg::passes::MapFusionByDomainPass map_fusion_by_domain_pass;
+    map_fusion_by_domain_pass.run(builder_opt, analysis_manager);
+    // Cleanup of artifacts of MapFusion
+    dde.run(builder_opt, analysis_manager);
+    dce.run(builder_opt, analysis_manager);
+    sdfg::passes::Pipeline block_fusion("BlockFusion");
+    block_fusion.register_pass<sdfg::passes::BlockFusionPass>();
+    block_fusion.run(builder_opt, analysis_manager);
+    sdfg::passes::RedundantLoadEliminationPass rle;
+    rle.run(builder_opt, analysis_manager);
+    dde.run(builder_opt, analysis_manager);
+    sdfg::passes::TaskletFusionPass task_fuse_pass;
+    task_fuse_pass.run(builder_opt, analysis_manager);
 
     // Fuse maps (no init-into-reduction hoisting in simplify; reserved for the final
     // normalize() map-fusion run so loop distribution and fusion do not fight)

--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -87,7 +87,8 @@ namespace fs = std::filesystem;
 using json = nlohmann::json;
 
 PyStructuredSDFG::PyStructuredSDFG(sdfg::plugins::Context& ctx, std::unique_ptr<sdfg::StructuredSDFG>& sdfg)
-    : docc_context_(ctx), sdfg_(std::move(sdfg)) {}
+    : docc_context_(ctx), sdfg_(std::move(sdfg)), use_new_fusion_in_simplify_(true),
+      use_new_fusion_in_normalize_(false) {}
 
 PyStructuredSDFG PyStructuredSDFG::parse(sdfg::plugins::Context& ctx, const std::string& sdfg_text) {
     json j = json::parse(sdfg_text);
@@ -334,6 +335,23 @@ void PyStructuredSDFG::simplify() {
     dde.run(builder_opt, analysis_manager);
     sdfg::passes::TaskletFusionPass task_fuse_pass;
     task_fuse_pass.run(builder_opt, analysis_manager);
+    if (use_new_fusion_in_simplify_) {
+        sdfg::passes::MapFusionByDomainPass map_fusion_by_domain_pass;
+        map_fusion_by_domain_pass.run(builder_opt, analysis_manager);
+
+        // Cleanup of artifacts of MapFusion
+        dde.run(builder_opt, analysis_manager);
+        dce.run(builder_opt, analysis_manager);
+        sdfg::passes::Pipeline block_fusion("BlockFusion");
+        block_fusion.register_pass<sdfg::passes::BlockFusionPass>();
+        block_fusion.run(builder_opt, analysis_manager);
+
+        sdfg::passes::RedundantLoadEliminationPass rle;
+        rle.run(builder_opt, analysis_manager);
+        dde.run(builder_opt, analysis_manager);
+        sdfg::passes::TaskletFusionPass task_fuse_pass;
+        task_fuse_pass.run(builder_opt, analysis_manager);
+    }
 
     // Fuse maps (no init-into-reduction hoisting in simplify; reserved for the final
     // normalize() map-fusion run so loop distribution and fusion do not fight)
@@ -403,19 +421,25 @@ void PyStructuredSDFG::normalize() {
     map_fusion_by_domain_pass.run(builder, analysis_manager);
     sdfg::passes::DeadDataElimination dde;
     sdfg::passes::Pipeline dce = sdfg::passes::Pipeline::dead_code_elimination();
+    if (use_new_fusion_in_normalize_) {
+        sdfg::passes::MapFusionByDomainPass map_fusion_by_domain_pass;
+        map_fusion_by_domain_pass.run(builder, analysis_manager);
+        sdfg::passes::DeadDataElimination dde;
+        sdfg::passes::Pipeline dce = sdfg::passes::Pipeline::dead_code_elimination();
 
-    // Cleanup of artifacts of MapFusion
-    dde.run(builder, analysis_manager);
-    dce.run(builder, analysis_manager);
-    sdfg::passes::Pipeline block_fusion("BlockFusion");
-    block_fusion.register_pass<sdfg::passes::BlockFusionPass>();
-    block_fusion.run(builder, analysis_manager);
+        // Cleanup of artifacts of MapFusion
+        dde.run(builder, analysis_manager);
+        dce.run(builder, analysis_manager);
+        sdfg::passes::Pipeline block_fusion("BlockFusion");
+        block_fusion.register_pass<sdfg::passes::BlockFusionPass>();
+        block_fusion.run(builder, analysis_manager);
 
-    sdfg::passes::RedundantLoadEliminationPass rle;
-    rle.run(builder, analysis_manager);
-    dde.run(builder, analysis_manager);
-    sdfg::passes::TaskletFusionPass task_fuse_pass;
-    task_fuse_pass.run(builder, analysis_manager);
+        sdfg::passes::RedundantLoadEliminationPass rle;
+        rle.run(builder, analysis_manager);
+        dde.run(builder, analysis_manager);
+        sdfg::passes::TaskletFusionPass task_fuse_pass;
+        task_fuse_pass.run(builder, analysis_manager);
+    }
 }
 
 void PyStructuredSDFG::schedule(const std::string& target, const std::string& category, bool remote_tuning) {

--- a/python/bindings/py_structured_sdfg.h
+++ b/python/bindings/py_structured_sdfg.h
@@ -16,6 +16,8 @@ class PyStructuredSDFG {
 private:
     sdfg::plugins::Context& docc_context_;
     std::unique_ptr<sdfg::StructuredSDFG> sdfg_;
+    bool use_new_fusion_in_simplify_;
+    bool use_new_fusion_in_normalize_;
 
     PyStructuredSDFG(sdfg::plugins::Context& ctx, std::unique_ptr<sdfg::StructuredSDFG>& sdfg);
 

--- a/python/bindings/py_structured_sdfg.h
+++ b/python/bindings/py_structured_sdfg.h
@@ -34,6 +34,8 @@ public:
 
     std::string name() const;
 
+    void set_output_dir(const std::filesystem::path& dir);
+
     sdfg::plugins::Context& docc_context() const;
 
     sdfg::StructuredSDFG& sdfg() { return *sdfg_; }

--- a/python/docc/compiler/docc_program.py
+++ b/python/docc/compiler/docc_program.py
@@ -147,6 +147,9 @@ class DoccProgram(ABC):
         if self.debug_dump:
             sdfg.dump(output_folder, "py0.parsed", dump_dot=True)
 
+        if not output_folder is None:
+            sdfg.output_dir = output_folder
+
         # Enable statistics if envvar is set
         if _statistics_enabled_by_env():
             _enable_statistics()

--- a/rpc/tests/transformations/rpc_node_transform_test.cpp
+++ b/rpc/tests/transformations/rpc_node_transform_test.cpp
@@ -1,22 +1,22 @@
 #include <gtest/gtest.h>
 #include <memory>
-#include <unordered_set>
 #include <sdfg/transformations/rpc_node_transform.h>
 #include <sdfg/util/utils_curl.h>
+#include <unordered_set>
 
 
 #include "sdfg/analysis/loop_analysis.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/codegen/utils.h"
 #include "sdfg/deepcopy/structured_sdfg_deep_copy.h"
 #include "sdfg/passes/rpc/rpc_context.h"
+#include "sdfg/serializer/json_serializer.h"
 #include "sdfg/structured_control_flow/map.h"
 #include "sdfg/structured_control_flow/structured_loop.h"
 #include "sdfg/structured_sdfg.h"
 #include "sdfg/transformations/loop_interchange.h"
 #include "sdfg/transformations/loop_tiling.h"
 #include "sdfg/transformations/recorder.h"
-#include "sdfg/codegen/utils.h"
-#include "sdfg/serializer/json_serializer.h"
 #include "sdfg/types/pointer.h"
 #include "sdfg/types/type.h"
 
@@ -184,9 +184,9 @@ TEST_F(RPCNodeTransformTest, Double_Matmul) {
 
     // Transfer tuning replayer
 
-        sdfg::analysis::AnalysisManager analysis_manager(builder.subject());
-        auto& loop_analysis = analysis_manager.get<sdfg::analysis::LoopAnalysis>();
-        auto outer_loops = loop_analysis.outermost_loops();
+    sdfg::analysis::AnalysisManager analysis_manager(builder.subject());
+    auto& loop_analysis = analysis_manager.get<sdfg::analysis::LoopAnalysis>();
+    auto outer_loops = loop_analysis.outermost_loops();
     EXPECT_EQ(outer_loops.size(), 2);
 
     auto outer_loop = static_cast<structured_control_flow::StructuredLoop*>(outer_loops[0]);
@@ -197,7 +197,6 @@ TEST_F(RPCNodeTransformTest, Double_Matmul) {
     sdfg::analysis::AnalysisManager test_analysis_manager(builder.subject());
 
     auto& test_loop_analysis = test_analysis_manager.get<sdfg::analysis::LoopAnalysis>();
-    auto loop_nest_tree = test_loop_analysis.loop_tree();
 
     EXPECT_NE(test_loop_analysis.find_loop_by_indvar("k_tile0"), nullptr);
     EXPECT_NE(test_loop_analysis.find_loop_by_indvar("j_tile0"), nullptr);
@@ -230,7 +229,8 @@ TEST_F(RPCNodeTransformTest, UniqueElementIDs) {
     ASSERT_GE(remaining_outer_loops.size(), 1);
 
     auto* second_outer_loop = static_cast<structured_control_flow::StructuredLoop*>(remaining_outer_loops.back());
-    sdfg::transformations::RPCNodeTransform second_rpc_transform(*second_outer_loop, "sequential", "server", *ctx_, false);
+    sdfg::transformations::RPCNodeTransform
+        second_rpc_transform(*second_outer_loop, "sequential", "server", *ctx_, false);
     ASSERT_TRUE(second_rpc_transform.can_be_applied(main_builder, main_analysis_manager));
     second_rpc_transform.apply(main_builder, main_analysis_manager);
 
@@ -284,7 +284,7 @@ TEST_F(RPCNodeTransformTest, HandleOtherHttpErrors) {
     result.body = R"({"error": "Internal Server Error"})";
     result.error_message = "HTTP error: 500, body: " + result.body;
 
-     sdfg::analysis::AnalysisManager analysis_manager(builder_->subject());
+    sdfg::analysis::AnalysisManager analysis_manager(builder_->subject());
     auto& loop_analysis = analysis_manager.get<sdfg::analysis::LoopAnalysis>();
     auto outer_loops = loop_analysis.outermost_loops();
     EXPECT_EQ(outer_loops.size(), 1);
@@ -325,8 +325,7 @@ TEST_F(RPCNodeTransformTest, ApplyUnwrapsReferenceTypedContainersFromResponse) {
     // Build an RPC context that sends the file path as SDFG-Result-Path header,
     // so the transfer server loads this SDFG as its response (same pattern as matmul tests).
     passes::rpc::SimpleRpcContextBuilder ctx_builder;
-    auto test_ctx = ctx_builder
-                        .initialize_local_default()
+    auto test_ctx = ctx_builder.initialize_local_default()
                         .add_header("SDFG-Result-Path", std::string(std::getenv("SDFG_TEST_SDFG_PATH")))
                         .build();
 

--- a/sdfg/include/sdfg/analysis/arguments_analysis.h
+++ b/sdfg/include/sdfg/analysis/arguments_analysis.h
@@ -59,6 +59,12 @@ struct RegionArgument : public DataRwFlags {
     ~RegionArgument() = default;
 
     RegionArgument& operator=(const RegionArgument& other) = default;
+
+    void merge(RegionArgument& other) {
+        DataRwFlags::merge(other);
+        is_scalar |= other.is_scalar;
+        is_ptr |= other.is_ptr;
+    }
 };
 
 class ArgumentsAnalysis : public Analysis {

--- a/sdfg/include/sdfg/analysis/loop_analysis.h
+++ b/sdfg/include/sdfg/analysis/loop_analysis.h
@@ -263,6 +263,15 @@ public:
     );
 
     void removed_loop(structured_control_flow::ControlFlowNode* existing_loop);
+
+    /**
+     *
+     * @param loop the loop to modify
+     * @param side_effects elements that have sideffects were added to the body of this loop (and not its children)
+     * @param non_perfectly_nested elements other than a loop were added to the body of this loop (block, another
+     * sequence etc.)
+     */
+    void added_local_contents(structured_control_flow::ControlFlowNode* loop, bool side_effects, bool non_perfectly_nested);
 };
 
 } // namespace analysis

--- a/sdfg/include/sdfg/analysis/loop_analysis.h
+++ b/sdfg/include/sdfg/analysis/loop_analysis.h
@@ -9,19 +9,6 @@ namespace analysis {
 
 class AssumptionsAnalysis;
 
-struct DFSLoopComparator {
-    const std::vector<structured_control_flow::ControlFlowNode*>* loops_order_;
-
-    DFSLoopComparator(const std::vector<structured_control_flow::ControlFlowNode*>* loops_order)
-        : loops_order_(loops_order) {}
-
-    bool operator()(const structured_control_flow::ControlFlowNode* lhs, const structured_control_flow::ControlFlowNode* rhs)
-        const {
-        return std::find(loops_order_->begin(), loops_order_->end(), lhs) <
-               std::find(loops_order_->begin(), loops_order_->end(), rhs);
-    }
-};
-
 #define LOOP_INFO_PROPERTIES              \
     X(int, loopnest_index, -1)            \
     X(sdfg::ElementId, element_id, 0)     \
@@ -60,6 +47,7 @@ struct LoopInfo {
  * And to allow for separate allocation in the future
  */
 struct LocalLoopInfo {
+    enum class LoopType : uint8_t { While, For, Map };
     /**
      * Unique ID for each loop, not just loop nests. Numbered in  pre-order DFS (children will always have higher
      * numbers than their parents)
@@ -71,7 +59,7 @@ struct LocalLoopInfo {
      */
     uint32_t last_child_id;
     uint32_t loop_level;
-    bool is_map;
+    LoopType type;
     bool is_elementwise;
     /**
      * The loop contains anything other than a direct child loop. Be it a block, an additional sequence or multiple
@@ -83,8 +71,6 @@ struct LocalLoopInfo {
      */
     bool contains_side_effects;
 };
-
-typedef std::pair<LocalLoopInfo, LoopInfo> LoopState;
 
 inline nlohmann::json loop_info_to_json(LoopInfo info) {
     nlohmann::json j = nlohmann::json{
@@ -105,6 +91,8 @@ inline nlohmann::json loop_info_to_json(LoopInfo info) {
     return j;
 }
 
+void loop_info_local_to_json(nlohmann::json& j, const LocalLoopInfo& info);
+
 /**
  * A perfectly nested, perfectly parallel loop-nest (only maps, 1 map per level, no instructions other then inside the
  * innermost map) Because you likely want to look at multiple dimensions at once to be more efficient. The stack ends at
@@ -120,12 +108,19 @@ struct MapStack {
 };
 
 class LoopAnalysis : public Analysis {
-private:
-    uint32_t next_loop_id_ = 0;
+public:
+    struct LoopState {
+        LocalLoopInfo local;
+        LoopInfo nest;
+    };
+    struct AggregatedResult {
+        uint32_t last_child_id;
+        LoopInfo nest;
+    };
 
-    std::vector<structured_control_flow::ControlFlowNode*> loops_;
-    std::map<structured_control_flow::ControlFlowNode*, structured_control_flow::ControlFlowNode*, DFSLoopComparator>
-        loop_tree_;
+private:
+    std::vector<structured_control_flow::ControlFlowNode*> loops_; // currently required in Pre-order
+    std::unordered_map<structured_control_flow::ControlFlowNode*, structured_control_flow::ControlFlowNode*> loop_tree_;
     std::unordered_map<structured_control_flow::ControlFlowNode*, std::vector<structured_control_flow::ControlFlowNode*>>
         loop_children_;
 
@@ -141,6 +136,7 @@ private:
      */
     void init_new_loop_info(
         LoopState& info,
+        uint32_t id,
         uint32_t loop_level,
         structured_control_flow::ControlFlowNode* loop,
         structured_control_flow::Map* map,
@@ -156,13 +152,49 @@ private:
 
     std::list<std::vector<sdfg::structured_control_flow::ControlFlowNode*>> loop_tree_paths(
         sdfg::structured_control_flow::ControlFlowNode* loop,
-        const std::map<
+        const std::unordered_map<
             sdfg::structured_control_flow::ControlFlowNode*,
-            sdfg::structured_control_flow::ControlFlowNode*,
-            DFSLoopComparator>& tree
+            sdfg::structured_control_flow::ControlFlowNode*>& tree
     ) const;
 
     LoopState& compute_loop_infos(structured_control_flow::ControlFlowNode* loop);
+
+    /**
+     * Combine the local state of a loop with the already-computed loop-nest infos of its direct
+     * children into a fresh LoopInfo. Does not recurse: all children must already hold up-to-date infos.
+     */
+    AggregatedResult aggregate_loop_info(structured_control_flow::ControlFlowNode* loop) const;
+
+    void reindex_loop_nest_idx();
+
+    /**
+     * Translate a requested child position under `new_parent` into the corresponding index in the
+     * pre-order `loops_` vector where a subtree should be inserted.
+     *
+     * The API only exposes front/back (`start_not_end`), but internally this maps an iterator on the
+     * parent's child list to a `loops_` index, so inserting at an arbitrary child position is a matter
+     * of passing a different iterator. `new_parent` may be nullptr (root / outermost level).
+     */
+    uint32_t child_insertion_index(structured_control_flow::ControlFlowNode* new_parent, bool start_not_end) const;
+
+    /**
+     * Update the indices of the loops in the range of the iterators
+     * Iterators must be from loop_
+     *
+     * Following the insert of removal of loops, the following loops will have wrong loop_idx
+     */
+    void reindex(
+        std::vector<structured_control_flow::ControlFlowNode*>::iterator start,
+        std::vector<structured_control_flow::ControlFlowNode*>::iterator end
+    );
+
+    /**
+     * Propagate changes to the cross-loop infos up to their parents, starting at the given loop and ending at the root
+     * (nullptr). Only changes of top and underneath are expected. And top all children of top are expected to have
+     * already up-to-date loop nest infos
+     * @param top
+     */
+    void propagate_changed_nest_info(std::vector<structured_control_flow::ControlFlowNode*>::iterator top);
 
 public:
     LoopAnalysis(StructuredSDFG& sdfg);
@@ -171,9 +203,22 @@ public:
 
     void run(analysis::AnalysisManager& analysis_manager) override;
 
+    /**
+     * Currently guaranteed to be in Pre-Order
+     */
     const std::vector<structured_control_flow::ControlFlowNode*> loops() const;
 
-    const std::map<structured_control_flow::ControlFlowNode*, structured_control_flow::ControlFlowNode*, DFSLoopComparator>&
+    /**
+     * Loops in Pre-order.
+     * @return This is a live vector. It will change if modifications to LoopAnalysis are processed
+     */
+    const std::vector<structured_control_flow::ControlFlowNode*>& loops_in_pre_order() const;
+
+    /**
+     * Tree of parents of nodes. Not in any stable order. Do NEVER iterate over this.
+     * If you need to iterate over `loops()`
+     */
+    const std::unordered_map<structured_control_flow::ControlFlowNode*, structured_control_flow::ControlFlowNode*>&
     loop_tree() const;
 
     LoopInfo loop_info(structured_control_flow::ControlFlowNode* loop) const;
@@ -208,7 +253,16 @@ public:
         structured_control_flow::ControlFlowNode* new_parent_loop,
         structured_control_flow::ControlFlowNode* new_loop,
         bool start_not_end = false
+
     );
+
+    void moved_loop(
+        structured_control_flow::ControlFlowNode* existing_loop,
+        structured_control_flow::StructuredLoop* new_parent,
+        bool start_not_end = false
+    );
+
+    void removed_loop(structured_control_flow::ControlFlowNode* existing_loop);
 };
 
 } // namespace analysis

--- a/sdfg/include/sdfg/analysis/loop_analysis.h
+++ b/sdfg/include/sdfg/analysis/loop_analysis.h
@@ -200,6 +200,15 @@ public:
     descendants(sdfg::structured_control_flow::ControlFlowNode* loop) const;
 
     void dump_to_file(std::filesystem::path file) const;
+
+    // update with changes
+
+    void copied_loop(
+        structured_control_flow::ControlFlowNode* existing_loop,
+        structured_control_flow::ControlFlowNode* new_parent_loop,
+        structured_control_flow::ControlFlowNode* new_loop,
+        bool start_not_end = false
+    );
 };
 
 } // namespace analysis

--- a/sdfg/include/sdfg/builder/structured_sdfg_builder.h
+++ b/sdfg/include/sdfg/builder/structured_sdfg_builder.h
@@ -164,6 +164,8 @@ public:
     std::pair<Sequence&, Transition&>
     add_sequence_before(Sequence& parent, ControlFlowNode& block, const DebugInfo& debug_info = DebugInfo());
 
+    void remove_from_parent(ControlFlowNode& child);
+
     void remove_child(Sequence& parent, size_t index);
 
     void remove_children(Sequence& parent);

--- a/sdfg/include/sdfg/data_flow/data_flow_graph.h
+++ b/sdfg/include/sdfg/data_flow/data_flow_graph.h
@@ -144,6 +144,7 @@ public:
     size_t out_degree(const data_flow::DataFlowNode& node) const;
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression);
+    void replace(const symbolic::ExpressionMapping& replacements);
 
     /***** Section: Analysis *****/
 

--- a/sdfg/include/sdfg/data_flow/data_flow_graph.h
+++ b/sdfg/include/sdfg/data_flow/data_flow_graph.h
@@ -99,7 +99,18 @@ public:
 
     const data_flow::Memlet* in_edge_for_connector(const data_flow::CodeNode& node, const std::string& conn) const;
 
+    /**
+     * @deprecated AccessNodes can have multiple input edges, because the node is not an operation, it is almost
+     * irrelevant to the operation represented by the edges Will throw if there are more than 1 edge on the AccessNode
+     */
     const data_flow::Memlet* in_edge(const data_flow::AccessNode& node) const;
+
+    /**
+     * Will return the single input edge if it exists. Will return null if zero or more than 2 input edges exist on this
+     * access node. Suitable for situations where more than 1 edge are not supported anyway.
+     */
+    const data_flow::Memlet* in_edge_if_single(const data_flow::AccessNode& node) const;
+
 
     std::vector<data_flow::Memlet*> in_edges_by_connector(const data_flow::CodeNode& node);
 

--- a/sdfg/include/sdfg/data_flow/library_nodes/barrier_local_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/barrier_local_node.h
@@ -25,6 +25,8 @@ public:
         const override;
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 };
 
 class BarrierLocalNodeSerializer : public serializer::LibraryNodeSerializer {

--- a/sdfg/include/sdfg/data_flow/library_nodes/call_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/call_node.h
@@ -38,6 +38,7 @@ public:
     symbolic::SymbolSet symbols() const override;
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 
     std::unique_ptr<DataFlowNode> clone(size_t element_id, const graph::Vertex vertex, DataFlowGraph& parent)
         const override;

--- a/sdfg/include/sdfg/data_flow/library_nodes/invoke_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/invoke_node.h
@@ -37,6 +37,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     std::unique_ptr<DataFlowNode> clone(size_t element_id, const graph::Vertex vertex, DataFlowGraph& parent)
         const override;
 };

--- a/sdfg/include/sdfg/data_flow/library_nodes/load_const_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/load_const_node.h
@@ -123,6 +123,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     std::unique_ptr<DataFlowNode> clone(size_t element_id, const graph::Vertex vertex, DataFlowGraph& parent)
         const override;
 

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/blas/batched_gemm_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/blas/batched_gemm_node.h
@@ -92,6 +92,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     std::unique_ptr<data_flow::DataFlowNode>
     clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent) const override;
 

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/blas/dot_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/blas/dot_node.h
@@ -44,6 +44,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     void validate(const Function& function) const override;
 
     bool expand(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) override;

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/blas/gemm_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/blas/gemm_node.h
@@ -77,6 +77,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     std::unique_ptr<data_flow::DataFlowNode>
     clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent) const override;
 

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/cmath/cmath_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/cmath/cmath_node.h
@@ -404,6 +404,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     bool expand(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) override {
         return false;
     };

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/batchnorm_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/batchnorm_node.h
@@ -44,6 +44,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     std::unique_ptr<data_flow::DataFlowNode>
     clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent) const override;
 

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/broadcast_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/broadcast_node.h
@@ -34,6 +34,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     bool supports_integer_types() const override { return true; }
 
     bool expand(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) override;

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/conv_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/conv_node.h
@@ -167,6 +167,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     bool supports_integer_types() const override { return false; }
 
     std::unique_ptr<data_flow::DataFlowNode>

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/einsum_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/einsum_node.h
@@ -85,6 +85,8 @@ public:
 
     virtual void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    virtual void replace(const symbolic::ExpressionMapping& replacements) override;
+
     virtual std::string toStr() const override;
 
     virtual symbolic::Expression flop() const override;

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/elementwise_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/elementwise_node.h
@@ -171,6 +171,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     static std::pair<structured_control_flow::Sequence*, std::vector<symbolic::Expression>> add_eltwise_scope(
         builder::StructuredSDFGBuilder& builder,
         const DebugInfo& scope_deb_info,

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/matmul_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/matmul_node.h
@@ -175,6 +175,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     std::unique_ptr<data_flow::DataFlowNode>
     clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent) const override;
 

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/reduce_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/reduce_node.h
@@ -134,6 +134,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     /**
      * @brief Expand into nested maps with reduction logic
      *

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/spatial_tensor_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/spatial_tensor_node.h
@@ -90,6 +90,8 @@ public:
     symbolic::SymbolSet symbols() const override;
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+
+    void replace(const symbolic::ExpressionMapping& replacements) override;
     /**
      * @brief Number of spatial dimensions.
      *

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/tensor_layout.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/tensor_layout.h
@@ -54,6 +54,8 @@ public:
 
     void replace_symbols(const symbolic::Expression& old, const symbolic::Expression& new_expr);
 
+    void replace_symbols(const symbolic::ExpressionMapping& replacements);
+
     /**
      *
      * @param i the dimension / entry in shape. 0 is outermost

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/transpose_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/transpose_node.h
@@ -33,6 +33,8 @@ public:
 
     void replace(const symbolic::Expression old_ex, const symbolic::Expression new_ex) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     std::unique_ptr<DataFlowNode> clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent)
         const override {
         return std::unique_ptr<DataFlowNode>(new TransposeNode(element_id, debug_info(), vertex, parent, shape_, perm_)

--- a/sdfg/include/sdfg/data_flow/library_nodes/metadata_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/metadata_node.h
@@ -35,6 +35,8 @@ public:
         const override;
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 };
 
 class MetadataNodeSerializer : public serializer::LibraryNodeSerializer {

--- a/sdfg/include/sdfg/data_flow/library_nodes/stdlib/alloca.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/stdlib/alloca.h
@@ -34,6 +34,8 @@ public:
         const override;
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 };
 
 class AllocaNodeSerializer : public serializer::LibraryNodeSerializer {

--- a/sdfg/include/sdfg/data_flow/library_nodes/stdlib/assert.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/stdlib/assert.h
@@ -50,6 +50,8 @@ public:
     clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent) const override;
 
     virtual void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+
+    virtual void replace(const symbolic::ExpressionMapping& replacements) override;
 };
 
 class AssertNodeSerializer : public serializer::LibraryNodeSerializer {

--- a/sdfg/include/sdfg/data_flow/library_nodes/stdlib/calloc.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/stdlib/calloc.h
@@ -36,6 +36,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     std::unique_ptr<DataFlowNode> clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent)
         const override;
 };

--- a/sdfg/include/sdfg/data_flow/library_nodes/stdlib/free.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/stdlib/free.h
@@ -24,6 +24,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     data_flow::PointerAccessType pointer_access_type(int input_idx) const override;
 };
 

--- a/sdfg/include/sdfg/data_flow/library_nodes/stdlib/malloc.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/stdlib/malloc.h
@@ -35,6 +35,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     std::string toStr() const override;
 };
 

--- a/sdfg/include/sdfg/data_flow/library_nodes/stdlib/memcpy.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/stdlib/memcpy.h
@@ -32,6 +32,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     std::unique_ptr<DataFlowNode> clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent)
         const override;
 

--- a/sdfg/include/sdfg/data_flow/library_nodes/stdlib/memmove.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/stdlib/memmove.h
@@ -32,6 +32,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     std::unique_ptr<DataFlowNode> clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent)
         const override;
 };

--- a/sdfg/include/sdfg/data_flow/library_nodes/stdlib/memset.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/stdlib/memset.h
@@ -36,6 +36,8 @@ public:
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     std::unique_ptr<DataFlowNode> clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent)
         const override;
 

--- a/sdfg/include/sdfg/data_flow/library_nodes/stdlib/trap.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/stdlib/trap.h
@@ -26,6 +26,8 @@ public:
         const override;
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 };
 
 class TrapNodeSerializer : public serializer::LibraryNodeSerializer {

--- a/sdfg/include/sdfg/data_flow/library_nodes/stdlib/unreachable.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/stdlib/unreachable.h
@@ -28,6 +28,8 @@ public:
         const override;
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 };
 
 class UnreachableNodeSerializer : public serializer::LibraryNodeSerializer {

--- a/sdfg/include/sdfg/data_flow/memlet.h
+++ b/sdfg/include/sdfg/data_flow/memlet.h
@@ -345,6 +345,7 @@ public:
      * Replaces occurrences in the subset vector.
      */
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 };
 } // namespace data_flow
 } // namespace sdfg

--- a/sdfg/include/sdfg/data_flow/pointer_metadata.h
+++ b/sdfg/include/sdfg/data_flow/pointer_metadata.h
@@ -4,6 +4,7 @@
 #include <optional>
 
 #include "sdfg/symbolic/symbolic.h"
+#include "symengine/subs.h"
 
 namespace sdfg::data_flow {
 
@@ -48,6 +49,7 @@ public:
     MemoryAccessPatternType ref() const;
 
     virtual void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) = 0;
+    virtual void replace(const symbolic::ExpressionMapping& replacements) = 0;
 
     virtual MemoryAccessPatternType clone() const = 0;
 
@@ -71,6 +73,9 @@ public:
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override {
         size_ = symbolic::subs(size_, old_expression, new_expression);
     }
+    void replace(const symbolic::ExpressionMapping& replacements) override {
+        size_ = SymEngine::subs(size_, replacements);
+    }
 
     MemoryAccessPatternType clone() const override;
 
@@ -89,6 +94,7 @@ public:
     bool every_element_accessed() const override { return true; }
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override {}
+    void replace(const symbolic::ExpressionMapping& replacements) override {}
 
     static MemoryAccessPatternType instance();
 
@@ -134,6 +140,7 @@ public:
     PointerAccessType ref() const;
 
     virtual void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) = 0;
+    virtual void replace(const symbolic::ExpressionMapping& replacements) = 0;
 
     virtual PointerAccessType clone() const = 0;
 
@@ -179,6 +186,7 @@ public:
     MemoryAccessPatternType access_write_pattern() const override;
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 
     PointerAccessType clone() const override;
 
@@ -212,6 +220,7 @@ public:
     bool invalidated_after() const override { return false; }
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 
     PointerAccessType clone() const override;
 
@@ -249,6 +258,7 @@ public:
     bool invalidated_after() const override { return false; }
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 
     PointerAccessType clone() const override;
 
@@ -274,6 +284,7 @@ public:
     MemoryAccessPatternType access_write_pattern() const override { return NoAccessPattern::instance(); }
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override {}
+    void replace(const symbolic::ExpressionMapping& replacements) override {}
 
     PointerAccessType clone() const override;
 

--- a/sdfg/include/sdfg/data_flow/tasklet.h
+++ b/sdfg/include/sdfg/data_flow/tasklet.h
@@ -497,6 +497,7 @@ public:
      * @param new_expression Replacement expression
      */
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 
     EdgeRemoveOption can_remove_out_edge(const data_flow::DataFlowGraph& graph, const Memlet* memlet) const override;
     EdgeRemoveOption can_remove_in_edge(const data_flow::DataFlowGraph& graph, const Memlet* memlet) const override;

--- a/sdfg/include/sdfg/element.h
+++ b/sdfg/include/sdfg/element.h
@@ -94,6 +94,8 @@ public:
     virtual void validate(const Function& function) const = 0;
 
     virtual void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) = 0;
+
+    virtual void replace(const symbolic::ExpressionMapping& replacements);
 };
 
 typedef size_t ElementId;

--- a/sdfg/include/sdfg/structured_control_flow/block.h
+++ b/sdfg/include/sdfg/structured_control_flow/block.h
@@ -72,6 +72,7 @@ public:
      * @param new_expression Expression to replace with
      */
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 
     template<typename T>
     T* is_a_library_node() {

--- a/sdfg/include/sdfg/structured_control_flow/if_else.h
+++ b/sdfg/include/sdfg/structured_control_flow/if_else.h
@@ -112,6 +112,7 @@ public:
      * @param new_expression Expression to replace with
      */
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 };
 
 } // namespace structured_control_flow

--- a/sdfg/include/sdfg/structured_control_flow/return.h
+++ b/sdfg/include/sdfg/structured_control_flow/return.h
@@ -84,6 +84,7 @@ public:
      * @param new_expression Expression to replace with
      */
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+    using Element::replace;
 };
 
 } // namespace structured_control_flow

--- a/sdfg/include/sdfg/structured_control_flow/sequence.h
+++ b/sdfg/include/sdfg/structured_control_flow/sequence.h
@@ -95,6 +95,8 @@ public:
      * @param new_expression Expression to replace with
      */
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+
+    using Element::replace;
 };
 
 /**
@@ -191,6 +193,7 @@ public:
      * @param new_expression Expression to replace with
      */
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 };
 
 } // namespace structured_control_flow

--- a/sdfg/include/sdfg/structured_control_flow/structured_loop.h
+++ b/sdfg/include/sdfg/structured_control_flow/structured_loop.h
@@ -110,6 +110,8 @@ public:
      */
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
 
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+
     /**
      * @brief Describes the stride of a loop's update as a constant.
      *

--- a/sdfg/include/sdfg/structured_control_flow/while.h
+++ b/sdfg/include/sdfg/structured_control_flow/while.h
@@ -68,6 +68,7 @@ public:
      * @param new_expression Expression to replace with
      */
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 };
 
 /**
@@ -91,6 +92,7 @@ public:
     void validate(const Function& function) const override;
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 };
 
 /**
@@ -115,6 +117,7 @@ public:
     void validate(const Function& function) const override;
 
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+    void replace(const symbolic::ExpressionMapping& replacements) override;
 };
 
 } // namespace structured_control_flow

--- a/sdfg/include/sdfg/symbolic/symbolic.h
+++ b/sdfg/include/sdfg/symbolic/symbolic.h
@@ -50,6 +50,7 @@
 
 #include <unordered_map>
 #include "symengine/functions.h"
+#include "symengine/subs.h"
 
 namespace sdfg {
 
@@ -104,6 +105,8 @@ typedef std::set<Expression, SymEngine::RCPBasicKeyLess> ExpressionSet;
 
 /** @brief Map from expressions to expressions */
 typedef std::unordered_map<Expression, Expression, SymEngine::RCPBasicHash, SymEngine::RCPBasicKeyEq> ExpressionMap;
+
+typedef SymEngine::map_basic_basic ExpressionMapping;
 
 /** @} */ // end of symbolic_types group
 
@@ -685,6 +688,13 @@ ExpressionSet muls(const Expression expr);
 Expression subs(const Expression expr, const Expression old_expr, const Expression new_expr);
 
 /**
+ * Bulk replacement
+ */
+inline Expression subs(const Expression expr, const symbolic::ExpressionMapping& replacements) {
+    return SymEngine::subs(expr, replacements);
+}
+
+/**
  * @brief Substitutes a sub-expression in a condition
  * @param expr Condition to perform substitution in
  * @param old_expr Sub-expression to replace
@@ -692,6 +702,11 @@ Expression subs(const Expression expr, const Expression old_expr, const Expressi
  * @return New condition with substitution applied
  */
 Condition subs(const Condition expr, const Expression old_expr, const Expression new_expr);
+
+/**
+ * Bulk replacement
+ */
+Condition subs(const Condition expr, const symbolic::ExpressionMapping& replacements);
 
 /**
  * @brief Computes the inverse of an expression with respect to a symbol

--- a/sdfg/include/sdfg/symbolic/utils.h
+++ b/sdfg/include/sdfg/symbolic/utils.h
@@ -92,5 +92,16 @@ std::string constraint_to_isl_str(const Expression con);
  */
 void canonicalize_map_dims(isl_map* map, const std::string& in_prefix, const std::string& out_prefix);
 
+bool vectors_of_expressions_match(const std::vector<Expression>& a, const std::vector<Expression>& b);
+
+/**
+ * Applies replacement mappings to a before checking
+ * @param replacements mapping from symbols inside a to the symbols used by b
+ * @return
+ */
+bool vectors_of_expressions_match(
+    const std::vector<Expression>& a, const std::vector<Expression>& b, const ExpressionMapping& replacements
+);
+
 } // namespace symbolic
 } // namespace sdfg

--- a/sdfg/src/analysis/base_user_visitor.cpp
+++ b/sdfg/src/analysis/base_user_visitor.cpp
@@ -74,7 +74,7 @@ bool BaseUserVisitor::visit(sdfg::structured_control_flow::Sequence& node) {
             for (auto& atom : symbolic::atoms(entry.second)) {
                 if (!symbolic::is_nullptr(atom)) {
                     use_as_symbol_read(
-                        atom->get_name(), &node, &transition, SymbolReadLocation::Assignment, i, entry.second
+                        atom->get_name(), &node, &transition, SymbolReadLocation::Assignment, i, entry.first
                     );
                 }
             }

--- a/sdfg/src/analysis/loop_analysis.cpp
+++ b/sdfg/src/analysis/loop_analysis.cpp
@@ -11,44 +11,34 @@
 namespace sdfg {
 namespace analysis {
 
-LoopAnalysis::LoopAnalysis(StructuredSDFG& sdfg) : Analysis(sdfg), loops_(), loop_tree_(DFSLoopComparator(&loops_)) {}
+LoopAnalysis::LoopAnalysis(StructuredSDFG& sdfg) : Analysis(sdfg), loops_(), loop_tree_() {}
 
 void LoopAnalysis::init_new_loop_info(
-    std::pair<LocalLoopInfo, LoopInfo>& info,
+    LoopState& info,
+    uint32_t id,
     uint32_t loop_level,
     structured_control_flow::ControlFlowNode* loop,
     structured_control_flow::Map* map,
     structured_control_flow::ControlFlowNode* while_loop
 ) {
     auto is_elementwise = (map != nullptr && map->is_contiguous());
+    LocalLoopInfo::LoopType type;
+    if (while_loop != nullptr) {
+        type = LocalLoopInfo::LoopType::While;
+    } else if (map != nullptr) {
+        type = LocalLoopInfo::LoopType::Map;
+    } else {
+        type = LocalLoopInfo::LoopType::For;
+    }
 
-    info.first = {
-        .loop_id = this->next_loop_id_++,
+    info.local = {
+        .loop_id = id,
         .loop_level = loop_level,
-        .is_map = map != nullptr,
+        .type = type,
         .is_elementwise = is_elementwise,
         .contains_non_perfectly_nested = false,
         .contains_side_effects = false
     };
-    info.second.element_id = loop->element_id();
-    info.second.is_elementwise = is_elementwise;
-    info.second.has_side_effects = false;
-    info.second.max_depth = 1;
-    info.second.num_loops = 1;
-    info.second.loop_level = loop_level;
-    if (map != nullptr) {
-        info.second.num_maps = 1;
-        info.second.num_fors = 0;
-        info.second.num_whiles = 0;
-    } else if (while_loop != nullptr) {
-        info.second.num_maps = 0;
-        info.second.num_fors = 0;
-        info.second.num_whiles = 1;
-    } else {
-        info.second.num_maps = 0;
-        info.second.num_fors = 1;
-        info.second.num_whiles = 0;
-    }
 }
 
 void LoopAnalysis::
@@ -80,12 +70,13 @@ void LoopAnalysis::
         }
 
         if (new_loop != nullptr) {
+            auto id = this->loops_.size();
             this->loops_.push_back(new_loop);
             this->loop_tree_[new_loop] = parent_loop;
             this->loop_children_[parent_loop].push_back(new_loop);
             this->loop_children_[new_loop]; // ensure it gets created
             auto& loop_info = loop_infos_[new_loop];
-            init_new_loop_info(loop_info, loop_level, new_loop, new_map, new_while);
+            init_new_loop_info(loop_info, id, loop_level, new_loop, new_map, new_while);
         }
 
         if (auto block = dynamic_cast<structured_control_flow::Block*>(current)) {
@@ -106,9 +97,6 @@ void LoopAnalysis::
             }
             for (size_t i = 0; i < seq_entries; i++) {
                 auto entry = sequence_stmt->at(i);
-                if (i > 0 || !entry.second.empty()) {
-                    non_perfectly_nested = true;
-                }
                 queue.push_back(&entry.first);
             }
         } else if (auto if_else_stmt = dynamic_cast<structured_control_flow::IfElse*>(current)) {
@@ -135,19 +123,9 @@ void LoopAnalysis::
     }
 
     if (parent_loop != nullptr) {
-        auto child_count = loop_children_.at(parent_loop).size();
         auto& state = loop_infos_.at(parent_loop);
-        state.first.last_child_id = this->next_loop_id_ - 1;
-        state.first.contains_side_effects = side_effects;
-
-        if (child_count > 1) {
-            non_perfectly_nested = true;
-        } else if (child_count < 1) {
-            non_perfectly_nested = false;
-        }
-        if (non_perfectly_nested) {
-            state.first.contains_non_perfectly_nested = non_perfectly_nested;
-        }
+        state.local.contains_side_effects = side_effects;
+        state.local.contains_non_perfectly_nested = non_perfectly_nested;
     }
 }
 
@@ -163,29 +141,55 @@ structured_control_flow::Sequence* LoopAnalysis::get_loop_content_root(structure
     return root;
 }
 
-LoopState& LoopAnalysis::compute_loop_infos(structured_control_flow::ControlFlowNode* loop) {
+LoopAnalysis::LoopState& LoopAnalysis::compute_loop_infos(structured_control_flow::ControlFlowNode* loop) {
     // Recursion
+    auto& loop_children = this->loop_children_.at(loop);
+    for (auto& child_loop : loop_children) {
+        this->compute_loop_infos(child_loop);
+    }
+
     auto& loop_state = this->loop_infos_.at(loop);
-    LoopInfo& info = loop_state.second;
+    auto new_state = this->aggregate_loop_info(loop);
+    loop_state.nest = std::move(new_state.nest);
+    loop_state.local.last_child_id = new_state.last_child_id;
+    return loop_state;
+}
+
+LoopAnalysis::AggregatedResult LoopAnalysis::aggregate_loop_info(structured_control_flow::ControlFlowNode* loop) const {
+    auto& loop_state = this->loop_infos_.at(loop);
+    const LocalLoopInfo& local = loop_state.local;
     auto& loop_children = this->loop_children_.at(loop);
 
-    bool is_perfectly_nested = !loop_state.first.contains_non_perfectly_nested;
-    bool is_perfectly_parallel = loop_state.first.is_map;
-    bool is_elementwise = loop_state.first.is_elementwise;
-    bool map_stack_member = loop_state.first.is_map;
-    bool has_side_effects = loop_state.first.contains_side_effects;
+    // Start from the existing infos to preserve fields that do not depend on the subtree
+    // (element_id, loop_level, loopnest_index) and reset the aggregated, subtree-derived fields.
+    AggregatedResult result;
+    auto& info = result.nest;
+    info.element_id = loop->element_id();
+    info.loop_level = local.loop_level;
+    info.num_loops = 1;
+    info.num_maps = local.type == LocalLoopInfo::LoopType::Map ? 1 : 0;
+    info.num_whiles = local.type == LocalLoopInfo::LoopType::While ? 1 : 0;
+    info.num_fors = local.type == LocalLoopInfo::LoopType::For ? 1 : 0;
+    info.max_depth = 1;
+    result.last_child_id = local.loop_id;
+
+    bool is_perfectly_nested = !local.contains_non_perfectly_nested;
+    bool is_perfectly_parallel = local.type == LocalLoopInfo::LoopType::Map;
+    bool is_elementwise = local.is_elementwise;
+    bool map_stack_member = local.type == LocalLoopInfo::LoopType::Map;
+    bool has_side_effects = local.contains_side_effects;
     bool map_stack_children = map_stack_member && loop_children.size() <= 1;
     uint32_t map_stack_depth = 0;
 
     for (auto& child_loop : loop_children) {
-        this->compute_loop_infos(child_loop);
-
-        auto& sub_info = this->loop_infos_.at(child_loop).second;
+        auto& sub_state = this->loop_infos_.at(child_loop);
+        auto& sub_info = sub_state.nest;
         info.num_loops += sub_info.num_loops;
         info.num_maps += sub_info.num_maps;
         info.num_fors += sub_info.num_fors;
         info.num_whiles += sub_info.num_whiles;
         info.max_depth = std::max(info.max_depth, 1 + sub_info.max_depth);
+        result.last_child_id = std::max(result.last_child_id, sub_state.local.last_child_id);
 
         has_side_effects |= sub_info.has_side_effects;
         is_perfectly_nested &= sub_info.is_perfectly_nested;
@@ -197,8 +201,15 @@ LoopState& LoopAnalysis::compute_loop_infos(structured_control_flow::ControlFlow
     }
 
     info.is_perfectly_parallel = is_perfectly_parallel;
-    info.is_perfectly_nested = is_perfectly_nested;
-    info.is_elementwise &= is_elementwise && is_perfectly_nested & is_perfectly_parallel;
+    auto child_count = loop_children.size();
+    if (child_count > 1) {
+        info.is_perfectly_nested = false;
+    } else if (child_count < 1) {
+        info.is_perfectly_nested = true;
+    } else {
+        info.is_perfectly_nested = is_perfectly_nested;
+    }
+    info.is_elementwise = is_elementwise && is_perfectly_nested & is_perfectly_parallel;
     info.has_side_effects = has_side_effects;
     if (map_stack_member) {
         if (!is_perfectly_nested) { // needs to be perfectly nested to form a larger stack
@@ -207,7 +218,15 @@ LoopState& LoopAnalysis::compute_loop_infos(structured_control_flow::ControlFlow
         info.map_stack_depth = map_stack_depth + 1;
     }
 
-    return loop_state;
+    return result;
+}
+
+void LoopAnalysis::reindex_loop_nest_idx() {
+    auto& root_loops = this->loop_children_.at(nullptr);
+
+    for (size_t i = 0; i < root_loops.size(); ++i) {
+        this->loop_infos_[root_loops.at(i)].nest.loopnest_index = i;
+    }
 }
 
 void LoopAnalysis::run(AnalysisManager& analysis_manager) {
@@ -220,24 +239,27 @@ void LoopAnalysis::run(AnalysisManager& analysis_manager) {
 
     // Set loopnest indices for outermost loops
     int loopnest_index = 0;
-    auto root_it = this->loop_children_.find(nullptr);
-    if (root_it != this->loop_children_.end()) {
-        auto& root_loops = root_it->second;
-        for (auto* root_loop : root_loops) {
-            this->compute_loop_infos(root_loop);
-            this->loop_infos_[root_loop].second.loopnest_index = loopnest_index++;
-        }
+    auto& root_loops = this->loop_children_.at(nullptr);
+
+    for (auto* root_loop : root_loops) {
+        this->compute_loop_infos(root_loop);
+        this->loop_infos_[root_loop].nest.loopnest_index = loopnest_index++;
     }
 }
 
-const std::vector<structured_control_flow::ControlFlowNode*> LoopAnalysis::loops() const { return this->loops_; }
+const std::vector<structured_control_flow::ControlFlowNode*> LoopAnalysis::loops() const {
+    return this->loops_;
+} // copies by default...
+const std::vector<structured_control_flow::ControlFlowNode*>& LoopAnalysis::loops_in_pre_order() const {
+    return this->loops_;
+}
 
 LoopInfo LoopAnalysis::loop_info(structured_control_flow::ControlFlowNode* loop) const {
-    return this->loop_infos_.at(loop).second;
+    return this->loop_infos_.at(loop).nest;
 }
 
 const LocalLoopInfo& LoopAnalysis::loop_info_local(structured_control_flow::ControlFlowNode* loop) const {
-    return this->loop_infos_.at(loop).first;
+    return this->loop_infos_.at(loop).local;
 }
 
 structured_control_flow::ControlFlowNode* LoopAnalysis::find_loop_by_indvar(const std::string& indvar) {
@@ -251,7 +273,7 @@ structured_control_flow::ControlFlowNode* LoopAnalysis::find_loop_by_indvar(cons
     return nullptr;
 }
 
-const std::map<structured_control_flow::ControlFlowNode*, structured_control_flow::ControlFlowNode*, DFSLoopComparator>&
+const std::unordered_map<structured_control_flow::ControlFlowNode*, structured_control_flow::ControlFlowNode*>&
 LoopAnalysis::loop_tree() const {
     return this->loop_tree_;
 }
@@ -305,10 +327,9 @@ std::list<std::vector<sdfg::structured_control_flow::ControlFlowNode*>> LoopAnal
 
 std::list<std::vector<sdfg::structured_control_flow::ControlFlowNode*>> LoopAnalysis::loop_tree_paths(
     sdfg::structured_control_flow::ControlFlowNode* loop,
-    const std::map<
+    const std::unordered_map<
         sdfg::structured_control_flow::ControlFlowNode*,
-        sdfg::structured_control_flow::ControlFlowNode*,
-        DFSLoopComparator>& tree
+        sdfg::structured_control_flow::ControlFlowNode*>& tree
 ) const {
     // Collect all paths in tree starting from loop recursively (DFS)
     std::list<std::vector<sdfg::structured_control_flow::ControlFlowNode*>> paths;
@@ -352,7 +373,10 @@ void LoopAnalysis::dump_to_file(std::filesystem::path file) const {
     for (auto& loop : this->loops_) {
         auto& info = loop_infos_.at(loop);
 
-        arr.push_back(loop_info_to_json(info.second));
+        nlohmann::json entry;
+        loop_info_local_to_json(entry["info"], info.local);
+        entry["nest"] = loop_info_to_json(info.nest);
+        arr.push_back(entry);
     }
 
 
@@ -371,32 +395,243 @@ void LoopAnalysis::copied_loop(
     structured_control_flow::ControlFlowNode* new_loop,
     bool start_not_end
 ) {
-    // this->loops_.push_back(new_loop);
-    // this->loop_tree_[new_loop] = new_parent_loop;
-    // auto& new_loop_state = loop_infos_[new_loop];
-    // size_t new_loop_id;
-    // {
-    //     auto& new_parent_loop_children = loop_children_.at(new_parent_loop);
-    //     if (start_not_end) {
-    //         new_loop_id = new_parent_loop_children.size();
-    //         new_parent_loop_children.insert(new_parent_loop_children.begin(), new_loop);
-    //     } else {
-    //         new_parent_loop_children.push_back(new_loop);
-    //     }
-    // }
-    // run(*new_loop, new_parent_loop, loop_infos_.at(new_parent_loop).first.loop_level + 1);
-    //
-    // auto& ex_loop_info = loop_infos_.at(existing_loop);
-    // auto& new_parent_state = loop_infos_.at(new_parent_loop);
-    // auto& copied_children = loop_children_.at(existing_loop);
-    //
-    // this->init_new_loop_info(
-    //     new_loop_state,
-    //     new_parent_state.first.loop_level+1,
-    //     new_loop,
-    //     dynamic_cast<structured_control_flow::Map*>(new_loop),
-    //     dynamic_cast<structured_control_flow::While*>(new_loop)
-    // );
+    // `existing_loop` is only the conceptual source of the copy. The caller has already materialized
+    // `new_loop` (with whatever subtree it has) inside `new_parent_loop` in the SDFG, so we simply
+    // (re)derive everything for the new subtree directly from the SDFG instead of cloning infos.
+    (void) existing_loop;
+
+    // Where the root of the new subtree should live in the pre-order `loops_` vector.
+    auto insert_idx = child_insertion_index(new_parent_loop, start_not_end);
+
+    uint32_t new_loop_level = new_parent_loop == nullptr ? 0 : loop_infos_.at(new_parent_loop).local.loop_level + 1;
+
+    // run() rescans the scope and overwrites the parent's local side-effect / non-perfect-nesting
+    // flags based on that scan. Adding a loop child does not legitimately change either flag (they
+    // describe non-loop body content), so snapshot and restore them around the call.
+    bool had_parent = new_parent_loop != nullptr;
+    bool saved_side_effects = false;
+    bool saved_non_perfect = false;
+    if (had_parent) {
+        auto& pl = loop_infos_.at(new_parent_loop).local;
+        saved_side_effects = pl.contains_side_effects;
+        saved_non_perfect = pl.contains_non_perfectly_nested;
+    }
+
+    // Analyze the new subtree. run() appends it (in pre-order) to the end of `loops_`, registers it
+    // in loop_tree_/loop_children_ (as the last child of new_parent_loop) and fills in local infos.
+    auto block_start = static_cast<uint32_t>(loops_.size());
+    this->run(*new_loop, new_parent_loop, new_loop_level);
+
+    if (had_parent) {
+        auto& pl = loop_infos_.at(new_parent_loop).local;
+        pl.contains_side_effects = saved_side_effects;
+        pl.contains_non_perfectly_nested = saved_non_perfect;
+    }
+
+    // Bottom-up fill the nest infos (and last_child_id spans) of the freshly added subtree. At this
+    // point the subtree still sits at the tail of `loops_` with contiguous, correct relative ids.
+    this->compute_loop_infos(new_loop);
+
+    // run() always appends the new root as the last child; move it to the front if requested.
+    if (start_not_end) {
+        auto& np_children = loop_children_.at(new_parent_loop);
+        np_children.pop_back();
+        np_children.insert(np_children.begin(), new_loop);
+    }
+
+    // Splice the new block out of the tail of `loops_` and into its pre-order position.
+    std::vector<structured_control_flow::ControlFlowNode*> new_block(loops_.begin() + block_start, loops_.end());
+    loops_.erase(loops_.begin() + block_start, loops_.end());
+    loops_.insert(loops_.begin() + insert_idx, new_block.begin(), new_block.end());
+
+    // Everything from the insertion point onward now has a stale loop_id (the block moved, the rest
+    // shifted right). reindex preserves each node's subtree span, which is correct for all of them.
+    reindex(loops_.begin() + insert_idx, loops_.end());
+
+    // Propagate the new subtree's contribution (grown last_child_id, changed nest aggregates) up the
+    // parent chain. The new subtree itself already holds up-to-date infos from compute_loop_infos.
+    if (new_parent_loop != nullptr) {
+        propagate_changed_nest_info(loops_.begin() + loop_infos_.at(new_parent_loop).local.loop_id);
+    }
+
+    reindex_loop_nest_idx();
+}
+
+uint32_t LoopAnalysis::child_insertion_index(structured_control_flow::ControlFlowNode* new_parent, bool start_not_end)
+    const {
+    const auto& children = loop_children_.at(new_parent);
+    auto it = start_not_end ? children.begin() : children.end();
+    if (it != children.end()) {
+        // Insert right where the chosen child's subtree starts.
+        return loop_infos_.at(*it).local.loop_id;
+    }
+    if (new_parent == nullptr) {
+        // Appending after all root-level loops.
+        return static_cast<uint32_t>(loops_.size());
+    }
+    // Insert right after the new parent's current subtree.
+    return loop_infos_.at(new_parent).local.last_child_id + 1;
+}
+
+void LoopAnalysis::moved_loop(
+    structured_control_flow::ControlFlowNode* existing_loop,
+    structured_control_flow::StructuredLoop* new_parent,
+    bool start_not_end
+) {
+    auto& moved_state = loop_infos_.at(existing_loop);
+    auto old_parent = loop_tree_.at(existing_loop);
+
+    // The moved subtree occupies the contiguous pre-order range [first_moved_idx, next_after_moved_idx).
+    auto first_moved_idx = moved_state.local.loop_id;
+    auto next_after_moved_idx = moved_state.local.last_child_id + 1;
+    auto moved_span = next_after_moved_idx - first_moved_idx;
+
+    // Translate the requested child position (front/back) into an index in the pre-order `loops_`.
+    auto insert_idx = child_insertion_index(new_parent, start_not_end);
+    auto& new_parent_children = loop_children_.at(new_parent);
+
+    // Snapshot the moved block of nodes before we mutate `loops_`.
+    std::vector<structured_control_flow::ControlFlowNode*>
+        moved_block(loops_.begin() + first_moved_idx, loops_.begin() + next_after_moved_idx);
+
+    // Update the level of every node in the moved subtree (its root's level becomes new_parent.level + 1).
+    auto level_delta = static_cast<int64_t>(loop_infos_.at(new_parent).local.loop_level) + 1 -
+                       static_cast<int64_t>(moved_state.local.loop_level);
+    if (level_delta != 0) {
+        for (auto* node : moved_block) {
+            auto& local = loop_infos_.at(node).local;
+            local.loop_level = static_cast<uint32_t>(static_cast<int64_t>(local.loop_level) + level_delta);
+        }
+    }
+
+    // Detach from the old parent's child list and reparent the moved root.
+    auto& old_parent_children = loop_children_.at(old_parent);
+    old_parent_children.erase(
+        std::remove(old_parent_children.begin(), old_parent_children.end(), existing_loop), old_parent_children.end()
+    );
+    loop_tree_[existing_loop] = new_parent;
+
+    // Splice the moved block out of `loops_` and back in at the insertion point.
+    // Erasing first shifts everything after the block left by `moved_span`; account for that when the
+    // insertion point lies past the removed block.
+    loops_.erase(loops_.begin() + first_moved_idx, loops_.begin() + next_after_moved_idx);
+    if (insert_idx > next_after_moved_idx) {
+        insert_idx -= moved_span;
+    } else if (insert_idx > first_moved_idx) {
+        // Insertion point was inside the moved block (only possible if new_parent is within the moved
+        // subtree, which is not a valid move) -> clamp to the block's start.
+        insert_idx = first_moved_idx;
+    }
+    loops_.insert(loops_.begin() + insert_idx, moved_block.begin(), moved_block.end());
+
+    // Insert into the new parent's child list. Recompute the iterator since `start_not_end` may not be the
+    // only supported mode in the future; for begin()/end() this is stable across the splice above.
+    auto new_insert_it = start_not_end ? new_parent_children.begin() : new_parent_children.end();
+    new_parent_children.insert(new_insert_it, existing_loop);
+
+    // All loop_ids from the lower of the two touched regions onward are now stale: reindex the whole span.
+    auto reindex_from = std::min(first_moved_idx, insert_idx);
+    reindex(loops_.begin() + reindex_from, loops_.end());
+
+    // Propagate nest-info changes up both affected parent chains. The deeper of the two parents must be
+    // processed first so the shallower one aggregates already-updated children.
+    structured_control_flow::ControlFlowNode* lo = old_parent;
+    structured_control_flow::ControlFlowNode* hi = new_parent;
+    if (lo != hi) {
+        auto level_of = [&](structured_control_flow::ControlFlowNode* n) {
+            return n == nullptr ? -1 : static_cast<int64_t>(loop_infos_.at(n).local.loop_level);
+        };
+        if (level_of(lo) < level_of(hi)) {
+            std::swap(lo, hi);
+        }
+        if (lo != nullptr) {
+            propagate_changed_nest_info(loops_.begin() + loop_infos_.at(lo).local.loop_id);
+        }
+        if (hi != nullptr) {
+            propagate_changed_nest_info(loops_.begin() + loop_infos_.at(hi).local.loop_id);
+        }
+    } else if (new_parent != nullptr) {
+        propagate_changed_nest_info(loops_.begin() + loop_infos_.at(new_parent).local.loop_id);
+    }
+
+    reindex_loop_nest_idx();
+}
+
+void LoopAnalysis::reindex(
+    std::vector<structured_control_flow::ControlFlowNode*>::iterator start,
+    std::vector<structured_control_flow::ControlFlowNode*>::iterator end
+) {
+    for (auto it = start; it != end; ++it) {
+        auto& local_info = loop_infos_.at(*it).local;
+        auto new_loop_id = static_cast<uint32_t>(std::distance(loops_.begin(), it));
+        // The number of (transitive) descendants is unchanged; only the base index shifts.
+        auto span = local_info.last_child_id - local_info.loop_id;
+        local_info.loop_id = new_loop_id;
+        local_info.last_child_id = new_loop_id + span;
+    }
+}
+
+void LoopAnalysis::propagate_changed_nest_info(std::vector<structured_control_flow::ControlFlowNode*>::iterator top) {
+    // Starting at `top`, recompute each loop's nest info from its (already up-to-date) children and local state.
+    // Walk up the parent chain, stopping as soon as a loop's info is unchanged or the root (nullptr) is reached.
+    auto loop_info_equal = [](const LoopInfo& a, const LoopInfo& b) {
+        bool equal = true;
+#define X(type, name, val) equal = equal && (a.name == b.name);
+        LOOP_INFO_PROPERTIES
+#undef X
+        return equal;
+    };
+
+    structured_control_flow::ControlFlowNode* current = *top;
+    while (current != nullptr) {
+        auto new_info = this->aggregate_loop_info(current);
+        auto& state = this->loop_infos_.at(current);
+        if (state.local.last_child_id == new_info.last_child_id && loop_info_equal(state.nest, new_info.nest)) {
+            break; // no change here means nothing changes further up
+        }
+        state.local.last_child_id = new_info.last_child_id;
+        state.nest = std::move(new_info.nest);
+        current = this->loop_tree_.at(current);
+    }
+}
+
+void LoopAnalysis::removed_loop(structured_control_flow::ControlFlowNode* existing_loop) {
+    auto& state = loop_infos_.at(existing_loop);
+    auto removed_loop_idx = state.local.loop_id;
+    auto next_not_removed_idx = state.local.last_child_id + 1;
+    auto parent_of_removed = loop_tree_.at(existing_loop);
+    auto first_removed = loops_.begin() + removed_loop_idx;
+    auto next_not_removed = loops_.begin() + next_not_removed_idx;
+
+    for (auto* elem : std::ranges::subrange(first_removed, next_not_removed) | std::views::reverse) {
+        loop_infos_.erase(elem);
+        loop_tree_.erase(elem);
+        loop_children_.erase(elem);
+    }
+
+    auto& parent_children = loop_children_.at(parent_of_removed);
+    parent_children
+        .erase(std::remove(parent_children.begin(), parent_children.end(), existing_loop), parent_children.end());
+
+    loops_.erase(first_removed, next_not_removed);
+
+    reindex(first_removed, loops_.end());
+
+    if (parent_of_removed != nullptr) {
+        propagate_changed_nest_info(loops_.begin() + loop_infos_.at(parent_of_removed).local.loop_id);
+    }
+
+    reindex_loop_nest_idx();
+}
+
+void loop_info_local_to_json(nlohmann::json& j, const LocalLoopInfo& info) {
+    j["loop_id"] = info.loop_id;
+    j["last_child_id"] = info.last_child_id;
+    j["loop_level"] = info.loop_level;
+    j["type"] = info.type;
+    j["is_elementwise"] = info.is_elementwise;
+    j["contains_non_perfectly_nested"] = info.contains_non_perfectly_nested;
+    j["contains_side_effects"] = info.contains_side_effects;
 }
 
 } // namespace analysis

--- a/sdfg/src/analysis/loop_analysis.cpp
+++ b/sdfg/src/analysis/loop_analysis.cpp
@@ -365,5 +365,39 @@ void LoopAnalysis::dump_to_file(std::filesystem::path file) const {
     out.close();
 }
 
+void LoopAnalysis::copied_loop(
+    structured_control_flow::ControlFlowNode* existing_loop,
+    structured_control_flow::ControlFlowNode* new_parent_loop,
+    structured_control_flow::ControlFlowNode* new_loop,
+    bool start_not_end
+) {
+    // this->loops_.push_back(new_loop);
+    // this->loop_tree_[new_loop] = new_parent_loop;
+    // auto& new_loop_state = loop_infos_[new_loop];
+    // size_t new_loop_id;
+    // {
+    //     auto& new_parent_loop_children = loop_children_.at(new_parent_loop);
+    //     if (start_not_end) {
+    //         new_loop_id = new_parent_loop_children.size();
+    //         new_parent_loop_children.insert(new_parent_loop_children.begin(), new_loop);
+    //     } else {
+    //         new_parent_loop_children.push_back(new_loop);
+    //     }
+    // }
+    // run(*new_loop, new_parent_loop, loop_infos_.at(new_parent_loop).first.loop_level + 1);
+    //
+    // auto& ex_loop_info = loop_infos_.at(existing_loop);
+    // auto& new_parent_state = loop_infos_.at(new_parent_loop);
+    // auto& copied_children = loop_children_.at(existing_loop);
+    //
+    // this->init_new_loop_info(
+    //     new_loop_state,
+    //     new_parent_state.first.loop_level+1,
+    //     new_loop,
+    //     dynamic_cast<structured_control_flow::Map*>(new_loop),
+    //     dynamic_cast<structured_control_flow::While*>(new_loop)
+    // );
+}
+
 } // namespace analysis
 } // namespace sdfg

--- a/sdfg/src/analysis/loop_analysis.cpp
+++ b/sdfg/src/analysis/loop_analysis.cpp
@@ -211,7 +211,7 @@ LoopAnalysis::AggregatedResult LoopAnalysis::aggregate_loop_info(structured_cont
     info.is_elementwise = is_elementwise && is_perfectly_nested & is_perfectly_parallel;
     info.has_side_effects = has_side_effects;
     if (map_stack_member) {
-        if (!is_perfectly_nested) { // needs to be perfectly nested to form a larger stack
+        if (local.contains_non_perfectly_nested) { // needs to be perfectly nested to form a larger stack
             map_stack_depth = 0;
         }
         info.map_stack_depth = map_stack_depth + 1;
@@ -353,7 +353,7 @@ std::unordered_set<sdfg::structured_control_flow::ControlFlowNode*> LoopAnalysis
     descendants(sdfg::structured_control_flow::ControlFlowNode* loop) const {
     std::unordered_set<sdfg::structured_control_flow::ControlFlowNode*> desc;
     std::list<sdfg::structured_control_flow::ControlFlowNode*> queue = {loop};
-    while (!queue.empty()) {
+    while (!queue.empty()) { // TODO use ordered list directly
         auto current = queue.front();
         queue.pop_front();
         auto& children = this->children(current);

--- a/sdfg/src/analysis/loop_analysis.cpp
+++ b/sdfg/src/analysis/loop_analysis.cpp
@@ -203,12 +203,11 @@ LoopAnalysis::AggregatedResult LoopAnalysis::aggregate_loop_info(structured_cont
     info.is_perfectly_parallel = is_perfectly_parallel;
     auto child_count = loop_children.size();
     if (child_count > 1) {
-        info.is_perfectly_nested = false;
+        is_perfectly_nested = false;
     } else if (child_count < 1) {
-        info.is_perfectly_nested = true;
-    } else {
-        info.is_perfectly_nested = is_perfectly_nested;
+        is_perfectly_nested = true;
     }
+    info.is_perfectly_nested = is_perfectly_nested;
     info.is_elementwise = is_elementwise && is_perfectly_nested & is_perfectly_parallel;
     info.has_side_effects = has_side_effects;
     if (map_stack_member) {
@@ -622,6 +621,15 @@ void LoopAnalysis::removed_loop(structured_control_flow::ControlFlowNode* existi
     }
 
     reindex_loop_nest_idx();
+}
+
+void LoopAnalysis::
+    added_local_contents(structured_control_flow::ControlFlowNode* loop, bool side_effects, bool non_perfectly_nested) {
+    auto& state = loop_infos_.at(loop);
+    state.local.contains_side_effects = side_effects;
+    state.local.contains_non_perfectly_nested = non_perfectly_nested;
+
+    propagate_changed_nest_info(loops_.begin() + state.local.loop_id);
 }
 
 void loop_info_local_to_json(nlohmann::json& j, const LocalLoopInfo& info) {

--- a/sdfg/src/builder/structured_sdfg_builder.cpp
+++ b/sdfg/src/builder/structured_sdfg_builder.cpp
@@ -15,7 +15,6 @@ using namespace sdfg::structured_control_flow;
 
 namespace sdfg {
 namespace builder {
-
 std::unordered_set<const control_flow::State*> StructuredSDFGBuilder::
     determine_loop_nodes(SDFG& sdfg, const control_flow::State& start, const control_flow::State& end) const {
     std::unordered_set<const control_flow::State*> nodes;
@@ -532,6 +531,20 @@ std::pair<Sequence&, Transition&> StructuredSDFGBuilder::
     }
 
     return insert_node_internal<Sequence>(parent, index, {}, debug_info);
+}
+
+void StructuredSDFGBuilder::remove_from_parent(ControlFlowNode& child) {
+    auto* parent = dynamic_cast<structured_control_flow::Sequence*>(child.get_parent());
+    if (parent == nullptr) {
+        throw InvalidSDFGException(
+            "StructuredSDFGBuilder: Child has no sequence parent: #" + std::to_string(child.element_id())
+        );
+    }
+    auto idx = parent->index(child);
+    if (idx < 0) {
+        throw InvalidSDFGException("StructuredSDFGBuilder: Child not found in parent");
+    }
+    remove_child(*parent, idx);
 }
 
 void StructuredSDFGBuilder::remove_child(Sequence& parent, size_t index) {

--- a/sdfg/src/data_flow/data_flow_graph.cpp
+++ b/sdfg/src/data_flow/data_flow_graph.cpp
@@ -139,7 +139,17 @@ void DataFlowGraph::replace(const symbolic::Expression old_expression, const sym
     for (auto& edge : this->edges_) {
         edge.second->replace(old_expression, new_expression);
     }
-};
+}
+
+void DataFlowGraph::replace(const symbolic::ExpressionMapping& replacements) {
+    for (auto& node : this->nodes_) {
+        node.second->replace(replacements);
+    }
+
+    for (auto& edge : this->edges_) {
+        edge.second->replace(replacements);
+    }
+}
 
 /***** Section: Analysis *****/
 

--- a/sdfg/src/data_flow/data_flow_graph.cpp
+++ b/sdfg/src/data_flow/data_flow_graph.cpp
@@ -60,6 +60,19 @@ const data_flow::Memlet* DataFlowGraph::in_edge(const data_flow::AccessNode& nod
     return &edge;
 }
 
+const data_flow::Memlet* DataFlowGraph::in_edge_if_single(const data_flow::AccessNode& node) const {
+    auto edges = in_edges(node);
+    auto it = edges.begin();
+    if (it == edges.end()) {
+        return nullptr;
+    }
+    const auto& edge = *it;
+    if (++it != edges.end()) {
+        return nullptr;
+    }
+    return &edge;
+}
+
 std::vector<data_flow::Memlet*> DataFlowGraph::in_edges_by_connector(const data_flow::CodeNode& node) {
     std::vector<data_flow::Memlet*> in_edges(node.inputs().size(), nullptr);
     for (auto& iedge : this->in_edges(node)) {

--- a/sdfg/src/data_flow/library_nodes/barrier_local_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/barrier_local_node.cpp
@@ -32,6 +32,10 @@ void BarrierLocalNode::replace(const symbolic::Expression old_expression, const 
     // Do nothing
 };
 
+void BarrierLocalNode::replace(const symbolic::ExpressionMapping& replacements) {
+    // Do nothing
+};
+
 nlohmann::json BarrierLocalNodeSerializer::serialize(const sdfg::data_flow::LibraryNode& library_node) {
     if (library_node.code() != data_flow::LibraryNodeType_BarrierLocal) {
         throw std::runtime_error("Invalid library node code");

--- a/sdfg/src/data_flow/library_nodes/call_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/call_node.cpp
@@ -102,6 +102,14 @@ void CallNode::replace(const symbolic::Expression old_expression, const symbolic
     }
 }
 
+void CallNode::replace(const symbolic::ExpressionMapping& replacements) {
+    for (auto& meta : ptr_access_meta_) {
+        if (meta) {
+            meta->replace(replacements);
+        }
+    }
+}
+
 nlohmann::json CallNodeSerializer::serialize(const data_flow::LibraryNode& library_node) {
     const CallNode& node = static_cast<const CallNode&>(library_node);
 

--- a/sdfg/src/data_flow/library_nodes/invoke_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/invoke_node.cpp
@@ -74,6 +74,8 @@ std::unique_ptr<data_flow::DataFlowNode> InvokeNode::
 
 void InvokeNode::replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {}
 
+void InvokeNode::replace(const symbolic::ExpressionMapping& replacements) {}
+
 nlohmann::json InvokeNodeSerializer::serialize(const data_flow::LibraryNode& library_node) {
     const InvokeNode& node = static_cast<const InvokeNode&>(library_node);
 

--- a/sdfg/src/data_flow/library_nodes/load_const_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/load_const_node.cpp
@@ -42,6 +42,8 @@ std::unique_ptr<data_flow::DataFlowNode> LoadConstNode::
 
 void LoadConstNode::replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {}
 
+void LoadConstNode::replace(const symbolic::ExpressionMapping& replacements) {}
+
 nlohmann::json LoadConstNodeSerializer::serialize(const data_flow::LibraryNode& library_node) {
     const LoadConstNode& node = static_cast<const LoadConstNode&>(library_node);
 

--- a/sdfg/src/data_flow/library_nodes/math/blas/batched_gemm_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/blas/batched_gemm_node.cpp
@@ -119,6 +119,19 @@ void BatchedGEMMNode::replace(const symbolic::Expression old_expression, const s
     this->stride_c_ = symbolic::subs(this->stride_c_, old_expression, new_expression);
 }
 
+void BatchedGEMMNode::replace(const symbolic::ExpressionMapping& replacements) {
+    this->batch_count_ = symbolic::subs(this->batch_count_, replacements);
+    this->m_ = symbolic::subs(this->m_, replacements);
+    this->n_ = symbolic::subs(this->n_, replacements);
+    this->k_ = symbolic::subs(this->k_, replacements);
+    this->lda_ = symbolic::subs(this->lda_, replacements);
+    this->ldb_ = symbolic::subs(this->ldb_, replacements);
+    this->ldc_ = symbolic::subs(this->ldc_, replacements);
+    this->stride_a_ = symbolic::subs(this->stride_a_, replacements);
+    this->stride_b_ = symbolic::subs(this->stride_b_, replacements);
+    this->stride_c_ = symbolic::subs(this->stride_c_, replacements);
+}
+
 void BatchedGEMMNode::validate(const Function& function) const { BLASNode::validate(function); }
 
 symbolic::Expression BatchedGEMMNode::flop() const {

--- a/sdfg/src/data_flow/library_nodes/math/blas/dot_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/blas/dot_node.cpp
@@ -63,6 +63,12 @@ void DotNode::replace(const symbolic::Expression old_expression, const symbolic:
     this->incy_ = symbolic::subs(this->incy_, old_expression, new_expression);
 };
 
+void DotNode::replace(const symbolic::ExpressionMapping& replacements) {
+    this->n_ = symbolic::subs(this->n_, replacements);
+    this->incx_ = symbolic::subs(this->incx_, replacements);
+    this->incy_ = symbolic::subs(this->incy_, replacements);
+};
+
 void DotNode::validate(const Function& function) const { BLASNode::validate(function); }
 
 bool DotNode::expand(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {

--- a/sdfg/src/data_flow/library_nodes/math/blas/gemm_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/blas/gemm_node.cpp
@@ -89,6 +89,15 @@ void GEMMNode::replace(const symbolic::Expression old_expression, const symbolic
     this->ldc_ = symbolic::subs(this->ldc_, old_expression, new_expression);
 };
 
+void GEMMNode::replace(const symbolic::ExpressionMapping& replacements) {
+    this->m_ = symbolic::subs(this->m_, replacements);
+    this->n_ = symbolic::subs(this->n_, replacements);
+    this->k_ = symbolic::subs(this->k_, replacements);
+    this->lda_ = symbolic::subs(this->lda_, replacements);
+    this->ldb_ = symbolic::subs(this->ldb_, replacements);
+    this->ldc_ = symbolic::subs(this->ldc_, replacements);
+};
+
 void GEMMNode::validate(const Function& function) const { BLASNode::validate(function); }
 
 bool GEMMNode::expand(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {

--- a/sdfg/src/data_flow/library_nodes/math/cmath/cmath_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/cmath/cmath_node.cpp
@@ -222,6 +222,8 @@ void CMathNode::replace(const symbolic::Expression old_expression, const symboli
     return;
 }
 
+void CMathNode::replace(const symbolic::ExpressionMapping& replacements) { return; }
+
 void CMathNode::validate(const Function& function) const {
     MathNode::validate(function);
 

--- a/sdfg/src/data_flow/library_nodes/math/tensor/batchnorm_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/batchnorm_node.cpp
@@ -45,6 +45,8 @@ void BatchNormNode::replace(const symbolic::Expression old_expression, const sym
     layout_.replace_symbols(old_expression, new_expression);
 }
 
+void BatchNormNode::replace(const symbolic::ExpressionMapping& replacements) { layout_.replace_symbols(replacements); }
+
 std::unique_ptr<data_flow::DataFlowNode> BatchNormNode::
     clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent) const {
     return std::unique_ptr<data_flow::DataFlowNode>(new BatchNormNode(

--- a/sdfg/src/data_flow/library_nodes/math/tensor/broadcast_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/broadcast_node.cpp
@@ -93,6 +93,15 @@ void BroadcastNode::replace(const symbolic::Expression old_expression, const sym
     }
 }
 
+void BroadcastNode::replace(const symbolic::ExpressionMapping& replacements) {
+    for (auto& dim : input_shape_) {
+        dim = symbolic::subs(dim, replacements);
+    }
+    for (auto& dim : output_shape_) {
+        dim = symbolic::subs(dim, replacements);
+    }
+}
+
 bool BroadcastNode::expand(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {
     auto& dataflow = this->get_parent();
     auto& block = static_cast<structured_control_flow::Block&>(*dataflow.get_parent());

--- a/sdfg/src/data_flow/library_nodes/math/tensor/conv_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/conv_node.cpp
@@ -603,6 +603,12 @@ void ConvNode::replace(const symbolic::Expression old_expression, const symbolic
     group_ = symbolic::subs(group_, old_expression, new_expression);
 }
 
+void ConvNode::replace(const symbolic::ExpressionMapping& replacements) {
+    SpatialTensorNode::replace(replacements);
+    output_channels_ = symbolic::subs(output_channels_, replacements);
+    group_ = symbolic::subs(group_, replacements);
+}
+
 std::unique_ptr<data_flow::DataFlowNode> ConvNode::
     clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent) const {
     return std::unique_ptr<data_flow::DataFlowNode>(new ConvNode(

--- a/sdfg/src/data_flow/library_nodes/math/tensor/einsum_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/einsum_node.cpp
@@ -564,6 +564,35 @@ void EinsumNode::replace(const symbolic::Expression old_expression, const symbol
     // Note: indices only contain internal indvars, so no substitution needed
 }
 
+void EinsumNode::replace(const symbolic::ExpressionMapping& replacements) {
+    // Filter out replacements whose key is an internal symbol (indvar)
+    symbolic::ExpressionMapping filtered;
+    for (auto& pair : replacements) {
+        bool is_internal = false;
+        for (auto& dim : this->dims_) {
+            if (symbolic::eq(dim.indvar, pair.first)) {
+                is_internal = true;
+                break;
+            }
+        }
+        if (!is_internal) {
+            filtered[pair.first] = pair.second;
+        }
+    }
+
+    if (filtered.empty()) {
+        return;
+    }
+
+    // Only replace external symbols in bounds/init expressions
+    for (auto& dim : this->dims_) {
+        dim.init = symbolic::subs(dim.init, filtered);
+        dim.bound = symbolic::subs(dim.bound, filtered);
+    }
+
+    // Note: indices only contain internal indvars, so no substitution needed
+}
+
 std::string EinsumNode::toStr() const {
     std::stringstream stream;
 

--- a/sdfg/src/data_flow/library_nodes/math/tensor/elementwise_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/elementwise_node.cpp
@@ -149,6 +149,12 @@ void ElementWiseDataflowTensorNode::
     }
 }
 
+void ElementWiseDataflowTensorNode::replace(const symbolic::ExpressionMapping& replacements) {
+    for (auto& dim : shape_) {
+        dim = symbolic::subs(dim, replacements);
+    }
+}
+
 std::pair<structured_control_flow::Sequence*, std::vector<symbolic::Expression>> ElementWiseDataflowTensorNode::
     add_eltwise_scope(
         builder::StructuredSDFGBuilder& builder,

--- a/sdfg/src/data_flow/library_nodes/math/tensor/matmul_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/matmul_node.cpp
@@ -127,6 +127,11 @@ void MatMulNode::replace(const symbolic::Expression old_expression, const symbol
     layout_b_.replace_symbols(old_expression, new_expression);
 }
 
+void MatMulNode::replace(const symbolic::ExpressionMapping& replacements) {
+    layout_a_.replace_symbols(replacements);
+    layout_b_.replace_symbols(replacements);
+}
+
 std::unique_ptr<data_flow::DataFlowNode> MatMulNode::
     clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent) const {
     return std::unique_ptr<data_flow::DataFlowNode>(new MatMulNode(

--- a/sdfg/src/data_flow/library_nodes/math/tensor/reduce_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/reduce_node.cpp
@@ -89,6 +89,12 @@ void ReduceNode::replace(const symbolic::Expression old_expression, const symbol
     }
 }
 
+void ReduceNode::replace(const symbolic::ExpressionMapping& replacements) {
+    for (auto& dim : shape_) {
+        dim = symbolic::subs(dim, replacements);
+    }
+}
+
 data_flow::PointerAccessType ReduceNode::pointer_access_type(int input_idx) const {
     if (input_idx == 0) {
         return data_flow::PointerAccessMeta::create_full_write_only(symbolic::__nullptr__(), true);

--- a/sdfg/src/data_flow/library_nodes/math/tensor/spatial_tensor_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/spatial_tensor_node.cpp
@@ -97,6 +97,24 @@ void SpatialTensorNode::replace(const symbolic::Expression old_expression, const
     }
 }
 
+void SpatialTensorNode::replace(const symbolic::ExpressionMapping& replacements) {
+    for (auto& expr : shape_) {
+        expr = symbolic::subs(expr, replacements);
+    }
+    for (auto& expr : kernel_shape_) {
+        expr = symbolic::subs(expr, replacements);
+    }
+    for (auto& expr : strides_) {
+        expr = symbolic::subs(expr, replacements);
+    }
+    for (auto& expr : pads_) {
+        expr = symbolic::subs(expr, replacements);
+    }
+    for (auto& expr : dilations_) {
+        expr = symbolic::subs(expr, replacements);
+    }
+}
+
 size_t SpatialTensorNode::num_spatial_dims() const {
     auto& s = shape_;
     assert(s.size() >= 2);

--- a/sdfg/src/data_flow/library_nodes/math/tensor/tensor_layout.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/tensor_layout.cpp
@@ -85,6 +85,16 @@ void TensorLayout::replace_symbols(const symbolic::Expression& old, const symbol
     offset_ = symbolic::subs(offset_, old, new_expr);
 }
 
+void TensorLayout::replace_symbols(const symbolic::ExpressionMapping& replacements) {
+    for (auto& dim : shape_) {
+        dim = symbolic::subs(dim, replacements);
+    }
+    for (auto& stride : strides_) {
+        stride = symbolic::subs(stride, replacements);
+    }
+    offset_ = symbolic::subs(offset_, replacements);
+}
+
 symbolic::Expression TensorLayout::total_elements() const { return SymEngine::mul(shape_); }
 
 symbolic::MultiExpression TensorLayout::linear_strides() const { return std::move(linear_strides(shape_)); }

--- a/sdfg/src/data_flow/library_nodes/math/tensor/transpose_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/transpose_node.cpp
@@ -94,6 +94,12 @@ void TransposeNode::replace(const symbolic::Expression old_expression, const sym
     }
 }
 
+void TransposeNode::replace(const symbolic::ExpressionMapping& replacements) {
+    for (auto& dim : shape_) {
+        dim = symbolic::subs(dim, replacements);
+    }
+}
+
 bool TransposeNode::expand(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {
     auto& dataflow = this->get_parent();
     auto& block = static_cast<structured_control_flow::Block&>(*dataflow.get_parent());

--- a/sdfg/src/data_flow/library_nodes/metadata_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/metadata_node.cpp
@@ -36,6 +36,11 @@ void MetadataNode::replace(const symbolic::Expression old_expression, const symb
     return;
 }
 
+void MetadataNode::replace(const symbolic::ExpressionMapping& replacements) {
+    // Do nothing
+    return;
+}
+
 nlohmann::json MetadataNodeSerializer::serialize(const LibraryNode& library_node) {
     const MetadataNode& metadata_node = static_cast<const MetadataNode&>(library_node);
     nlohmann::json j;

--- a/sdfg/src/data_flow/library_nodes/stdlib/alloca.cpp
+++ b/sdfg/src/data_flow/library_nodes/stdlib/alloca.cpp
@@ -38,6 +38,10 @@ void AllocaNode::replace(const symbolic::Expression old_expression, const symbol
     this->size_ = symbolic::subs(this->size_, old_expression, new_expression);
 }
 
+void AllocaNode::replace(const symbolic::ExpressionMapping& replacements) {
+    this->size_ = symbolic::subs(this->size_, replacements);
+}
+
 nlohmann::json AllocaNodeSerializer::serialize(const data_flow::LibraryNode& library_node) {
     const AllocaNode& node = static_cast<const AllocaNode&>(library_node);
 

--- a/sdfg/src/data_flow/library_nodes/stdlib/assert.cpp
+++ b/sdfg/src/data_flow/library_nodes/stdlib/assert.cpp
@@ -66,6 +66,8 @@ std::unique_ptr<data_flow::DataFlowNode> AssertNode::
 
 void AssertNode::replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {}
 
+void AssertNode::replace(const symbolic::ExpressionMapping& replacements) {}
+
 nlohmann::json AssertNodeSerializer::serialize(const data_flow::LibraryNode& library_node) {
     const auto& assert_node = static_cast<const AssertNode&>(library_node);
 

--- a/sdfg/src/data_flow/library_nodes/stdlib/calloc.cpp
+++ b/sdfg/src/data_flow/library_nodes/stdlib/calloc.cpp
@@ -47,6 +47,11 @@ void CallocNode::replace(const symbolic::Expression old_expression, const symbol
     this->num_ = symbolic::subs(this->num_, old_expression, new_expression);
 }
 
+void CallocNode::replace(const symbolic::ExpressionMapping& replacements) {
+    this->size_ = symbolic::subs(this->size_, replacements);
+    this->num_ = symbolic::subs(this->num_, replacements);
+}
+
 nlohmann::json CallocNodeSerializer::serialize(const data_flow::LibraryNode& library_node) {
     const CallocNode& node = static_cast<const CallocNode&>(library_node);
 

--- a/sdfg/src/data_flow/library_nodes/stdlib/free.cpp
+++ b/sdfg/src/data_flow/library_nodes/stdlib/free.cpp
@@ -33,6 +33,11 @@ void FreeNode::replace(const symbolic::Expression old_expression, const symbolic
     return;
 }
 
+void FreeNode::replace(const symbolic::ExpressionMapping& replacements) {
+    // Do nothing
+    return;
+}
+
 data_flow::PointerAccessType FreeNode::pointer_access_type(int input_idx) const {
     if (input_idx == 0) {
         return data_flow::PointerAccessMeta::create_invalidate();

--- a/sdfg/src/data_flow/library_nodes/stdlib/malloc.cpp
+++ b/sdfg/src/data_flow/library_nodes/stdlib/malloc.cpp
@@ -38,6 +38,10 @@ void MallocNode::replace(const symbolic::Expression old_expression, const symbol
     this->size_ = symbolic::subs(this->size_, old_expression, new_expression);
 }
 
+void MallocNode::replace(const symbolic::ExpressionMapping& replacements) {
+    this->size_ = symbolic::subs(this->size_, replacements);
+}
+
 std::string MallocNode::toStr() const { return LibraryNode::toStr() + "(" + size_->__str__() + ")"; }
 
 nlohmann::json MallocNodeSerializer::serialize(const data_flow::LibraryNode& library_node) {

--- a/sdfg/src/data_flow/library_nodes/stdlib/memcpy.cpp
+++ b/sdfg/src/data_flow/library_nodes/stdlib/memcpy.cpp
@@ -53,6 +53,10 @@ void MemcpyNode::replace(const symbolic::Expression old_expression, const symbol
     this->count_ = symbolic::subs(this->count_, old_expression, new_expression);
 }
 
+void MemcpyNode::replace(const symbolic::ExpressionMapping& replacements) {
+    this->count_ = symbolic::subs(this->count_, replacements);
+}
+
 nlohmann::json MemcpyNodeSerializer::serialize(const data_flow::LibraryNode& library_node) {
     const MemcpyNode& node = static_cast<const MemcpyNode&>(library_node);
 

--- a/sdfg/src/data_flow/library_nodes/stdlib/memmove.cpp
+++ b/sdfg/src/data_flow/library_nodes/stdlib/memmove.cpp
@@ -41,6 +41,10 @@ void MemmoveNode::replace(const symbolic::Expression old_expression, const symbo
     this->count_ = symbolic::subs(this->count_, old_expression, new_expression);
 }
 
+void MemmoveNode::replace(const symbolic::ExpressionMapping& replacements) {
+    this->count_ = symbolic::subs(this->count_, replacements);
+}
+
 nlohmann::json MemmoveNodeSerializer::serialize(const data_flow::LibraryNode& library_node) {
     const MemmoveNode& node = static_cast<const MemmoveNode&>(library_node);
 

--- a/sdfg/src/data_flow/library_nodes/stdlib/memset.cpp
+++ b/sdfg/src/data_flow/library_nodes/stdlib/memset.cpp
@@ -59,6 +59,11 @@ void MemsetNode::replace(const symbolic::Expression old_expression, const symbol
     this->num_ = symbolic::subs(this->num_, old_expression, new_expression);
 }
 
+void MemsetNode::replace(const symbolic::ExpressionMapping& replacements) {
+    this->value_ = symbolic::subs(this->value_, replacements);
+    this->num_ = symbolic::subs(this->num_, replacements);
+}
+
 nlohmann::json MemsetNodeSerializer::serialize(const data_flow::LibraryNode& library_node) {
     const MemsetNode& node = static_cast<const MemsetNode&>(library_node);
 

--- a/sdfg/src/data_flow/library_nodes/stdlib/trap.cpp
+++ b/sdfg/src/data_flow/library_nodes/stdlib/trap.cpp
@@ -23,6 +23,10 @@ void TrapNode::replace(const symbolic::Expression old_expression, const symbolic
     this->size_ = symbolic::subs(this->size_, old_expression, new_expression);
 }
 
+void TrapNode::replace(const symbolic::ExpressionMapping& replacements) {
+    this->size_ = symbolic::subs(this->size_, replacements);
+}
+
 nlohmann::json TrapNodeSerializer::serialize(const data_flow::LibraryNode& library_node) {
     const TrapNode& node = static_cast<const TrapNode&>(library_node);
 

--- a/sdfg/src/data_flow/library_nodes/stdlib/unreachable.cpp
+++ b/sdfg/src/data_flow/library_nodes/stdlib/unreachable.cpp
@@ -31,6 +31,10 @@ void UnreachableNode::replace(const symbolic::Expression old_expression, const s
     this->size_ = symbolic::subs(this->size_, old_expression, new_expression);
 }
 
+void UnreachableNode::replace(const symbolic::ExpressionMapping& replacements) {
+    this->size_ = symbolic::subs(this->size_, replacements);
+}
+
 nlohmann::json UnreachableNodeSerializer::serialize(const data_flow::LibraryNode& library_node) {
     const UnreachableNode& node = static_cast<const UnreachableNode&>(library_node);
 

--- a/sdfg/src/data_flow/memlet.cpp
+++ b/sdfg/src/data_flow/memlet.cpp
@@ -6,6 +6,7 @@
 #include "sdfg/symbolic/symbolic.h"
 #include "sdfg/types/type.h"
 #include "sdfg/types/utils.h"
+#include "symengine/subs.h"
 
 namespace sdfg {
 namespace data_flow {
@@ -470,6 +471,14 @@ void Memlet::replace(const symbolic::Expression old_expression, const symbolic::
     Subset new_subset;
     for (auto& dim : this->subset_) {
         new_subset.push_back(symbolic::subs(dim, old_expression, new_expression));
+    }
+    this->subset_ = new_subset;
+}
+
+void Memlet::replace(const symbolic::ExpressionMapping& replacements) {
+    Subset new_subset;
+    for (auto& dim : this->subset_) {
+        new_subset.push_back(SymEngine::subs(dim, replacements));
     }
     this->subset_ = new_subset;
 };

--- a/sdfg/src/data_flow/pointer_metadata.cpp
+++ b/sdfg/src/data_flow/pointer_metadata.cpp
@@ -78,6 +78,10 @@ void PointerReadOnly::replace(const symbolic::Expression old_expression, const s
     size_ = symbolic::subs(size_, old_expression, new_expression);
 }
 
+void PointerReadOnly::replace(const symbolic::ExpressionMapping& replacements) {
+    size_ = SymEngine::subs(size_, replacements);
+}
+
 PointerAccessType PointerReadOnly::clone() const { return PointerAccessType(new PointerReadOnly(size_, no_capture_)); }
 
 void PointerReadOnly::serialize_to_json(nlohmann::json& entry) {
@@ -102,6 +106,10 @@ MemoryAccessPatternType PointerFullWriteOnly::access_read_pattern() const { retu
 
 void PointerFullWriteOnly::replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {
     size_ = symbolic::subs(size_, old_expression, new_expression);
+}
+
+void PointerFullWriteOnly::replace(const symbolic::ExpressionMapping& replacements) {
+    size_ = SymEngine::subs(size_, replacements);
 }
 
 PointerAccessType PointerFullWriteOnly::clone() const {
@@ -137,6 +145,15 @@ void PointerGenericAccess::replace(const symbolic::Expression old_expression, co
     }
     if (write_pattern_) {
         write_pattern_->replace(old_expression, new_expression);
+    }
+}
+
+void PointerGenericAccess::replace(const symbolic::ExpressionMapping& replacements) {
+    if (read_pattern_) {
+        read_pattern_->replace(replacements);
+    }
+    if (write_pattern_) {
+        write_pattern_->replace(replacements);
     }
 }
 

--- a/sdfg/src/data_flow/tasklet.cpp
+++ b/sdfg/src/data_flow/tasklet.cpp
@@ -286,6 +286,8 @@ std::unique_ptr<DataFlowNode> Tasklet::clone(size_t element_id, const graph::Ver
 
 void Tasklet::replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {}
 
+void Tasklet::replace(const symbolic::ExpressionMapping& replacements) {}
+
 EdgeRemoveOption Tasklet::can_remove_out_edge(const data_flow::DataFlowGraph& graph, const Memlet* memlet) const {
     if (graph.out_edges_for_connector(*this, memlet->src_conn()).size() > 1) {
         return EdgeRemoveOption::Trivially;

--- a/sdfg/src/element.cpp
+++ b/sdfg/src/element.cpp
@@ -85,6 +85,12 @@ size_t Element::element_id() const { return this->element_id_; };
 
 const DebugInfo& Element::debug_info() const { return this->debug_info_; };
 
-void Element::set_debug_info(const DebugInfo& debug_info) { this->debug_info_ = debug_info; };
+void Element::set_debug_info(const DebugInfo& debug_info) { this->debug_info_ = debug_info; }
+
+void Element::replace(const symbolic::ExpressionMapping& replacements) {
+    for (auto& pair : replacements) {
+        replace(pair.first, pair.second);
+    }
+};
 
 } // namespace sdfg

--- a/sdfg/src/passes/structured_control_flow/for2map.cpp
+++ b/sdfg/src/passes/structured_control_flow/for2map.cpp
@@ -140,12 +140,11 @@ bool For2MapPass::can_be_applied(
 
 bool For2MapPass::run_pass(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {
     auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();
-    auto& loop_tree = loop_analysis.loop_tree();
 
     // Traverse loops in bottom-up fashion (reverse loop)
     std::list<structured_control_flow::For*> for_queue;
-    for (auto& entry : loop_tree) {
-        if (auto for_stmt = dynamic_cast<structured_control_flow::For*>(entry.first)) {
+    for (auto& loop : loop_analysis.loops_in_pre_order()) {
+        if (auto for_stmt = dynamic_cast<structured_control_flow::For*>(loop)) {
             for_queue.push_front(for_stmt);
         }
     }

--- a/sdfg/src/structured_control_flow/block.cpp
+++ b/sdfg/src/structured_control_flow/block.cpp
@@ -23,7 +23,9 @@ data_flow::DataFlowGraph& Block::dataflow() { return *this->dataflow_; };
 
 void Block::replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {
     this->dataflow_->replace(old_expression, new_expression);
-};
+}
+
+void Block::replace(const symbolic::ExpressionMapping& replacements) { this->dataflow_->replace(replacements); }
 
 } // namespace structured_control_flow
 } // namespace sdfg

--- a/sdfg/src/structured_control_flow/if_else.cpp
+++ b/sdfg/src/structured_control_flow/if_else.cpp
@@ -2,6 +2,7 @@
 
 #include "sdfg/symbolic/conjunctive_normal_form.h"
 #include "sdfg/symbolic/symbolic.h"
+#include "symengine/subs.h"
 
 namespace sdfg {
 namespace structured_control_flow {
@@ -56,6 +57,13 @@ void IfElse::replace(const symbolic::Expression old_expression, const symbolic::
     for (size_t i = 0; i < this->cases_.size(); ++i) {
         this->cases_.at(i)->replace(old_expression, new_expression);
         this->conditions_.at(i) = symbolic::subs(this->conditions_.at(i), old_expression, new_expression);
+    }
+}
+
+void IfElse::replace(const symbolic::ExpressionMapping& replacements) {
+    for (size_t i = 0; i < this->cases_.size(); ++i) {
+        this->cases_.at(i)->replace(replacements);
+        this->conditions_.at(i) = symbolic::subs(this->conditions_.at(i), replacements);
     }
 };
 

--- a/sdfg/src/structured_control_flow/return.cpp
+++ b/sdfg/src/structured_control_flow/return.cpp
@@ -53,7 +53,7 @@ void Return::replace(const symbolic::Expression old_expression, const symbolic::
     if (is_data() && data_ == old_expression->__str__()) {
         data_ = new_expression->__str__();
     }
-};
+}
 
 } // namespace structured_control_flow
 } // namespace sdfg

--- a/sdfg/src/structured_control_flow/sequence.cpp
+++ b/sdfg/src/structured_control_flow/sequence.cpp
@@ -164,6 +164,16 @@ void Sequence::replace(const symbolic::Expression old_expression, const symbolic
     for (auto& trans : this->transitions_) {
         trans->replace(old_expression, new_expression);
     }
+}
+
+void Sequence::replace(const symbolic::ExpressionMapping& replacements) {
+    for (auto& child : this->children_) {
+        child->replace(replacements);
+    }
+
+    for (auto& trans : this->transitions_) {
+        trans->replace(replacements);
+    }
 };
 
 } // namespace structured_control_flow

--- a/sdfg/src/structured_control_flow/structured_loop.cpp
+++ b/sdfg/src/structured_control_flow/structured_loop.cpp
@@ -2,6 +2,7 @@
 
 #include "sdfg/symbolic/conjunctive_normal_form.h"
 #include "sdfg/symbolic/polynomials.h"
+#include "symengine/subs.h"
 
 namespace sdfg {
 namespace structured_control_flow {
@@ -59,7 +60,20 @@ void StructuredLoop::replace(const symbolic::Expression old_expression, const sy
     this->condition_ = symbolic::subs(this->condition_, old_expression, new_expression);
 
     this->root_->replace(old_expression, new_expression);
-};
+}
+
+void StructuredLoop::replace(const symbolic::ExpressionMapping& replacements) {
+    auto indvar_repl = replacements.find(this->indvar_);
+    if (indvar_repl != replacements.end()) {
+        this->indvar_ = SymEngine::rcp_static_cast<const SymEngine::Symbol>(indvar_repl->second);
+    }
+
+    this->init_ = SymEngine::subs(this->init_, replacements);
+    this->update_ = SymEngine::subs(this->update_, replacements);
+    this->condition_ = symbolic::subs(this->condition_, replacements);
+
+    this->root_->replace(replacements);
+}
 
 symbolic::Integer StructuredLoop::stride() {
     auto expr = this->update();

--- a/sdfg/src/structured_control_flow/while.cpp
+++ b/sdfg/src/structured_control_flow/while.cpp
@@ -16,7 +16,9 @@ Sequence& While::root() { return *this->root_; };
 
 void While::replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {
     this->root_->replace(old_expression, new_expression);
-};
+}
+
+void While::replace(const symbolic::ExpressionMapping& replacements) { this->root_->replace(replacements); }
 
 Break::Break(size_t element_id, const DebugInfo& debug_info, ControlFlowNode* parent)
     : ControlFlowNode(element_id, debug_info, parent) {
@@ -25,18 +27,18 @@ Break::Break(size_t element_id, const DebugInfo& debug_info, ControlFlowNode* pa
 
 void Break::validate(const Function& function) const {};
 
-void Break::replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {
+void Break::replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {}
 
-};
+void Break::replace(const symbolic::ExpressionMapping& replacements) {}
 
 Continue::Continue(size_t element_id, const DebugInfo& debug_info, ControlFlowNode* parent)
     : ControlFlowNode(element_id, debug_info, parent) {};
 
 void Continue::validate(const Function& function) const {};
 
-void Continue::replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {
+void Continue::replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {}
 
-};
+void Continue::replace(const symbolic::ExpressionMapping& replacements) {}
 
 } // namespace structured_control_flow
 } // namespace sdfg

--- a/sdfg/src/symbolic/symbolic.cpp
+++ b/sdfg/src/symbolic/symbolic.cpp
@@ -911,6 +911,10 @@ Condition subs(const Condition expr, const Expression old_expr, const Expression
     return SymEngine::rcp_dynamic_cast<const SymEngine::Boolean>(subs(expr, d));
 };
 
+Condition subs(const Condition expr, const symbolic::ExpressionMapping& replacements) {
+    return SymEngine::rcp_dynamic_cast<const SymEngine::Boolean>(SymEngine::subs(expr, replacements));
+}
+
 Expression parse(const std::string& expr_str) {
     auto expr = SymEngine::parse(expr_str);
     expr = symbolic::subs(expr, symbolic::symbol("true"), symbolic::one());

--- a/sdfg/src/symbolic/utils.cpp
+++ b/sdfg/src/symbolic/utils.cpp
@@ -579,5 +579,31 @@ void canonicalize_map_dims(isl_map* map, const std::string& in_prefix, const std
     }
 }
 
+bool vectors_of_expressions_match(const std::vector<Expression>& a, const std::vector<Expression>& b) {
+    if (a.size() != b.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < a.size(); i++) {
+        if (!symbolic::eq(a.at(i), b.at(i))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool vectors_of_expressions_match(
+    const std::vector<Expression>& a, const std::vector<Expression>& b, const ExpressionMapping& replacements
+) {
+    if (a.size() != b.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < a.size(); i++) {
+        if (!symbolic::eq(SymEngine::subs(a.at(i), replacements), b.at(i))) {
+            return false;
+        }
+    }
+    return true;
+}
+
 } // namespace symbolic
 } // namespace sdfg

--- a/sdfg/tests/analysis/loop_analysis_test.cpp
+++ b/sdfg/tests/analysis/loop_analysis_test.cpp
@@ -2,8 +2,10 @@
 
 #include <gtest/gtest.h>
 
+#include "loop_info_debug_dump.h"
 #include "sdfg/analysis/assumptions_analysis.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/structured_control_flow/map.h"
 #include "sdfg/structured_control_flow/structured_loop.h"
 
 using namespace sdfg;
@@ -476,4 +478,419 @@ TEST(LoopAnalysisTest, outermost_loops) {
             dynamic_cast<sdfg::structured_control_flow::StructuredLoop*>(outermost_loops_copy2[i])->indvar()->get_name()
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// Incremental-update tests: removed_loop / moved_loop / copied_loop
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/**
+ * Pointers to every loop of the reusable multi-nest fixture, in pre-order.
+ * Pre-order over loops(): a0, a1, a2, b0, b1, b2, c0, c1, c2, c3 (indices 0..9).
+ */
+struct MultiNestLoops {
+    // Nest A (idx 0..2): perfectly nested chain of two maps followed by a for-loop.
+    structured_control_flow::Map* a0;
+    structured_control_flow::Map* a1;
+    structured_control_flow::For* a2;
+    // Nest B (idx 3..5): a chain of 3 maps, b1 is non-perfectly nested due to an empty block in its body.
+    structured_control_flow::Map* b0;
+    structured_control_flow::Map* b1;
+    structured_control_flow::Map* b2;
+    // Nest C (idx 6..9): a map c0 with two child loops (c1, c2); one leaf map and one map -> for.
+    structured_control_flow::Map* c0;
+    structured_control_flow::Map* c1;
+    structured_control_flow::Map* c2;
+    structured_control_flow::For* c3;
+};
+
+/**
+ * Builds three independent loop nests at the SDFG root, mixing maps and fors,
+ * a non-perfectly-nested loop (empty block in a non-leaf body) and a loop with
+ * multiple children. Reuse this across the incremental-update tests and then
+ * issue a single removed_loop / moved_loop / copied_loop call.
+ */
+MultiNestLoops build_multi_nest(builder::StructuredSDFGBuilder& builder) {
+    using namespace sdfg::structured_control_flow;
+    auto& root = builder.subject().root();
+    auto sched = ScheduleType_Sequential::create();
+
+    auto add_map = [&](Sequence& parent, const std::string& iv) -> Map& {
+        builder.add_container(iv, types::Scalar(types::PrimitiveType::Int32));
+        auto sym = symbolic::symbol(iv);
+        return builder.add_map(
+            parent,
+            sym,
+            symbolic::Lt(sym, symbolic::symbol("N")),
+            symbolic::zero(),
+            symbolic::add(sym, symbolic::one()),
+            sched
+        );
+    };
+    auto add_for = [&](Sequence& parent, const std::string& iv) -> For& {
+        builder.add_container(iv, types::Scalar(types::PrimitiveType::Int32));
+        auto sym = symbolic::symbol(iv);
+        return builder.add_for(
+            parent, sym, symbolic::Lt(sym, symbolic::symbol("N")), symbolic::zero(), symbolic::add(sym, symbolic::one())
+        );
+    };
+
+    MultiNestLoops loops;
+
+    // Nest A: a0 -> a1 -> a2 (perfectly nested maps).
+    auto& a0 = add_map(root, "i_a0");
+    auto& a1 = add_map(a0.root(), "i_a1");
+    auto& a2 = add_for(a1.root(), "i_a2");
+    loops.a0 = &a0;
+    loops.a1 = &a1;
+    loops.a2 = &a2;
+
+    // Nest B: for b0 with an empty block (=> non-perfectly nested) then b1 -> b2 (maps).
+    auto& b0 = add_map(root, "i_b0");
+    auto& b1 = add_map(b0.root(), "i_b1");
+    builder.add_block(b1.root());
+    auto& b2 = add_map(b1.root(), "i_b2");
+    loops.b0 = &b0;
+    loops.b1 = &b1;
+    loops.b2 = &b2;
+
+    // Nest C: c0 with two children: leaf map c1 and c2 -> for c3.
+    auto& c0 = add_map(root, "i_c0");
+    auto& c1 = add_map(c0.root(), "i_c1");
+    auto& c2 = add_map(c0.root(), "i_c2");
+    auto& c3 = add_for(c2.root(), "i_c3");
+    loops.c0 = &c0;
+    loops.c1 = &c1;
+    loops.c2 = &c2;
+    loops.c3 = &c3;
+
+    return loops;
+}
+
+/**
+ * Verifies the core LoopAnalysis index invariant after an incremental update:
+ *  - loop_id equals the loop's position in the pre-order loops() vector,
+ *  - the subtree occupies a contiguous index range [loop_id, last_child_id],
+ *  - last_child_id == loop_id + number-of-descendants.
+ */
+void verify_loop_index_consistency(analysis::LoopAnalysis& la) {
+    const auto& order = la.loops_in_pre_order();
+    for (uint32_t i = 0; i < order.size(); ++i) {
+        auto* loop = order[i];
+        const auto& info = la.loop_info_local(loop);
+        EXPECT_EQ(info.loop_id, i) << "loop_id must match pre-order position";
+
+        auto desc = la.descendants(loop);
+        EXPECT_EQ(info.last_child_id, info.loop_id + desc.size()) << "last_child_id must cover exactly the subtree";
+        for (uint32_t j = info.loop_id + 1; j <= info.last_child_id; ++j) {
+            ASSERT_LT(j, order.size());
+            EXPECT_EQ(desc.count(order[j]), 1u) << "index " << j << " in subtree range must be a descendant";
+        }
+    }
+}
+
+} // namespace
+
+TEST(LoopAnalysisTest, RemovedLoop_Leaf) {
+    builder::StructuredSDFGBuilder builder("sdfg_remove_leaf", FunctionType_CPU);
+    auto loops = build_multi_nest(builder);
+
+    analysis::AnalysisManager manager(builder.subject());
+    auto& la = manager.get<analysis::LoopAnalysis>();
+    ASSERT_EQ(la.loops_in_pre_order().size(), 10u);
+    EXPECT_FALSE(la.loop_info(loops.a0).is_perfectly_parallel);
+
+    dump_loop_info(la, "0.org");
+
+    // Remove the innermost leaf of nest A.
+    la.removed_loop(loops.a2);
+
+    dump_loop_info(la, "1.remove");
+
+    EXPECT_EQ(la.loops_in_pre_order().size(), 9u);
+    for (auto* l : la.loops_in_pre_order()) {
+        EXPECT_NE(l, loops.a2);
+    }
+    // a1 is now a leaf, a0 spans {a0, a1}.
+    EXPECT_EQ(la.children(loops.a1).size(), 0u);
+    EXPECT_EQ(la.loop_info_local(loops.a0).loop_id, 0u);
+    EXPECT_EQ(la.loop_info_local(loops.a0).last_child_id, 1u);
+    // Everything after the removal shifted down by one (c0 was 6, now 5).
+    EXPECT_EQ(la.loop_info_local(loops.c0).loop_id, 5u);
+    EXPECT_EQ(la.loop_info_local(loops.c0).last_child_id, 8u);
+    EXPECT_TRUE(la.loop_info(loops.a0).is_perfectly_parallel);
+
+
+    verify_loop_index_consistency(la);
+    manager.invalidate_all();
+}
+
+TEST(LoopAnalysisTest, RemovedLoop_InternalSubtree) {
+    builder::StructuredSDFGBuilder builder("sdfg_remove_subtree", FunctionType_CPU);
+    auto loops = build_multi_nest(builder);
+
+    analysis::AnalysisManager manager(builder.subject());
+    auto& la = manager.get<analysis::LoopAnalysis>();
+    ASSERT_EQ(la.loops_in_pre_order().size(), 10u);
+    EXPECT_FALSE(la.loop_info(loops.c0).is_perfectly_parallel);
+    EXPECT_FALSE(la.loop_info(loops.c0).is_perfectly_nested);
+
+    dump_loop_info(la, "0.org");
+
+    // Remove c2, which carries its child c3 along with it.
+    la.removed_loop(loops.c2);
+
+    dump_loop_info(la, "1.remove");
+
+    EXPECT_EQ(la.loops_in_pre_order().size(), 8u);
+    for (auto* l : la.loops_in_pre_order()) {
+        EXPECT_NE(l, loops.c2);
+        EXPECT_NE(l, loops.c3);
+    }
+    // c0 now has only c1 as a child.
+    const auto& c0_children = la.children(loops.c0);
+    EXPECT_EQ(c0_children.size(), 1u);
+    EXPECT_EQ(c0_children.at(0), loops.c1);
+    EXPECT_EQ(la.loop_info_local(loops.c0).last_child_id, la.loop_info_local(loops.c1).loop_id);
+    EXPECT_TRUE(la.loop_info(loops.c0).is_perfectly_parallel);
+    EXPECT_TRUE(la.loop_info(loops.c0).is_perfectly_nested);
+
+    verify_loop_index_consistency(la);
+}
+
+TEST(LoopAnalysisTest, RemovedLoop_WholeOutermostNest) {
+    builder::StructuredSDFGBuilder builder("sdfg_remove_nest", FunctionType_CPU);
+    auto loops = build_multi_nest(builder);
+
+    analysis::AnalysisManager manager(builder.subject());
+    auto& la = manager.get<analysis::LoopAnalysis>();
+    ASSERT_EQ(la.outermost_loops().size(), 3u);
+
+    // Remove the entire middle nest (for b0 plus b1 -> b2).
+    la.removed_loop(loops.b0);
+
+    EXPECT_EQ(la.loops_in_pre_order().size(), 7u);
+    for (auto* l : la.loops_in_pre_order()) {
+        EXPECT_NE(l, loops.b0);
+        EXPECT_NE(l, loops.b1);
+        EXPECT_NE(l, loops.b2);
+    }
+    EXPECT_EQ(la.outermost_loops().size(), 2u);
+    // Nest C shifted to directly follow nest A (c0 was 6, now 3).
+    EXPECT_EQ(la.loop_info_local(loops.c0).loop_id, 3u);
+    EXPECT_EQ(la.loop_info_local(loops.c0).last_child_id, 6u);
+
+    verify_loop_index_consistency(la);
+}
+
+// The moved_loop / copied_loop APIs are still under construction. These document
+// the intended scenarios and post-conditions; enable once the methods are implemented.
+
+TEST(LoopAnalysisTest, MovedLoop_Reparent) {
+    builder::StructuredSDFGBuilder builder("sdfg_move", FunctionType_CPU);
+    auto loops = build_multi_nest(builder);
+
+    analysis::AnalysisManager manager(builder.subject());
+    auto& la = manager.get<analysis::LoopAnalysis>();
+
+    EXPECT_FALSE(la.loop_info(loops.c0).is_perfectly_parallel);
+    EXPECT_FALSE(la.loop_info(loops.c0).is_perfectly_nested);
+    EXPECT_TRUE(la.loop_info(loops.a2).is_perfectly_nested);
+
+    // Move c2 (with its child c3) from under c0 to become a child of a2.
+    la.moved_loop(loops.c2, loops.a2);
+
+    EXPECT_EQ(la.parent_loop(loops.c2), loops.a2);
+    const auto& a2_children = la.children(loops.a2);
+    EXPECT_NE(std::find(a2_children.begin(), a2_children.end(), loops.c2), a2_children.end());
+    const auto& c0_children = la.children(loops.c0);
+    EXPECT_EQ(std::find(c0_children.begin(), c0_children.end(), loops.c2), c0_children.end());
+
+    EXPECT_TRUE(la.loop_info(loops.c0).is_perfectly_parallel);
+    EXPECT_TRUE(la.loop_info(loops.c0).is_perfectly_nested);
+    EXPECT_TRUE(la.loop_info(loops.a2).is_perfectly_nested);
+
+    verify_loop_index_consistency(la);
+}
+
+TEST(LoopAnalysisTest, MovedLoop_ToOwnParent) {
+    builder::StructuredSDFGBuilder builder("sdfg_move", FunctionType_CPU);
+    auto loops = build_multi_nest(builder);
+
+    analysis::AnalysisManager manager(builder.subject());
+    auto& la = manager.get<analysis::LoopAnalysis>();
+
+    // move to a parent
+    la.moved_loop(loops.a2, loops.a0);
+
+    EXPECT_EQ(la.parent_loop(loops.a2), loops.a0);
+    const auto& a0_children = la.children(loops.a0);
+    EXPECT_NE(std::find(a0_children.begin(), a0_children.end(), loops.a2), a0_children.end());
+    const auto& a1_children = la.children(loops.a1);
+    EXPECT_EQ(std::find(a1_children.begin(), a1_children.end(), loops.a2), a1_children.end());
+
+    verify_loop_index_consistency(la);
+}
+
+TEST(LoopAnalysisTest, CopiedLoop_Append) {
+    builder::StructuredSDFGBuilder builder("sdfg_copy", FunctionType_CPU);
+    auto loops = build_multi_nest(builder);
+
+    analysis::AnalysisManager manager(builder.subject());
+    auto& la = manager.get<analysis::LoopAnalysis>();
+
+    EXPECT_FALSE(la.loop_info(loops.b0).is_perfectly_nested);
+    EXPECT_TRUE(la.loop_info(loops.b0).is_perfectly_parallel);
+
+    // Materialize a copy of a2 as a new child of b1, then register it.
+    auto sym = symbolic::symbol("i_copy");
+    builder.add_container("i_copy", types::Scalar(types::PrimitiveType::Int32));
+    auto& new_loop = builder.add_for(
+        loops.b1->root(),
+        sym,
+        symbolic::Lt(sym, symbolic::symbol("N")),
+        symbolic::zero(),
+        symbolic::add(sym, symbolic::one())
+    );
+
+    la.copied_loop(loops.a2, loops.b1, &new_loop, true);
+
+    // old one still there
+    EXPECT_EQ(la.parent_loop(loops.a2), loops.a1);
+    const auto& a1_children = la.children(loops.a1);
+    EXPECT_NE(std::find(a1_children.begin(), a1_children.end(), loops.a2), a1_children.end());
+
+    EXPECT_EQ(la.parent_loop(&new_loop), loops.b1);
+    const auto& b1_children = la.children(loops.b1);
+    EXPECT_NE(std::find(b1_children.begin(), b1_children.end(), &new_loop), b1_children.end());
+
+    EXPECT_FALSE(la.loop_info(loops.b0).is_perfectly_nested);
+    EXPECT_FALSE(la.loop_info(loops.b0).is_perfectly_parallel);
+
+    verify_loop_index_consistency(la);
+}
+
+TEST(LoopAnalysisTest, CopiedLoop_AppendBack) {
+    builder::StructuredSDFGBuilder builder("sdfg_copy_back", FunctionType_CPU);
+    auto loops = build_multi_nest(builder);
+
+    analysis::AnalysisManager manager(builder.subject());
+    auto& la = manager.get<analysis::LoopAnalysis>();
+
+    ASSERT_EQ(la.loops_in_pre_order().size(), 10u);
+
+    // Append a fresh map as the last child of c0 (which already has c1, c2).
+    auto sym = symbolic::symbol("i_copy_back");
+    builder.add_container("i_copy_back", types::Scalar(types::PrimitiveType::Int32));
+    auto& new_loop = builder.add_map(
+        loops.c0->root(),
+        sym,
+        symbolic::Lt(sym, symbolic::symbol("N")),
+        symbolic::zero(),
+        symbolic::add(sym, symbolic::one()),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+
+    la.copied_loop(loops.c1, loops.c0, &new_loop); // default: append at the back
+
+    EXPECT_EQ(la.loops_in_pre_order().size(), 11u);
+    EXPECT_EQ(la.parent_loop(&new_loop), loops.c0);
+
+    const auto& c0_children = la.children(loops.c0);
+    ASSERT_EQ(c0_children.size(), 3u);
+    EXPECT_EQ(c0_children.back(), &new_loop); // appended after the existing children
+
+    // The new loop is the last entry in pre-order; c0's subtree grew to include it.
+    EXPECT_EQ(la.loop_info_local(&new_loop).loop_id, 10u);
+    EXPECT_EQ(la.loop_info_local(loops.c0).last_child_id, 10u);
+
+    verify_loop_index_consistency(la);
+}
+
+TEST(LoopAnalysisTest, CopiedLoop_Subtree) {
+    builder::StructuredSDFGBuilder builder("sdfg_copy_subtree", FunctionType_CPU);
+    auto loops = build_multi_nest(builder);
+
+    analysis::AnalysisManager manager(builder.subject());
+    auto& la = manager.get<analysis::LoopAnalysis>();
+
+    // Materialize a small nested subtree (map -> for) as a new child of the leaf a2.
+    auto outer = symbolic::symbol("i_cp_outer");
+    auto inner = symbolic::symbol("i_cp_inner");
+    builder.add_container("i_cp_outer", types::Scalar(types::PrimitiveType::Int32));
+    builder.add_container("i_cp_inner", types::Scalar(types::PrimitiveType::Int32));
+    auto& new_outer = builder.add_map(
+        loops.a2->root(),
+        outer,
+        symbolic::Lt(outer, symbolic::symbol("N")),
+        symbolic::zero(),
+        symbolic::add(outer, symbolic::one()),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+    auto& new_inner = builder.add_for(
+        new_outer.root(),
+        inner,
+        symbolic::Lt(inner, symbolic::symbol("N")),
+        symbolic::zero(),
+        symbolic::add(inner, symbolic::one())
+    );
+
+    la.copied_loop(loops.c2, loops.a2, &new_outer); // a2 had no children -> back == front
+
+    EXPECT_EQ(la.loops_in_pre_order().size(), 12u);
+    // The whole copied subtree is registered with correct parentage.
+    EXPECT_EQ(la.parent_loop(&new_outer), loops.a2);
+    EXPECT_EQ(la.parent_loop(&new_inner), &new_outer);
+
+    // Pre-order: a2 (idx 2) is now immediately followed by the new subtree.
+    EXPECT_EQ(la.loop_info_local(&new_outer).loop_id, 3u);
+    EXPECT_EQ(la.loop_info_local(&new_inner).loop_id, 4u);
+    EXPECT_EQ(la.loop_info_local(&new_outer).last_child_id, 4u);
+
+    // Nest aggregates of the freshly added subtree.
+    EXPECT_EQ(la.loop_info(&new_outer).num_loops, 2u);
+    EXPECT_EQ(la.loop_info(&new_outer).num_maps, 1u);
+    EXPECT_EQ(la.loop_info(&new_outer).num_fors, 1u);
+    EXPECT_EQ(la.loop_info(&new_outer).max_depth, 2u);
+    EXPECT_EQ(la.loop_info(&new_outer).loop_level, 3u); // a2 sits at level 2
+
+    verify_loop_index_consistency(la);
+}
+
+TEST(LoopAnalysisTest, CopiedLoop_AsOutermost) {
+    builder::StructuredSDFGBuilder builder("sdfg_copy_outer", FunctionType_CPU);
+    auto loops = build_multi_nest(builder);
+
+    analysis::AnalysisManager manager(builder.subject());
+    auto& la = manager.get<analysis::LoopAnalysis>();
+
+    ASSERT_EQ(la.outermost_loops().size(), 3u);
+
+    // Append a fresh outermost map directly at the SDFG root (no parent loop).
+    auto sym = symbolic::symbol("i_cp_root");
+    builder.add_container("i_cp_root", types::Scalar(types::PrimitiveType::Int32));
+    auto& new_loop = builder.add_map(
+        builder.subject().root(),
+        sym,
+        symbolic::Lt(sym, symbolic::symbol("N")),
+        symbolic::zero(),
+        symbolic::add(sym, symbolic::one()),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+
+    la.copied_loop(loops.a0, nullptr, &new_loop); // new outermost nest, appended at the back
+
+    EXPECT_EQ(la.loops_in_pre_order().size(), 11u);
+    EXPECT_TRUE(la.is_outermost_loop(&new_loop));
+    EXPECT_EQ(la.parent_loop(&new_loop), nullptr);
+
+    const auto& outer = la.outermost_loops();
+    ASSERT_EQ(outer.size(), 4u);
+    EXPECT_EQ(outer.back(), &new_loop);
+    EXPECT_EQ(la.loop_info_local(&new_loop).loop_id, 10u);
+    EXPECT_EQ(la.loop_info(&new_loop).loopnest_index, 3); // 4th outermost nest
+
+    verify_loop_index_consistency(la);
 }

--- a/sdfg/tests/analysis/loop_analysis_test.cpp
+++ b/sdfg/tests/analysis/loop_analysis_test.cpp
@@ -948,3 +948,39 @@ TEST(LoopAnalysisTest, CopiedLoop_AsOutermost) {
 
     verify_loop_index_consistency(la);
 }
+
+TEST(LoopAnalysisTest, MapStackDepth_3outers) {
+    builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
+    MultiNestBuilder b(builder);
+
+    auto& a0 = b.add_map(b.root, "i0");
+    auto& a1 = b.add_map(a0.root(), "i1");
+    auto& a2 = b.add_map(a1.root(), "i2");
+    auto& a3 = b.add_for(a2.root(), "i3");
+    auto& a4 = b.add_for(a3.root(), "i4");
+    auto& a5 = b.add_for(a4.root(), "i5");
+
+    analysis::AnalysisManager manager(builder.subject());
+    auto& la = manager.get<analysis::LoopAnalysis>();
+
+    EXPECT_EQ(la.loop_info(&a5).map_stack_depth, 0);
+    EXPECT_EQ(la.loop_info(&a4).map_stack_depth, 0);
+    EXPECT_EQ(la.loop_info(&a3).map_stack_depth, 0);
+    EXPECT_EQ(la.loop_info(&a2).map_stack_depth, 1);
+    EXPECT_EQ(la.loop_info(&a1).map_stack_depth, 2);
+    EXPECT_EQ(la.loop_info(&a0).map_stack_depth, 3);
+}
+
+TEST(LoopAnalysisTest, MapStackDepth_just2) {
+    builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
+    MultiNestBuilder b(builder);
+
+    auto& a0 = b.add_map(b.root, "i0");
+    auto& a1 = b.add_map(a0.root(), "i1");
+
+    analysis::AnalysisManager manager(builder.subject());
+    auto& la = manager.get<analysis::LoopAnalysis>();
+
+    EXPECT_EQ(la.loop_info(&a1).map_stack_depth, 1);
+    EXPECT_EQ(la.loop_info(&a0).map_stack_depth, 2);
+}

--- a/sdfg/tests/analysis/loop_analysis_test.cpp
+++ b/sdfg/tests/analysis/loop_analysis_test.cpp
@@ -512,12 +512,15 @@ struct MultiNestLoops {
  * multiple children. Reuse this across the incremental-update tests and then
  * issue a single removed_loop / moved_loop / copied_loop call.
  */
-MultiNestLoops build_multi_nest(builder::StructuredSDFGBuilder& builder) {
-    using namespace sdfg::structured_control_flow;
-    auto& root = builder.subject().root();
-    auto sched = ScheduleType_Sequential::create();
+class MultiNestBuilder {
+public:
+    builder::StructuredSDFGBuilder& builder;
+    MultiNestBuilder(builder::StructuredSDFGBuilder& builder) : builder(builder) {}
 
-    auto add_map = [&](Sequence& parent, const std::string& iv) -> Map& {
+    ScheduleType sched_ = ScheduleType_Sequential::create();
+    Sequence& root = builder.subject().root();
+
+    Map& add_map(Sequence& parent, const std::string& iv) {
         builder.add_container(iv, types::Scalar(types::PrimitiveType::Int32));
         auto sym = symbolic::symbol(iv);
         return builder.add_map(
@@ -526,47 +529,54 @@ MultiNestLoops build_multi_nest(builder::StructuredSDFGBuilder& builder) {
             symbolic::Lt(sym, symbolic::symbol("N")),
             symbolic::zero(),
             symbolic::add(sym, symbolic::one()),
-            sched
+            sched_
         );
-    };
-    auto add_for = [&](Sequence& parent, const std::string& iv) -> For& {
+    }
+    For& add_for(Sequence& parent, const std::string& iv) {
         builder.add_container(iv, types::Scalar(types::PrimitiveType::Int32));
         auto sym = symbolic::symbol(iv);
         return builder.add_for(
             parent, sym, symbolic::Lt(sym, symbolic::symbol("N")), symbolic::zero(), symbolic::add(sym, symbolic::one())
         );
-    };
+    }
 
-    MultiNestLoops loops;
+    MultiNestLoops build_default_multi_nest() {
+        MultiNestLoops loops;
 
-    // Nest A: a0 -> a1 -> a2 (perfectly nested maps).
-    auto& a0 = add_map(root, "i_a0");
-    auto& a1 = add_map(a0.root(), "i_a1");
-    auto& a2 = add_for(a1.root(), "i_a2");
-    loops.a0 = &a0;
-    loops.a1 = &a1;
-    loops.a2 = &a2;
+        // Nest A: a0 -> a1 -> a2 (perfectly nested maps).
+        auto& a0 = add_map(root, "i_a0");
+        auto& a1 = add_map(a0.root(), "i_a1");
+        auto& a2 = add_for(a1.root(), "i_a2");
+        loops.a0 = &a0;
+        loops.a1 = &a1;
+        loops.a2 = &a2;
 
-    // Nest B: for b0 with an empty block (=> non-perfectly nested) then b1 -> b2 (maps).
-    auto& b0 = add_map(root, "i_b0");
-    auto& b1 = add_map(b0.root(), "i_b1");
-    builder.add_block(b1.root());
-    auto& b2 = add_map(b1.root(), "i_b2");
-    loops.b0 = &b0;
-    loops.b1 = &b1;
-    loops.b2 = &b2;
+        // Nest B: for b0 with an empty block (=> non-perfectly nested) then b1 -> b2 (maps).
+        auto& b0 = add_map(root, "i_b0");
+        auto& b1 = add_map(b0.root(), "i_b1");
+        builder.add_block(b1.root());
+        auto& b2 = add_map(b1.root(), "i_b2");
+        loops.b0 = &b0;
+        loops.b1 = &b1;
+        loops.b2 = &b2;
 
-    // Nest C: c0 with two children: leaf map c1 and c2 -> for c3.
-    auto& c0 = add_map(root, "i_c0");
-    auto& c1 = add_map(c0.root(), "i_c1");
-    auto& c2 = add_map(c0.root(), "i_c2");
-    auto& c3 = add_for(c2.root(), "i_c3");
-    loops.c0 = &c0;
-    loops.c1 = &c1;
-    loops.c2 = &c2;
-    loops.c3 = &c3;
+        // Nest C: c0 with two children: leaf map c1 and c2 -> for c3.
+        auto& c0 = add_map(root, "i_c0");
+        auto& c1 = add_map(c0.root(), "i_c1");
+        auto& c2 = add_map(c0.root(), "i_c2");
+        auto& c3 = add_for(c2.root(), "i_c3");
+        loops.c0 = &c0;
+        loops.c1 = &c1;
+        loops.c2 = &c2;
+        loops.c3 = &c3;
 
-    return loops;
+        return loops;
+    }
+};
+
+MultiNestLoops build_multi_nest(builder::StructuredSDFGBuilder& builder) {
+    MultiNestBuilder b(builder);
+    return b.build_default_multi_nest();
 }
 
 /**
@@ -730,6 +740,50 @@ TEST(LoopAnalysisTest, MovedLoop_ToOwnParent) {
     EXPECT_NE(std::find(a0_children.begin(), a0_children.end(), loops.a2), a0_children.end());
     const auto& a1_children = la.children(loops.a1);
     EXPECT_EQ(std::find(a1_children.begin(), a1_children.end(), loops.a2), a1_children.end());
+
+    verify_loop_index_consistency(la);
+}
+
+TEST(LoopAnalysisTest, Added_LocalContents) {
+    builder::StructuredSDFGBuilder builder("sdfg_move", FunctionType_CPU);
+    MultiNestBuilder b(builder);
+
+    auto a0 = &b.add_map(b.root, "i_a0");
+    auto a1 = &b.add_map(a0->root(), "i_a1");
+    auto a2 = &b.add_map(a1->root(), "i_a2");
+
+    analysis::AnalysisManager manager(builder.subject());
+    auto& la = manager.get<analysis::LoopAnalysis>();
+
+    dump_loop_info(la, "0.org");
+
+    EXPECT_TRUE(la.loop_info(a0).is_perfectly_nested);
+    EXPECT_TRUE(la.loop_info(a0).is_perfectly_parallel);
+    EXPECT_EQ(la.loop_info(a0).map_stack_depth, 3u);
+    EXPECT_EQ(la.loop_info(a1).map_stack_depth, 2u);
+    EXPECT_EQ(la.loop_info(a2).map_stack_depth, 1u);
+    EXPECT_FALSE(la.loop_info(a0).has_side_effects);
+
+    // move to a parent
+    la.added_local_contents(a1, true, true);
+
+    dump_loop_info(la, "0.added");
+
+    EXPECT_EQ(la.parent_loop(a2), a1);
+    EXPECT_EQ(la.parent_loop(a1), a0);
+
+    EXPECT_TRUE(la.loop_info(a2).is_perfectly_nested);
+    EXPECT_FALSE(la.loop_info(a1).is_perfectly_nested);
+    EXPECT_FALSE(la.loop_info(a0).is_perfectly_nested);
+
+    EXPECT_TRUE(la.loop_info(a2).is_perfectly_parallel);
+    EXPECT_TRUE(la.loop_info(a1).is_perfectly_parallel);
+    EXPECT_TRUE(la.loop_info(a0).is_perfectly_parallel);
+
+    EXPECT_FALSE(la.loop_info(a2).has_side_effects);
+    EXPECT_TRUE(la.loop_info(a1).has_side_effects);
+    EXPECT_TRUE(la.loop_info(a0).has_side_effects);
+
 
     verify_loop_index_consistency(la);
 }

--- a/sdfg/tests/builder/structured_sdfg_builder_test.cpp
+++ b/sdfg/tests/builder/structured_sdfg_builder_test.cpp
@@ -470,6 +470,46 @@ TEST(StructuredSDFGBuilderTest, FindElementById_Block) {
     EXPECT_EQ(builder.find_element_by_id(block.element_id()), &block);
 }
 
+TEST(StructuredSdfgBuilderTest, Sequence_RemoveChild) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+
+    types::Scalar desc(types::PrimitiveType::Int64);
+    builder.add_container("N", desc);
+
+    auto& root = builder.subject().root();
+    auto& block0 = builder.add_block(root);
+    auto& block1 = builder.add_block(root);
+    auto& block2 = builder.add_block(root);
+
+    EXPECT_EQ(root.size(), 3);
+
+    builder.remove_child(root, 1);
+
+    EXPECT_EQ(root.size(), 2);
+    EXPECT_EQ(&root.at(0).first, &block0);
+    EXPECT_EQ(&root.at(1).first, &block2);
+}
+
+TEST(StructuredSdfgBuilderTest, Sequence_RemoveFromParent) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+
+    types::Scalar desc(types::PrimitiveType::Int64);
+    builder.add_container("N", desc);
+
+    auto& root = builder.subject().root();
+    auto& block0 = builder.add_block(root);
+    auto& block1 = builder.add_block(root);
+    auto& block2 = builder.add_block(root);
+
+    EXPECT_EQ(root.size(), 3);
+
+    builder.remove_from_parent(block1);
+
+    EXPECT_EQ(root.size(), 2);
+    EXPECT_EQ(&root.at(0).first, &block0);
+    EXPECT_EQ(&root.at(1).first, &block2);
+}
+
 TEST(StructuredSDFGBuilderTest, ClearNode_AccessNode_Unused) {
     builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
 

--- a/sdfg/tests/loop_info_debug_dump.h
+++ b/sdfg/tests/loop_info_debug_dump.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <sdfg/analysis/analysis.h>
+
+void dump_loop_info(const sdfg::analysis::LoopAnalysis& analysis, const std::string& step);

--- a/sdfg/tests/replace/symbol_replace_test.cpp
+++ b/sdfg/tests/replace/symbol_replace_test.cpp
@@ -24,6 +24,40 @@ TEST(SymbolReplaceTest, AccessNodeTest) {
     EXPECT_EQ(access_node.data(), "scalar_2");
 }
 
+TEST(SymbolReplaceTest, BatchReplaceSequenceToSubsetTest) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    types::Scalar scalar(types::PrimitiveType::Int32);
+    types::Pointer ptr(scalar);
+    builder.add_container("ptr_1", ptr, true);
+    builder.add_container("ptr_2", ptr, true);
+    builder.add_container("a0", scalar, true);
+    builder.add_container("a1", scalar, true);
+    builder.add_container("b0", scalar, true);
+    builder.add_container("b1", scalar, true);
+
+    auto& sdfg = builder.subject();
+
+    auto& block = builder.add_block(sdfg.root());
+
+    auto& src_node = builder.add_access(block, "ptr_1");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    auto& dst_node = builder.add_access(block, "ptr_2");
+    auto& memlet_src =
+        builder.add_computational_memlet(block, src_node, tasklet, "_in", {symbolic::parse("3*a0+5-a1")}, ptr);
+    auto& memlet_dst =
+        builder.add_computational_memlet(block, tasklet, "_out", dst_node, {symbolic::parse("5+a0")}, ptr);
+
+    symbolic::ExpressionMapping mapping{
+        {symbolic::symbol("a0"), symbolic::symbol("b0")},
+        {symbolic::symbol("a1"), symbolic::mul(symbolic::symbol("b1"), symbolic::integer(2))}
+    };
+
+    sdfg.root().replace(mapping);
+
+    EXPECT_TRUE(symbolic::eq(memlet_src.subset().at(0), symbolic::parse("3*b0+5-(b1*2)")));
+    EXPECT_TRUE(symbolic::eq(memlet_dst.subset().at(0), symbolic::parse("5+b0")));
+}
+
 /*
 TEST(SymbolReplaceTest, TaskletTest) {
     builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);

--- a/sdfg/tests/test.cpp
+++ b/sdfg/tests/test.cpp
@@ -4,6 +4,9 @@
 #include "sdfg/serializer/json_serializer.h"
 #include "sdfg/visualizer/dot_visualizer.h"
 
+#include "loop_info_debug_dump.h"
+#include "sdfg_debug_dump.h"
+
 static std::optional<std::filesystem::path> test_output_dir;
 
 
@@ -29,5 +32,15 @@ void dump_sdfg(const sdfg::StructuredSDFG& sdfg, const std::string& step) {
         std::filesystem::create_directories(base_path);
         sdfg::serializer::JSONSerializer::writeToFile(sdfg, base_path / (sdfg.name() + "." + step + ".sdfg.json"));
         sdfg::visualizer::DotVisualizer::writeToFile(sdfg, base_path / (sdfg.name() + "." + step + ".sdfg.dot"));
+    }
+}
+
+void dump_loop_info(const sdfg::analysis::LoopAnalysis& analysis, const std::string& step) {
+    if (test_output_dir) {
+        auto info = ::testing::UnitTest::GetInstance()->current_test_info();
+        auto suite_name = info->test_suite_name();
+        auto test_name = info->name();
+        auto base_path = test_output_dir.value() / suite_name / test_name;
+        analysis.dump_to_file(base_path / (step + ".loop_info.json"));
     }
 }


### PR DESCRIPTION
 + new MapFusion that works simpler by just comparing the iteration domain for each level until there is no more perfectly nested & parallel loop. This way, we can easily fuse [Map] and [Map -> Map] or [Map -> Map] and [Map -> For] by not being forced to fuse all loops in the nest. Its also much easier to check the domain for all the cases where the iteration domains trivially match.

 + new infrastructure to handle updating patterns and continue looking (even inside the updated parts) by updating LoopAnalysis instead of fully invalidating it. Prepwork to make map-fusion scale better.

+ Element.replace(map): version that can replace multiple expressions at once, way more efficient when replacing multiple things on an entiore sub-tree

Closes #754 