### PR TITLE
Adds codegen option to emit a global constructor

### DIFF
--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -523,8 +523,25 @@ std::string PyStructuredSDFG::compile(
     docc::compile::CodegenBuildPool pool((threads > 0) ? threads : std::thread::hardware_concurrency());
 
     std::shared_ptr<sdfg::codegen::CodeSnippetFactory> snippet_factory = fcomp_handler->create_snippet_factory(*sdfg_);
-    sdfg::codegen::CPPCodeGenerator
-        generator(*sdfg_, analysis_manager, *instrumentation_plan, *arg_capture_plan, snippet_factory);
+
+    // Opt-in to one-shot GPU context warmup at .so load time so that the
+    // first kernel invocation does not pay the cold CUDA/HIP driver+context
+    // init cost. The constructor runs inside ctypes.CDLL(lib_path) during
+    // `program.compile()`, i.e. before any timed user call.
+    sdfg::codegen::GlobalConstructor global_constructor = sdfg::codegen::GlobalConstructor::None;
+    if (target == "cuda") {
+        global_constructor = sdfg::codegen::GlobalConstructor::CUDA;
+    }
+
+    sdfg::codegen::CPPCodeGenerator generator(
+        *sdfg_,
+        analysis_manager,
+        *instrumentation_plan,
+        *arg_capture_plan,
+        snippet_factory,
+        /*externals_prefix=*/"",
+        global_constructor
+    );
 
     return fcomp_handler->process(generator, pool, "lib" + sdfg_->name());
 }

--- a/sdfg/include/sdfg/codegen/code_generators/cpp_code_generator.h
+++ b/sdfg/include/sdfg/codegen/code_generators/cpp_code_generator.h
@@ -7,9 +7,16 @@
 namespace sdfg {
 namespace codegen {
 
+/// @brief Optional GPU-runtime context warmup emitted as a `.so`-load
+/// constructor. Off by default; enable to amortize the one-shot CUDA
+/// driver/context init cost out of the first kernel call (and out of any
+/// measured region wrapping it).
+enum class GlobalConstructor { None, CUDA };
+
 class CPPCodeGenerator : public CStyleBaseCodeGenerator {
 private:
     CPPLanguageExtension language_extension_;
+    GlobalConstructor global_constructor_;
 
 protected:
     void dispatch_header_includes(PrettyPrinter& out) override;
@@ -29,7 +36,8 @@ public:
         InstrumentationPlan& instrumentation_plan,
         ArgCapturePlan& arg_capture_plan,
         std::shared_ptr<CodeSnippetFactory> library_snippet_factory = std::make_shared<CodeSnippetFactory>(),
-        const std::string& externals_prefix = ""
+        const std::string& externals_prefix = "",
+        GlobalConstructor global_constructor = GlobalConstructor::None
     )
         : CStyleBaseCodeGenerator(
               sdfg,
@@ -39,7 +47,7 @@ public:
               std::move(library_snippet_factory),
               externals_prefix
           ),
-          language_extension_(sdfg, externals_prefix) {}
+          language_extension_(sdfg, externals_prefix), global_constructor_(global_constructor) {}
 
     std::string function_definition() override;
 

--- a/sdfg/src/codegen/code_generators/cpp_code_generator.cpp
+++ b/sdfg/src/codegen/code_generators/cpp_code_generator.cpp
@@ -115,6 +115,25 @@ void CPPCodeGenerator::dispatch_header_structures(PrettyPrinter& out) {
 }
 
 void CPPCodeGenerator::dispatch_globals() {
+    // Optional one-shot GPU runtime / context warmup, executed at .so load time
+    // via __attribute__((constructor)). Moves the cold CUDA driver+context
+    // init cost out of the first kernel call (and out of any instrumented region
+    // wrapping it). Opt-in: callers set GlobalConstructor at construction time.
+    if (this->global_constructor_ != GlobalConstructor::None) {
+        // No explicit cuda_runtime.h include: the source file
+        // is compiled with `-x cuda`, which provides the runtime
+        // API declarations implicitly (matches the rest of the emitted host
+        // wrapper, e.g. cudaSetDevice/cudaMalloc below).
+        this->globals_stream_ << "static void __attribute__((constructor)) "
+                                 "__daisy_gpu_context_warmup(void) {"
+                              << std::endl;
+        if (this->global_constructor_ == GlobalConstructor::CUDA) {
+            this->globals_stream_ << "    (void)cudaSetDevice(0);" << std::endl;
+            this->globals_stream_ << "    (void)cudaFree(0);" << std::endl;
+        }
+        this->globals_stream_ << "}" << std::endl;
+    }
+
     // Declare globals
     for (auto& container : sdfg_.externals()) {
         // Function declarations


### PR DESCRIPTION
Improves pure execution performance of first run on JIT-targets by moving context initialization time into .so loading