### PR TITLE
Offload grouped convolutions

### DIFF
--- a/mlir/benchmarks/harness.py
+++ b/mlir/benchmarks/harness.py
@@ -3,33 +3,101 @@ import torch
 import time
 import docc.torch
 
+
+def _torch_to_device(
+    input: None | int | float | torch.Tensor | tuple, device: torch.device
+) -> None | int | float | torch.Tensor | tuple:
+    if type(input) in [None, int, float]:
+        return input
+    elif type(input) == torch.Tensor:
+        return input.to(device)
+    elif type(input) == tuple:
+        res = []
+        for elem in input:
+            res.append(_torch_to_device(elem, device))
+        return tuple(res)
+    else:
+        raise ValueError(f"Unknown type for copying to device: {type(input)}")
+
+
+def _torch_from_device(
+    output: None | int | float | torch.Tensor | tuple,
+) -> None | int | float | torch.Tensor | tuple:
+    if type(output) in [None, int, float]:
+        return output
+    elif type(output) == torch.Tensor:
+        return output.to("cpu")
+    elif type(output) == tuple:
+        res = []
+        for elem in output:
+            res.append(_torch_from_device(elem))
+        return tuple(res)
+    else:
+        raise ValueError(f"Unknown type for copying from device: {type(output)}")
+
+
 def run_benchmark(setup_func, name):
     parser = argparse.ArgumentParser()
     parser.add_argument("--docc", action="store_true")
     parser.add_argument("--torch", action="store_true")
-    parser.add_argument("--target", type=str, default="none")
+    parser.add_argument(
+        "--target",
+        type=str,
+        choices=["none", "sequential", "openmp", "cuda", "rocm"],
+        default="none",
+    )
     parser.add_argument("--n_runs", type=int, default=10)
     args = parser.parse_args()
 
     model, model_input = setup_func()
 
     if args.torch:
+        # Check for GPU and set device accordingly
+        if args.target in ["cuda", "rocm"]:
+            if not torch.cuda.is_available():
+                print(f"Error: Target {args.target} not available")
+                exit(1)
+            device = torch.device("cuda")
+        else:
+            device = torch.device("cpu")
+
+        # Move model to GPU if necessary
+        model = model.to(device)
+
+        # Print device
+        if device.type == "cuda":
+            print(f"Torch device: {torch.cuda.get_device_name(device)}")
+        else:
+            print(f"Torch device: {device}")
+
         for _ in range(args.n_runs):
+            if device.type == "cuda":
+                torch.cuda.synchronize(device)
             start = time.time()
             with torch.no_grad():
+                if device.type == "cuda":
+                    model_input = _torch_to_device(model_input, device)
                 program = torch.compile(model)
                 if type(model_input) == tuple:
-                    program(*model_input)
+                    model_output = program(*model_input)
                 else:
-                    program(model_input)
+                    model_output = program(model_input)
+                if device.type == "cuda":
+                    _torch_from_device(model_output)
+            if device.type == "cuda":
+                torch.cuda.synchronize(device)
             end = time.time()
             print(f"{name} torch execution time: {end - start:.6f} seconds")
-    
+
     if args.docc:
         for _ in range(args.n_runs):
             start = time.time()
             with torch.no_grad():
-                program = torch.compile(model, backend="docc", options={"target": args.target, "category": "server"})
+                program = torch.compile(
+                    model,
+                    backend="docc",
+                    options={"target": args.target, "category": "server"},
+                )
                 if type(model_input) == tuple:
                     program(*model_input)
                 else:

--- a/mlir/benchmarks/torch/model_zoo/segformer.py
+++ b/mlir/benchmarks/torch/model_zoo/segformer.py
@@ -601,7 +601,7 @@ class SegformerDecodeHead(nn.Module):
 
 def setup_segformer_decode_head() -> tuple[
     SegformerDecodeHead,
-    tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+    tuple[tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]],
 ]:
     model = SegformerDecodeHead()
     model.eval()
@@ -609,7 +609,7 @@ def setup_segformer_decode_head() -> tuple[
     x = torch.randn(1, 64, 64, 64)
     y = torch.randn(1, 160, 32, 32)
     z = torch.randn(1, 256, 16, 16)
-    return model, (w, x, y, z)
+    return model, ((w, x, y, z),)
 
 
 class SegformerForSemanticSegmentation(nn.Module):

--- a/opt/include/sdfg/targets/cuda/math/tensor/conv_expander.h
+++ b/opt/include/sdfg/targets/cuda/math/tensor/conv_expander.h
@@ -23,6 +23,18 @@ public:
         analysis::AnalysisManager& analysis_manager,
         math::tensor::ConvNode& node
     );
+
+    static bool expand_conv_naive(
+        builder::StructuredSDFGBuilder& builder,
+        analysis::AnalysisManager& analysis_manager,
+        math::tensor::ConvNode& node
+    );
+
+    static bool expand_conv_im2row(
+        builder::StructuredSDFGBuilder& builder,
+        analysis::AnalysisManager& analysis_manager,
+        math::tensor::ConvNode& node
+    );
 };
 } // namespace offloading
 } // namespace sdfg

--- a/opt/src/targets/cuda/math/tensor/conv_expander.cpp
+++ b/opt/src/targets/cuda/math/tensor/conv_expander.cpp
@@ -20,6 +20,258 @@ bool CudaConvExpander::expand(builder::StructuredSDFGBuilder& builder, analysis:
 bool CudaConvExpander::expand_conv(
     builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager, math::tensor::ConvNode& node
 ) {
+    // First, try im2row expansion
+    if (expand_conv_im2row(builder, analysis_manager, node)) {
+        return true;
+    }
+    // When im2row fails, e.g., for grouped convolutions, use naïve expansion
+    return expand_conv_naive(builder, analysis_manager, node);
+}
+
+bool CudaConvExpander::expand_conv_naive(
+    builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager, math::tensor::ConvNode& node
+) {
+    auto& dfg = node.get_parent();
+    math::tensor::ConvNode::ConvExpandPrerequisits b;
+    if (!node.check_expandable(dfg, analysis_manager, b)) {
+        return false;
+    }
+
+    types::Scalar base_type(node.primitive_type(dfg));
+    math::blas::BLAS_Precision precision = node.get_blas_precision(base_type);
+
+    // Create new sequence for expansion
+    auto& new_sequence = builder.add_sequence_before(
+        *b.block_parent, *b.block, b.block_parent->at(b.block_index).second.assignments(), b.block->debug_info()
+    );
+
+    // Dimensions, i.e., 1D, 2D, 3D, ...
+    size_t dims = node.kernel_shape().size();
+    symbolic::MultiExpression out_shape = node.get_out_shape();
+    types::Scalar indvar_type(types::PrimitiveType::Int64);
+
+    // Create nested map structure for convolution
+    structured_control_flow::Sequence* current_seq = &new_sequence;
+
+    // Add loop over batch size
+    auto n_container = builder.find_new_name("_n");
+    builder.add_container(n_container, indvar_type);
+    auto n = symbolic::symbol(n_container);
+    auto& loop_n = builder.add_map(
+        *current_seq,
+        n,
+        symbolic::Lt(n, node.shape()[0]),
+        symbolic::zero(),
+        symbolic::add(n, symbolic::one()),
+        ScheduleType_Sequential::create(),
+        {},
+        b.block->debug_info()
+    );
+    current_seq = &loop_n.root();
+
+    // Add loop over output channels
+    auto l_container = builder.find_new_name("_l");
+    builder.add_container(l_container, indvar_type);
+    auto l = symbolic::symbol(l_container);
+    auto& loop_l = builder.add_map(
+        *current_seq,
+        l,
+        symbolic::Lt(l, node.output_channels()),
+        symbolic::zero(),
+        symbolic::add(l, symbolic::one()),
+        ScheduleType_Sequential::create(),
+        {},
+        b.block->debug_info()
+    );
+    current_seq = &loop_l.root();
+
+    // Add loops over output dimensions
+    symbolic::SymbolVec os;
+    os.reserve(dims);
+    for (size_t i = 0; i < dims; i++) {
+        auto o_container = builder.find_new_name("_o");
+        builder.add_container(o_container, indvar_type);
+        auto o = symbolic::symbol(o_container);
+        os.push_back(o);
+        auto& loop_o = builder.add_map(
+            *current_seq,
+            o,
+            symbolic::Lt(o, out_shape[i]),
+            symbolic::zero(),
+            symbolic::add(o, symbolic::one()),
+            ScheduleType_Sequential::create(),
+            {},
+            b.block->debug_info()
+        );
+        current_seq = &loop_o.root();
+    }
+
+    // Create accumulator variable for the sum
+    std::string accum_container = builder.find_new_name("_conv_accum");
+    builder.add_container(accum_container, base_type);
+
+    // Initialize accumulator with zero
+    structured_control_flow::Sequence* accum_seq = current_seq;
+    auto& init_block = builder.add_block(*accum_seq, {}, b.block->debug_info());
+    {
+        auto& constant_zero = builder.add_constant(init_block, "0.0", base_type, node.debug_info());
+        auto& accum_access = builder.add_access(init_block, accum_container, node.debug_info());
+        auto& tasklet =
+            builder.add_tasklet(init_block, data_flow::TaskletCode::assign, "_out", {"_in"}, node.debug_info());
+        builder.add_computational_memlet(init_block, constant_zero, tasklet, "_in", {}, node.debug_info());
+        builder.add_computational_memlet(init_block, tasklet, "_out", accum_access, {}, node.debug_info());
+    }
+
+    // Add loop over channels (per group)
+    auto channels_per_group = symbolic::div(node.shape()[1], node.group());
+    auto c_container = builder.find_new_name("_c");
+    builder.add_container(c_container, indvar_type);
+    auto c = symbolic::symbol(c_container);
+    auto& loop_c = builder.add_for(
+        *current_seq,
+        c,
+        symbolic::Lt(c, channels_per_group),
+        symbolic::zero(),
+        symbolic::add(c, symbolic::one()),
+        {},
+        b.block->debug_info()
+    );
+    current_seq = &loop_c.root();
+
+    // Add loops over kernel shape
+    symbolic::SymbolVec ks;
+    ks.reserve(dims);
+    for (size_t i = 0; i < dims; i++) {
+        auto k_container = builder.find_new_name("_k");
+        builder.add_container(k_container, indvar_type);
+        auto k = symbolic::symbol(k_container);
+        ks.push_back(k);
+        auto& loop_k = builder.add_for(
+            *current_seq,
+            k,
+            symbolic::Lt(k, node.kernel_shape()[i]),
+            symbolic::zero(),
+            symbolic::add(k, symbolic::one()),
+            {},
+            b.block->debug_info()
+        );
+        current_seq = &loop_k.root();
+    }
+
+    // Check if at least one padding value is non-zero or unknown
+    bool has_padding = false;
+    for (auto& pad : node.pads()) {
+        if (SymEngine::is_a<SymEngine::Integer>(*pad)) {
+            if (SymEngine::rcp_static_cast<const SymEngine::Integer>(pad)->as_int() != 0) {
+                // We found a non-zero padding value
+                has_padding = true;
+                break;
+            }
+        } else {
+            // We just don't know if the convolution is padded and assume that it is as a fall-back
+            has_padding = true;
+            break;
+        }
+    }
+
+    // Compute spatial input dimensions
+    symbolic::MultiExpression is;
+    is.reserve(dims);
+    for (size_t i = 0; i < dims; i++) {
+        is.push_back(symbolic::
+                         add(symbolic::sub(symbolic::mul(os[i], node.strides()[i]), node.pads()[i]),
+                             symbolic::mul(ks[i], node.dilations()[i])));
+    }
+
+    // If convolution is padded, add branch to stay in bounds for computation
+    if (has_padding) {
+        symbolic::Condition comp_condition = symbolic::__true__();
+        for (size_t i = 0; i < dims; i++) {
+            comp_condition = symbolic::
+                And(comp_condition,
+                    symbolic::And(symbolic::Lt(is[i], node.shape()[i + 2]), symbolic::Ge(is[i], symbolic::zero())));
+        }
+        auto& branch = builder.add_if_else(*current_seq, {}, b.block->debug_info());
+        current_seq = &builder.add_case(branch, comp_condition, b.block->debug_info());
+    }
+
+    // Determine subsets for computation
+    auto out_channels_per_group = symbolic::div(node.output_channels(), node.group());
+    auto group_idx = symbolic::div(l, out_channels_per_group);
+    auto input_channel_idx = symbolic::add(symbolic::mul(group_idx, channels_per_group), c);
+    data_flow::Subset X_subset;
+    X_subset.push_back(n);
+    X_subset.push_back(input_channel_idx);
+    X_subset.insert(X_subset.end(), is.begin(), is.end());
+    data_flow::Subset W_subset;
+    W_subset.push_back(l);
+    W_subset.push_back(c);
+    W_subset.insert(W_subset.end(), ks.begin(), ks.end());
+
+    // Create computation block
+    auto& comp_block = builder.add_block(*current_seq, {}, b.block->debug_info());
+    {
+        auto& X_access = builder.add_access(comp_block, b.access_X->data(), b.access_X->debug_info());
+        auto& W_access = builder.add_access(comp_block, b.access_W->data(), b.access_W->debug_info());
+        auto& accum_access_in = builder.add_access(comp_block, accum_container, node.debug_info());
+        auto& accum_access_out = builder.add_access(comp_block, accum_container, node.debug_info());
+        auto& tasklet = builder.add_tasklet(
+            comp_block, data_flow::TaskletCode::fp_fma, "_out", {"_in1", "_in2", "_in3"}, node.debug_info()
+        );
+        builder.add_computational_memlet(
+            comp_block, X_access, tasklet, "_in1", X_subset, b.iedge_X->base_type(), b.iedge_X->debug_info()
+        );
+        builder.add_computational_memlet(
+            comp_block, W_access, tasklet, "_in2", W_subset, b.iedge_W->base_type(), b.iedge_W->debug_info()
+        );
+        builder.add_computational_memlet(comp_block, accum_access_in, tasklet, "_in3", {}, base_type, node.debug_info());
+        builder
+            .add_computational_memlet(comp_block, tasklet, "_out", accum_access_out, {}, base_type, node.debug_info());
+    }
+
+    // Determine subsets for output
+    data_flow::Subset Y_subset;
+    Y_subset.push_back(n);
+    Y_subset.push_back(l);
+    Y_subset.insert(Y_subset.end(), os.begin(), os.end());
+
+    // Create output block, i.e., write accumulation back to output
+    auto& output_block = builder.add_block(*accum_seq, {}, b.block->debug_info());
+    if (b.has_bias) {
+        auto& accum_access = builder.add_access(output_block, accum_container, node.debug_info());
+        auto& B_access = builder.add_access(output_block, b.access_B->data(), b.access_B->debug_info());
+        auto& Y_access = builder.add_access(output_block, b.access_Y->data(), b.access_Y->debug_info());
+        auto& tasklet =
+            builder
+                .add_tasklet(output_block, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"}, node.debug_info());
+        builder.add_computational_memlet(output_block, accum_access, tasklet, "_in1", {}, base_type, node.debug_info());
+        builder.add_computational_memlet(
+            output_block, B_access, tasklet, "_in2", {l}, b.iedge_B->base_type(), b.iedge_B->debug_info()
+        );
+        builder.add_computational_memlet(
+            output_block, tasklet, "_out", Y_access, Y_subset, b.iedge_Y->base_type(), b.iedge_Y->debug_info()
+        );
+    } else {
+        auto& accum_access = builder.add_access(output_block, accum_container, node.debug_info());
+        auto& Y_access = builder.add_access(output_block, b.access_Y->data(), b.access_Y->debug_info());
+        auto& tasklet =
+            builder.add_tasklet(output_block, data_flow::TaskletCode::assign, "_out", {"_in"}, node.debug_info());
+        builder.add_computational_memlet(output_block, accum_access, tasklet, "_in", {}, base_type, node.debug_info());
+        builder.add_computational_memlet(
+            output_block, tasklet, "_out", Y_access, Y_subset, b.iedge_Y->base_type(), b.iedge_Y->debug_info()
+        );
+    }
+
+    // Clean up the original block
+    builder.clear_code_node_legacy(*b.block, node);
+    builder.remove_child(*b.block_parent, b.block_index + 1);
+
+    return true;
+}
+
+bool CudaConvExpander::expand_conv_im2row(
+    builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager, math::tensor::ConvNode& node
+) {
     auto& dfg = node.get_parent();
     math::tensor::ConvNode::ConvExpandPrerequisits b;
     if (!node.check_expandable(dfg, analysis_manager, b)) {
@@ -28,7 +280,7 @@ bool CudaConvExpander::expand_conv(
 
     if (!symbolic::eq(node.group(), symbolic::one())) {
         // If there are no groups (i.e., group == 1), then we can do im2row with one GEMM.
-        // Else, no CUDA specific expand is needed
+        // Else, im2row is not possible
         return false;
     }
 

--- a/opt/src/targets/rocm/math/tensor/conv_expander.cpp
+++ b/opt/src/targets/rocm/math/tensor/conv_expander.cpp
@@ -15,7 +15,7 @@ namespace sdfg {
 namespace offloading {
 
 bool RocmConvExpander::expand(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {
-    // for now we reuse the cuda impl until we find sth. where they need to diver
+    // for now we reuse the cuda impl until we find sth. where they need to diverge
     return CudaConvExpander::expand_conv(builder, analysis_manager, node_);
 }
 } // namespace offloading

--- a/opt/tests/CMakeLists.txt
+++ b/opt/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ set(TEST_FILES
     optimizations/gpu_kernels_test.cpp
     passes/offloading/cuda_library_node_transfer_extraction_pass_test.cpp
     passes/offloading/cuda_library_node_expand_tests.cpp
+    passes/offloading/rocm_library_node_expand_tests.cpp
     passes/offloading/rocm_library_node_transfer_extraction_pass_test.cpp
     passes/offloading/cuda_library_node_rewriter_pass_test.cpp
     passes/offloading/rocm_library_node_rewriter_pass_test.cpp

--- a/opt/tests/passes/offloading/rocm_library_node_expand_tests.cpp
+++ b/opt/tests/passes/offloading/rocm_library_node_expand_tests.cpp
@@ -3,14 +3,14 @@
 #include "sdfg/analysis/analysis.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/conv_node.h"
-#include "sdfg/targets/cuda/math/tensor/conv_expander.h"
+#include "sdfg/targets/rocm/math/tensor/conv_expander.h"
 
 #include "sdfg_debug_dump.h"
 
 using namespace sdfg;
 
-// Test that CudaConvExpander successfully expands a valid 2D ConvNode with group==1 with im2row expansion
-TEST(CudaConvExpanderTest, ExpandsValidConv2D_Group1) {
+// Test that RocmConvExpander successfully expands a valid 2D ConvNode with group==1 with im2row expansion
+TEST(RocmConvExpanderTest, ExpandsValidConv2D_Group1) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
     auto& sdfg = builder.subject();
 
@@ -58,7 +58,7 @@ TEST(CudaConvExpanderTest, ExpandsValidConv2D_Group1) {
     dump_sdfg(sdfg, "0.before");
 
     analysis::AnalysisManager analysis_manager(sdfg);
-    offloading::CudaConvExpander expander(conv_node);
+    offloading::RocmConvExpander expander(conv_node);
     EXPECT_TRUE(expander.expand(builder, analysis_manager));
 
     EXPECT_NO_THROW(sdfg.validate());
@@ -70,8 +70,8 @@ TEST(CudaConvExpanderTest, ExpandsValidConv2D_Group1) {
     EXPECT_EQ(new_sequence->size(), 7) << "Expecting im2row expansion";
 }
 
-// Test that CudaConvExpander successfully expands a valid 2D ConvNode with group!=1 with naïve expansion
-TEST(CudaConvExpanderTest, ExpandsValidConv2D_GroupNotOne) {
+// Test that RocmConvExpander successfully expands a valid 2D ConvNode with group!=1 with naïve expansion
+TEST(RocmConvExpanderTest, ExpandsValidConv2D_GroupNotOne) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
     auto& sdfg = builder.subject();
 
@@ -119,7 +119,7 @@ TEST(CudaConvExpanderTest, ExpandsValidConv2D_GroupNotOne) {
     dump_sdfg(sdfg, "0.before");
 
     analysis::AnalysisManager analysis_manager(sdfg);
-    offloading::CudaConvExpander expander(conv_node);
+    offloading::RocmConvExpander expander(conv_node);
     EXPECT_TRUE(expander.expand(builder, analysis_manager));
 
     EXPECT_NO_THROW(sdfg.validate());
@@ -131,8 +131,8 @@ TEST(CudaConvExpanderTest, ExpandsValidConv2D_GroupNotOne) {
     EXPECT_EQ(new_sequence->size(), 1) << "Expecting naïve expansion";
 }
 
-// Test that CudaConvExpander successfully expands a valid 2D ConvNode with group==1 with im2row expansion
-TEST(CudaConvExpanderTest, ExpandsValidConv2DWithBias_Group1) {
+// Test that RocmConvExpander successfully expands a valid 2D ConvNode with group==1 with im2row expansion
+TEST(RocmConvExpanderTest, ExpandsValidConv2DWithBias_Group1) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
     auto& sdfg = builder.subject();
 
@@ -184,7 +184,7 @@ TEST(CudaConvExpanderTest, ExpandsValidConv2DWithBias_Group1) {
     dump_sdfg(sdfg, "0.before");
 
     analysis::AnalysisManager analysis_manager(sdfg);
-    offloading::CudaConvExpander expander(conv_node);
+    offloading::RocmConvExpander expander(conv_node);
     EXPECT_TRUE(expander.expand(builder, analysis_manager));
 
     EXPECT_NO_THROW(sdfg.validate());
@@ -196,8 +196,8 @@ TEST(CudaConvExpanderTest, ExpandsValidConv2DWithBias_Group1) {
     EXPECT_EQ(new_sequence->size(), 7) << "Expecting im2row expansion";
 }
 
-// Test that CudaConvExpander successfully expands a valid 2D ConvNode with group!=1 with naïve expansion
-TEST(CudaConvExpanderTest, ExpandsValidConv2DWithBias_GroupNotOne) {
+// Test that RocmConvExpander successfully expands a valid 2D ConvNode with group!=1 with naïve expansion
+TEST(RocmConvExpanderTest, ExpandsValidConv2DWithBias_GroupNotOne) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
     auto& sdfg = builder.subject();
 
@@ -249,7 +249,7 @@ TEST(CudaConvExpanderTest, ExpandsValidConv2DWithBias_GroupNotOne) {
     dump_sdfg(sdfg, "0.before");
 
     analysis::AnalysisManager analysis_manager(sdfg);
-    offloading::CudaConvExpander expander(conv_node);
+    offloading::RocmConvExpander expander(conv_node);
     EXPECT_TRUE(expander.expand(builder, analysis_manager));
 
     EXPECT_NO_THROW(sdfg.validate());
@@ -261,8 +261,8 @@ TEST(CudaConvExpanderTest, ExpandsValidConv2DWithBias_GroupNotOne) {
     EXPECT_EQ(new_sequence->size(), 1) << "Expecting naïve expansion";
 }
 
-// Test that CudaConvExpander successfully expands a valid 2D ConvNode with group!=1 with naïve expansion
-TEST(CudaConvExpanderTest, ExpandsValidConv2D_GroupNotOne_SymbolicPadding) {
+// Test that RocmConvExpander successfully expands a valid 2D ConvNode with group!=1 with naïve expansion
+TEST(RocmConvExpanderTest, ExpandsValidConv2D_GroupNotOne_SymbolicPadding) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
     auto& sdfg = builder.subject();
 
@@ -313,7 +313,7 @@ TEST(CudaConvExpanderTest, ExpandsValidConv2D_GroupNotOne_SymbolicPadding) {
     dump_sdfg(sdfg, "0.before");
 
     analysis::AnalysisManager analysis_manager(sdfg);
-    offloading::CudaConvExpander expander(conv_node);
+    offloading::RocmConvExpander expander(conv_node);
     EXPECT_TRUE(expander.expand(builder, analysis_manager));
 
     EXPECT_NO_THROW(sdfg.validate());
@@ -325,9 +325,9 @@ TEST(CudaConvExpanderTest, ExpandsValidConv2D_GroupNotOne_SymbolicPadding) {
     EXPECT_EQ(new_sequence->size(), 1) << "Expecting naïve expansion";
 }
 
-// Test that CudaConvExpander declines when the dataflow graph has extra nodes
+// Test that RocmConvExpander declines when the dataflow graph has extra nodes
 // (i.e., check_expandable fails due to unexpected graph structure)
-TEST(CudaConvExpanderTest, DeclinesWhenNotExpandable_ExtraNodes) {
+TEST(RocmConvExpanderTest, DeclinesWhenNotExpandable_ExtraNodes) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
     auto& sdfg = builder.subject();
 
@@ -375,15 +375,15 @@ TEST(CudaConvExpanderTest, DeclinesWhenNotExpandable_ExtraNodes) {
     builder.add_computational_memlet(block, output_node, conv_node, "Y", {}, desc_tensor_output, block.debug_info());
 
     analysis::AnalysisManager analysis_manager(sdfg);
-    offloading::CudaConvExpander expander(conv_node);
+    offloading::RocmConvExpander expander(conv_node);
     bool expanded = expander.expand(builder, analysis_manager);
 
     // Should decline because check_expandable fails (extra node in DFG)
     EXPECT_FALSE(expanded);
 }
 
-// Test that CudaConvExpander successfully expands a valid 1D ConvNode with group==1
-TEST(CudaConvExpanderTest, ExpandsValidConv1D_Group1) {
+// Test that RocmConvExpander successfully expands a valid 1D ConvNode with group==1
+TEST(RocmConvExpanderTest, ExpandsValidConv1D_Group1) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
     auto& sdfg = builder.subject();
 
@@ -423,7 +423,7 @@ TEST(CudaConvExpanderTest, ExpandsValidConv1D_Group1) {
     EXPECT_NO_THROW(sdfg.validate());
 
     analysis::AnalysisManager analysis_manager(sdfg);
-    offloading::CudaConvExpander expander(conv_node);
+    offloading::RocmConvExpander expander(conv_node);
     bool expanded = expander.expand(builder, analysis_manager);
 
     EXPECT_TRUE(expanded);


### PR DESCRIPTION
- The target specific expansion for CUDA and ROCm used im2row which does not support grouped convolutions. The fallback was im2col which could not be offloaded. Now, the fallback for im2row is the naïve expansion such that a grouped convolution can be offloaded successfully.
- Extended/added unit tests for target specific expansion of convolutions
- Fixed a small bug in the segformer component benchmarks
- Adapted the harness to test PyTorch with CUDA/ROCm