### PR TITLE
Fix segformer benchmark

### DIFF
--- a/mlir/benchmarks/torch/model_zoo/segformer.py
+++ b/mlir/benchmarks/torch/model_zoo/segformer.py
@@ -39,7 +39,7 @@ def setup_segformer_overlap_patch_embeddings(
         patch_size, stride, num_channels, hidden_size
     )
     model.eval()
-    x = torch.randn(1, num_channels, 512, 512)
+    x = torch.randn(1, num_channels, h, w)
     return model, x
 
 


### PR DESCRIPTION
512 was hard coded instead of using dynamic image sizes