### PR TITLE
Replicate MLIR Linalg.Fill nodes with 0 (zero initializers) 

### DIFF
--- a/mlir/include/mlir/Target/SDFG/SDFGTranslator.h
+++ b/mlir/include/mlir/Target/SDFG/SDFGTranslator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <list>
+#include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/ScopedHashTable.h>
 #include <memory>
 #include <string>
@@ -81,6 +82,11 @@ class SDFGTranslator {
 
     std::unordered_map<std::string, std::string> alias_map_;
 
+    // Maps a linalg.fill result whose materialization was deferred to the constant scalar value it
+    // fills with, so each consumer can regenerate a freshly-filled array instead of copying from a
+    // single shared buffer.
+    llvm::DenseMap<Value, Value> constant_fill_map_;
+
     std::vector<std::string> output_args_;
 
 public:
@@ -129,6 +135,14 @@ public:
     std::string get_or_copy_output_container(
         Value output, const ::sdfg::DebugInfo& deb_info = ::sdfg::DebugInfo(), bool consumer_overwrites_output = false
     );
+
+    /// Record that `result` is produced by a constant `value` linalg.fill whose materialization is
+    /// deferred. Each consumer regenerates a freshly-filled array on demand instead of copying from
+    /// a single shared buffer (saving the source buffer and turning per-use memcpys into fills).
+    void record_constant_fill(Value result, Value value);
+
+    /// Returns true if `result` was recorded via record_constant_fill.
+    bool is_constant_fill(Value result) const;
 
     /// Returns the container of `input` if its buffer can be safely overwritten in place by an
     /// elementwise consumer producing `result`, otherwise the empty string. Conservatively limited

--- a/mlir/lib/Target/SDFG/LinalgToSDFGTranslator.cpp
+++ b/mlir/lib/Target/SDFG/LinalgToSDFGTranslator.cpp
@@ -867,6 +867,27 @@ LogicalResult translateLinalgOp(SDFGTranslator& translator, Operation* op) {
         });
 }
 
+// Returns true iff every use of `result` is a linalg destination-style init operand and there is
+// more than one such use. In that case each consumer copies the buffer for itself, so the fill's
+// own buffer is never read directly and its materialization can be deferred.
+static bool shouldDeferConstantFill(Value result) {
+    int count = 0;
+    for (OpOperand& use : result.getUses()) {
+        auto dps = dyn_cast<DestinationStyleOpInterface>(use.getOwner());
+        if (!dps) {
+            return false;
+        }
+        auto inits = dps.getDpsInits();
+        unsigned begin = inits.getBeginOperandIndex();
+        unsigned end = begin + static_cast<unsigned>(inits.size());
+        if (use.getOperandNumber() < begin || use.getOperandNumber() >= end) {
+            return false;
+        }
+        count++;
+    }
+    return count > 1;
+}
+
 LogicalResult translateLinalgFillOp(SDFGTranslator& translator, linalg::FillOp* op) {
     auto& sequence = translator.insertion_point();
 
@@ -874,6 +895,14 @@ LogicalResult translateLinalgFillOp(SDFGTranslator& translator, linalg::FillOp* 
     Value output = op->output();
     Value result = op->result();
     auto deb_info = translator.get_debug_info(op->getOperationName(), op->getLoc());
+
+    // If the fill writes a constant whose result is consumed only as a linalg destination init by
+    // more than one op, defer materialization: record the fill so each consumer regenerates a
+    // freshly-filled array on demand instead of copying from a single shared buffer.
+    if (dyn_cast_or_null<arith::ConstantOp>(value.getDefiningOp()) && shouldDeferConstantFill(result)) {
+        translator.record_constant_fill(result, value);
+        return success();
+    }
 
     auto value_container = translator.get_or_create_container(value);
     auto output_container = translator.get_or_copy_output_container(output, deb_info);

--- a/mlir/lib/Target/SDFG/SDFGTranslator.cpp
+++ b/mlir/lib/Target/SDFG/SDFGTranslator.cpp
@@ -25,6 +25,7 @@
 #include "mlir/Target/SDFG/TensorToSDFGTranslator.h"
 #include "mlir/Target/SDFG/helper.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/fill_node.h"
 #include "sdfg/data_flow/library_nodes/stdlib/free.h"
 #include "sdfg/data_flow/library_nodes/stdlib/malloc.h"
 #include "sdfg/data_flow/library_nodes/stdlib/memcpy.h"
@@ -386,6 +387,12 @@ static int count_linalg_output_uses(Value value) {
     return count;
 }
 
+void SDFGTranslator::record_constant_fill(Value result, Value value) {
+    this->constant_fill_map_.insert({result, value});
+}
+
+bool SDFGTranslator::is_constant_fill(Value result) const { return this->constant_fill_map_.count(result) != 0; }
+
 std::string SDFGTranslator::
     get_or_copy_output_container(Value output, const ::sdfg::DebugInfo& deb_info, bool consumer_overwrites_output) {
     auto output_container = this->get_or_create_container(output);
@@ -419,17 +426,38 @@ std::string SDFGTranslator::
     // (e.g. matmul with beta=0), or the output is uninitialized (tensor.empty).
     if (!consumer_overwrites_output &&
         (!output.getDefiningOp() || !llvm::isa<tensor::EmptyOp>(output.getDefiningOp()))) {
-        auto& src_type = builder_.subject().type(output_container);
-        auto& dst_type = builder_.subject().type(copy_container);
-        ::sdfg::stdlib::add_memcpy_block(
-            builder_,
-            this->insertion_point(),
-            output_container,
-            copy_container,
-            byte_count,
-            src_type, // original had dst_type as well. but memcpy needs both same and we do not model read-only
-            deb_info
-        );
+        auto fill_it = this->constant_fill_map_.find(output);
+        if (fill_it != this->constant_fill_map_.end()) {
+            // The source is a deferred constant fill: regenerate a freshly-filled array directly
+            // instead of copying from a shared buffer.
+            auto constant_op = llvm::cast<arith::ConstantOp>(fill_it->second.getDefiningOp());
+            auto sdfg_tensor = tensor_info.get_sdfg_tensor(scalar_type);
+
+            auto& block = this->builder_.add_block(this->insertion_point(), {}, deb_info);
+            auto& in_access = this->builder_.add_constant(
+                block,
+                this->convertTypedAttr(constant_op.getValue()),
+                *this->convertType(constant_op.getType()),
+                deb_info
+            );
+            auto& fill_node =
+                this->builder_.add_library_node<::sdfg::math::tensor::FillNode>(block, deb_info, sdfg_tensor->shape());
+            this->builder_.add_computational_memlet(block, in_access, fill_node, "X", {}, scalar_type, deb_info);
+            auto& out_access = this->builder_.add_access(block, copy_container, deb_info);
+            this->builder_.add_computational_memlet(block, out_access, fill_node, "Y", {}, *sdfg_tensor, deb_info);
+        } else {
+            auto& src_type = builder_.subject().type(output_container);
+            auto& dst_type = builder_.subject().type(copy_container);
+            ::sdfg::stdlib::add_memcpy_block(
+                builder_,
+                this->insertion_point(),
+                output_container,
+                copy_container,
+                byte_count,
+                src_type, // original had dst_type as well. but memcpy needs both same and we do not model read-only
+                deb_info
+            );
+        }
     }
 
     this->tensor_info_map_.insert({copy_container, tensor_info});


### PR DESCRIPTION
instead of generating them once and adding a memcpy. This saves on allocation and allows for more aggressive map fusion