### PR TITLE
Fix PyTorch attention & replication padding

### DIFF
--- a/llvm/integration/.gitignore
+++ b/llvm/integration/.gitignore
@@ -1,3 +1,4 @@
 llvm-test-suite/
 __pycache__
 *.log
+pytestOut/

--- a/mlir/include/mlir/Target/SDFG/SDFGTranslator.h
+++ b/mlir/include/mlir/Target/SDFG/SDFGTranslator.h
@@ -42,6 +42,9 @@ public:
     /// Create TensorInfo from a tensor type (assumes C-order contiguous).
     static TensorInfo from_tensor_type(TensorType type);
 
+    /// Returns true iff the tensor has basic C-order contiguous strides.
+    static bool has_basic_strides(ArrayRef<int64_t> shape, ArrayRef<int64_t> strides);
+
     /// Create transposed view: output_strides[i] = input_strides[perm[i]].
     TensorInfo transpose(ArrayRef<int64_t> permutation) const;
 
@@ -54,6 +57,9 @@ public:
     /// Returns true iff the tensor has basic C-order contiguous strides.
     bool has_basic_strides() const;
 
+    /// Returns true iff the tensor is transposed in the last two dimensions.
+    bool has_transposed_strides_last_two_dims() const;
+
     /// Create reshaped view (only valid for contiguous tensors).
     TensorInfo reshape(ArrayRef<int64_t> new_shape) const;
 
@@ -62,6 +68,9 @@ public:
 
     /// Create SDFG tensor type
     std::unique_ptr<::sdfg::types::Tensor> get_sdfg_tensor(const ::sdfg::types::Scalar& element_type) const;
+
+    /// Create SDFG tensor layout
+    ::sdfg::math::tensor::TensorLayout get_tensor_layout() const;
 
     /// Return string representation of tensor info (for debug purposes)
     std::string toStr() const;

--- a/mlir/integration/torch/test_attention.py
+++ b/mlir/integration/torch/test_attention.py
@@ -5,11 +5,9 @@ import torch.nn as nn
 
 from integration.torch.check import check_backend, check_compile
 
-
 # --- Self-attention: 8 heads, dim 64 ---
 
 
-@pytest.mark.skip(reason="requires tensor.extract_slice")
 def test_self_attention_compile():
     class SelfAttn8h64dCompile(nn.Module):
         def __init__(self):
@@ -25,7 +23,6 @@ def test_self_attention_compile():
     check_compile(SelfAttn8h64dCompile().eval(), torch.randn(2, 16, 64))
 
 
-@pytest.mark.skip(reason="requires tensor.extract_slice")
 def test_self_attention_backend():
     class SelfAttn8h64dBackend(nn.Module):
         def __init__(self):
@@ -44,7 +41,6 @@ def test_self_attention_backend():
 # --- Self-attention: 4 heads, dim 128 ---
 
 
-@pytest.mark.skip(reason="requires tensor.extract_slice")
 def test_self_attention_4h128d_compile():
     class SelfAttn4h128dCompile(nn.Module):
         def __init__(self):
@@ -60,7 +56,6 @@ def test_self_attention_4h128d_compile():
     check_compile(SelfAttn4h128dCompile().eval(), torch.randn(2, 32, 128))
 
 
-@pytest.mark.skip(reason="requires tensor.extract_slice")
 def test_self_attention_4h128d_backend():
     class SelfAttn4h128dBackend(nn.Module):
         def __init__(self):
@@ -79,7 +74,6 @@ def test_self_attention_4h128d_backend():
 # --- Self-attention: 1 head (degenerate) ---
 
 
-@pytest.mark.skip(reason="requires tensor.extract_slice")
 def test_self_attention_1head_compile():
     class SelfAttn1hCompile(nn.Module):
         def __init__(self):
@@ -95,7 +89,6 @@ def test_self_attention_1head_compile():
     check_compile(SelfAttn1hCompile().eval(), torch.randn(4, 8, 32))
 
 
-@pytest.mark.skip(reason="requires tensor.extract_slice")
 def test_self_attention_1head_backend():
     class SelfAttn1hBackend(nn.Module):
         def __init__(self):
@@ -114,7 +107,6 @@ def test_self_attention_1head_backend():
 # --- Self-attention: 16 heads, dim 256 ---
 
 
-@pytest.mark.skip(reason="requires tensor.extract_slice")
 def test_self_attention_16h256d_compile():
     class SelfAttn16h256dCompile(nn.Module):
         def __init__(self):
@@ -130,7 +122,6 @@ def test_self_attention_16h256d_compile():
     check_compile(SelfAttn16h256dCompile().eval(), torch.randn(1, 16, 256))
 
 
-@pytest.mark.skip(reason="requires tensor.extract_slice")
 def test_self_attention_16h256d_backend():
     class SelfAttn16h256dBackend(nn.Module):
         def __init__(self):
@@ -149,7 +140,6 @@ def test_self_attention_16h256d_backend():
 # --- Self-attention: batch_first=False ---
 
 
-@pytest.mark.skip(reason="requires tensor.extract_slice")
 def test_self_attention_seq_first_compile():
     class SelfAttnSeqFirstCompile(nn.Module):
         def __init__(self):
@@ -166,7 +156,6 @@ def test_self_attention_seq_first_compile():
     check_compile(SelfAttnSeqFirstCompile().eval(), torch.randn(16, 2, 64))
 
 
-@pytest.mark.skip(reason="requires tensor.extract_slice")
 def test_self_attention_seq_first_backend():
     class SelfAttnSeqFirstBackend(nn.Module):
         def __init__(self):
@@ -185,7 +174,6 @@ def test_self_attention_seq_first_backend():
 # --- Cross-attention ---
 
 
-@pytest.mark.skip(reason="requires tensor.extract_slice")
 def test_cross_attention_compile():
     class CrossAttn8h64dCompile(nn.Module):
         def __init__(self):
@@ -203,7 +191,6 @@ def test_cross_attention_compile():
     )
 
 
-@pytest.mark.skip(reason="requires tensor.extract_slice")
 def test_cross_attention_backend():
     class CrossAttn8h64dBackend(nn.Module):
         def __init__(self):
@@ -221,7 +208,6 @@ def test_cross_attention_backend():
     )
 
 
-@pytest.mark.skip(reason="requires tensor.extract_slice")
 def test_cross_attention_large_compile():
     class CrossAttn4h128dCompile(nn.Module):
         def __init__(self):
@@ -239,7 +225,6 @@ def test_cross_attention_large_compile():
     )
 
 
-@pytest.mark.skip(reason="requires tensor.extract_slice")
 def test_cross_attention_large_backend():
     class CrossAttn4h128dBackend(nn.Module):
         def __init__(self):

--- a/mlir/integration/torch/test_matmul.py
+++ b/mlir/integration/torch/test_matmul.py
@@ -3,7 +3,6 @@ import torch.nn as nn
 
 from integration.torch.check import check_backend, check_compile
 
-
 # --- Self matmul (x @ x) ---
 
 
@@ -203,6 +202,41 @@ def test_batched_matmul_backend():
 
     weight = torch.randn(4, 10, 5)
     check_backend(BatchedMatmulNet(weight).eval(), torch.randn(4, 8, 10), rtol=1e-4)
+
+
+# --- Batched matmul with explicit transpose (3D) ---
+
+
+def test_batched_matmul_explicit_transpose_compile():
+    class BatchedMatmulExplicitTransposeNet(nn.Module):
+        def __init__(self, weight: torch.Tensor):
+            super().__init__()
+            self.W = nn.Parameter(weight)
+
+        def forward(self, x: torch.Tensor):
+            transposed = torch.transpose(x, 0, 1)
+            return torch.matmul(transposed, self.W)
+
+    weight = torch.randn(4, 10, 5)
+    check_compile(
+        BatchedMatmulExplicitTransposeNet(weight).eval(), torch.randn(8, 4, 10)
+    )
+
+
+def test_batched_matmul_explicit_transpose_backend():
+    class BatchedMatmulExplicitTransposeNet(nn.Module):
+        def __init__(self, weight: torch.Tensor):
+            super().__init__()
+            self.W = nn.Parameter(weight)
+
+        def forward(self, x: torch.Tensor):
+            transposed = torch.transpose(x, 0, 1)
+            return torch.matmul(transposed, self.W)
+
+    weight = torch.randn(4, 10, 5)
+    check_backend(
+        BatchedMatmulExplicitTransposeNet(weight).eval(), torch.randn(8, 4, 10)
+    )
 
 
 # --- Chained matmul (x @ W1 @ W2) ---

--- a/mlir/integration/torch/test_padding.py
+++ b/mlir/integration/torch/test_padding.py
@@ -6,131 +6,166 @@ import torch.nn as nn
 from integration.torch.check import check_backend
 
 
-@pytest.mark.skip("Requires tensor.extract_slice")
+@pytest.mark.skip("Unsupported by torch-mlir")
 def test_reflection_pad_1d():
     class ReflectionPad1dNet(nn.Module):
         def __init__(self):
             super().__init__()
             self.pad = nn.ReflectionPad1d((3, 1))
+
         def forward(self, x: torch.Tensor):
             return self.pad(x)
 
-    check_backend(ReflectionPad1dNet().eval(), torch.arange(8, dtype=torch.float).reshape(1, 2, 4))
+    check_backend(
+        ReflectionPad1dNet().eval(), torch.arange(8, dtype=torch.float).reshape(1, 2, 4)
+    )
 
-@pytest.mark.skip("Requires tensor.extract_slice")
+
+@pytest.mark.skip("Unsupported by torch-mlir")
 def test_reflection_pad_2d():
     class ReflectionPad2dNet(nn.Module):
         def __init__(self):
             super().__init__()
             self.pad = nn.ReflectionPad2d((1, 1, 2, 0))
+
         def forward(self, x: torch.Tensor):
             return self.pad(x)
 
-    check_backend(ReflectionPad2dNet().eval(), torch.arange(9, dtype=torch.float).reshape(1, 1, 3, 3))
+    check_backend(
+        ReflectionPad2dNet().eval(),
+        torch.arange(9, dtype=torch.float).reshape(1, 1, 3, 3),
+    )
 
-@pytest.mark.skip("Requires tensor.extract_slice")
+
+@pytest.mark.skip("Unsupported by torch-mlir")
 def test_reflection_pad_3d():
     class ReflectionPad3dNet(nn.Module):
         def __init__(self):
             super().__init__()
             self.pad = nn.ReflectionPad3d(1)
+
         def forward(self, x: torch.Tensor):
             return self.pad(x)
 
-    check_backend(ReflectionPad3dNet().eval(), torch.arange(8, dtype=torch.float).reshape(1, 1, 2, 2, 2))
+    check_backend(
+        ReflectionPad3dNet().eval(),
+        torch.arange(8, dtype=torch.float).reshape(1, 1, 2, 2, 2),
+    )
 
-@pytest.mark.skip("Requires tensor.extract_slice")
-def test_replicateion_pad_1d():
+
+def test_replication_pad_1d():
     class ReplicationPad1dNet(nn.Module):
         def __init__(self):
             super().__init__()
             self.pad = nn.ReplicationPad1d((3, 1))
+
         def forward(self, x: torch.Tensor):
             return self.pad(x)
 
-    check_backend(ReplicationPad1dNet().eval(), torch.arange(8, dtype=torch.float).reshape(1, 2, 4))
+    check_backend(
+        ReplicationPad1dNet().eval(),
+        torch.arange(8, dtype=torch.float).reshape(1, 2, 4),
+    )
 
-@pytest.mark.skip("Requires tensor.extract_slice")
-def test_replicateion_pad_2d():
+
+def test_replication_pad_2d():
     class ReplicationPad2dNet(nn.Module):
         def __init__(self):
             super().__init__()
             self.pad = nn.ReplicationPad2d((1, 1, 2, 0))
+
         def forward(self, x: torch.Tensor):
             return self.pad(x)
 
-    check_backend(ReplicationPad2dNet().eval(), torch.arange(9, dtype=torch.float).reshape(1, 1, 3, 3))
+    check_backend(
+        ReplicationPad2dNet().eval(),
+        torch.arange(9, dtype=torch.float).reshape(1, 1, 3, 3),
+    )
 
-@pytest.mark.skip("Requires tensor.extract_slice")
-def test_replicateion_pad_3d():
+
+def test_replication_pad_3d():
     class ReplicationPad3dNet(nn.Module):
         def __init__(self):
             super().__init__()
             self.pad = nn.ReplicationPad3d((3, 3, 6, 6, 1, 1))
+
         def forward(self, x: torch.Tensor):
             return self.pad(x)
 
     check_backend(ReplicationPad3dNet().eval(), torch.randn(16, 3, 8, 320, 480))
+
 
 def test_zero_pad_1d():
     class ZeroPad1dNet(nn.Module):
         def __init__(self):
             super().__init__()
             self.pad = nn.ZeroPad1d((3, 1))
+
         def forward(self, x: torch.Tensor):
             return self.pad(x)
 
     check_backend(ZeroPad1dNet().eval(), torch.randn(1, 2, 4))
+
 
 def test_zero_pad_2d():
     class ZeroPad2dNet(nn.Module):
         def __init__(self):
             super().__init__()
             self.pad = nn.ZeroPad2d((1, 1, 2, 0))
+
         def forward(self, x: torch.Tensor):
             return self.pad(x)
-    
+
     check_backend(ZeroPad2dNet().eval(), torch.randn(1, 1, 3, 3))
+
 
 def test_zero_pad_3d():
     class ZeroPad3dNet(nn.Module):
         def __init__(self):
             super().__init__()
             self.pad = nn.ZeroPad3d((3, 3, 6, 6, 0, 1))
+
         def forward(self, x: torch.Tensor):
             return self.pad(x)
-    
+
     check_backend(ZeroPad3dNet().eval(), torch.randn(16, 3, 10, 20, 30))
+
 
 def test_constant_pad_1d():
     class ConstantPad1dNet(nn.Module):
         def __init__(self):
             super().__init__()
             self.pad = nn.ConstantPad1d((3, 1), 3.5)
+
         def forward(self, x: torch.Tensor):
             return self.pad(x)
 
     check_backend(ConstantPad1dNet().eval(), torch.randn(1, 2, 4))
+
 
 def test_constant_pad_2d():
     class ConstantPad2dNet(nn.Module):
         def __init__(self):
             super().__init__()
             self.pad = nn.ConstantPad2d((3, 0, 2, 1), 3.5)
+
         def forward(self, x: torch.Tensor):
             return self.pad(x)
-    
+
     check_backend(ConstantPad2dNet().eval(), torch.randn(1, 2, 2))
+
 
 def test_constant_pad_3d():
     class ConstantPad3dNet(nn.Module):
         def __init__(self):
             super().__init__()
             self.pad = nn.ConstantPad3d((3, 3, 6, 6, 0, 1), 3.5)
+
         def forward(self, x: torch.Tensor):
             return self.pad(x)
-    
+
     check_backend(ConstantPad3dNet().eval(), torch.randn(16, 3, 10, 20, 30))
+
 
 # @pytest.mark.skip("Unsupported by torch-mlir")
 # def test_circular_pad_1d():

--- a/mlir/lib/Target/SDFG/LinalgToSDFGTranslator.cpp
+++ b/mlir/lib/Target/SDFG/LinalgToSDFGTranslator.cpp
@@ -1082,95 +1082,89 @@ LogicalResult translateLinalgMatmulOp(SDFGTranslator& translator, linalg::Matmul
     return success();
 }
 
-LogicalResult translateLinalgBatchMatmulOp(SDFGTranslator& translator, linalg::BatchMatmulOp* op) {
-    auto& sequence = translator.insertion_point();
-
-    auto output = op->getOutputs()[0];
-    auto result = op->getResult(0);
-    auto deb_info = translator.get_debug_info(op->getOperationName(), op->getLoc());
+LogicalResult translateLinalgBatchMatmulOp(SDFGTranslator& translator, linalg::BatchMatmulOp* batch_matmul_op) {
+    Value lhs = batch_matmul_op->getInputs()[0];
+    Value rhs = batch_matmul_op->getInputs()[1];
+    Value output = batch_matmul_op->getOutputs()[0];
+    Value result = batch_matmul_op->getResults()[0];
+    auto deb_info = translator.get_debug_info(batch_matmul_op->getOperationName(), batch_matmul_op->getLoc());
 
     // The batch matmul fully overwrites its output (beta=0), so the init copy is dead.
+    auto lhs_container = translator.get_or_create_container(lhs);
+    auto rhs_container = translator.get_or_create_container(rhs);
     auto output_container =
         translator.get_or_copy_output_container(output, deb_info, /*consumer_overwrites_output=*/true);
     auto result_container = translator.get_or_create_container(result);
 
+    // Handle LHS tensor info
+    auto lhs_type = llvm::dyn_cast_or_null<TensorType>(lhs.getType());
+    if (!lhs_type || lhs_type.getRank() != 3) {
+        return batch_matmul_op->emitOpError("lhs only supports 3D tensors for now");
+    }
+    auto& lhs_tensor_info = translator.get_or_create_tensor_info(lhs_container, lhs_type);
+    if (lhs_tensor_info.offset() != 0) {
+        return batch_matmul_op->emitOpError("lhs only supports zero offset for now");
+    }
+    auto lhs_element_type = translator.convertType(lhs_type.getElementType());
+    if (!lhs_tensor_info.has_basic_strides() && !lhs_tensor_info.has_transposed_strides_last_two_dims()) {
+        // Only basic strides or transposed in the last two dimensions are supported
+        lhs_container = translator.store_in_c_order(
+            lhs_container, lhs_tensor_info, static_cast<::sdfg::types::Scalar&>(*lhs_element_type), deb_info
+        );
+        lhs_tensor_info = translator.get_or_create_tensor_info(lhs_container, lhs_type);
+        lhs_element_type = translator.convertType(lhs_type.getElementType());
+    }
+    auto lhs_sdfg_tensor = lhs_tensor_info.get_sdfg_tensor(static_cast<::sdfg::types::Scalar&>(*lhs_element_type));
+
+    // Handle RHS tensor info
+    auto rhs_type = llvm::dyn_cast_or_null<TensorType>(rhs.getType());
+    if (!rhs_type || rhs_type.getRank() != 3) {
+        return batch_matmul_op->emitOpError("rhs only supports 3D tensors for now");
+    }
+    auto& rhs_tensor_info = translator.get_or_create_tensor_info(rhs_container, rhs_type);
+    if (rhs_tensor_info.offset() != 0) {
+        return batch_matmul_op->emitOpError("rhs only supports zero offset for now");
+    }
+    auto rhs_element_type = translator.convertType(rhs_type.getElementType());
+    if (!rhs_tensor_info.has_basic_strides() && !rhs_tensor_info.has_transposed_strides_last_two_dims()) {
+        // Only basic strides or transposed in the last two dimensions are supported
+        rhs_container = translator.store_in_c_order(
+            rhs_container, rhs_tensor_info, static_cast<::sdfg::types::Scalar&>(*rhs_element_type), deb_info
+        );
+        rhs_tensor_info = translator.get_or_create_tensor_info(rhs_container, rhs_type);
+        rhs_element_type = translator.convertType(rhs_type.getElementType());
+    }
+    auto rhs_sdfg_tensor = rhs_tensor_info.get_sdfg_tensor(static_cast<::sdfg::types::Scalar&>(*rhs_element_type));
+
+    // Handle result tensor info
+    auto result_type = llvm::dyn_cast_or_null<TensorType>(result.getType());
+    if (!result_type || result_type.getRank() != 3) {
+        return batch_matmul_op->emitOpError("result only supports 3D tensors for now");
+    }
+    auto& result_tensor_info = translator.get_or_create_tensor_info(result_container, result_type);
+    if (result_tensor_info.offset() != 0) {
+        return batch_matmul_op->emitOpError("result only supports zero offset for now");
+    }
+    auto result_element_type = translator.convertType(result_type.getElementType());
+    auto result_sdfg_tensor =
+        result_tensor_info.get_sdfg_tensor(static_cast<::sdfg::types::Scalar&>(*result_element_type));
+
     translator.add_reference(output_container, result_container, deb_info);
 
-    auto lhs_type = dyn_cast_or_null<RankedTensorType>(op->getOperand(0).getType());
-    auto rhs_type = dyn_cast_or_null<RankedTensorType>(op->getOperand(1).getType());
-    auto output_type = dyn_cast_or_null<RankedTensorType>(op->getResult(0).getType());
-    if (!lhs_type || !rhs_type || !output_type || lhs_type.getRank() != 3 || rhs_type.getRank() != 3 ||
-        output_type.getRank() != 3) {
-        return op->emitError("Only 3D batch matmul is supported for now");
-    }
-
-    auto in_container_lhs = translator.get_or_create_container(op->getOperand(0));
-    auto in_container_rhs = translator.get_or_create_container(op->getOperand(1));
-    auto out_container = translator.get_or_create_container(op->getResult(0));
-
     auto& builder = translator.builder();
-    auto& block = builder.add_block(sequence, {}, deb_info);
-
-    ::sdfg::data_flow::AccessNode* lhs_access = &builder.add_access(block, in_container_lhs, deb_info);
-    ::sdfg::data_flow::AccessNode* rhs_access;
-
-    if (in_container_lhs == in_container_rhs) {
-        rhs_access = lhs_access;
-    } else {
-        rhs_access = &builder.add_access(block, in_container_rhs, deb_info);
-    }
-
-    // Get tensor info after possible reordering
-    auto& tensor_info_lhs = translator.get_or_create_tensor_info(in_container_lhs, lhs_type);
-    auto& tensor_info_rhs = translator.get_or_create_tensor_info(in_container_rhs, rhs_type);
-    auto& tensor_info_out = translator.get_or_create_tensor_info(out_container, output_type);
-
-    if (tensor_info_lhs.offset() != 0 || tensor_info_rhs.offset() != 0 || tensor_info_out.offset() != 0) {
-        return op->emitError("Only tensors with 0 offset are supported for now");
-    }
-
-    ::sdfg::symbolic::MultiExpression shape_lhs;
-    for (auto entry : tensor_info_lhs.shape()) {
-        shape_lhs.push_back(::sdfg::symbolic::integer(entry));
-    }
-    ::sdfg::symbolic::MultiExpression shape_rhs;
-    for (auto entry : tensor_info_rhs.shape()) {
-        shape_rhs.push_back(::sdfg::symbolic::integer(entry));
-    }
-    ::sdfg::symbolic::MultiExpression shape_out;
-    for (auto entry : tensor_info_out.shape()) {
-        shape_out.push_back(::sdfg::symbolic::integer(entry));
-    }
-
-    ::sdfg::symbolic::MultiExpression strides_lhs;
-    for (auto entry : tensor_info_lhs.strides()) {
-        strides_lhs.push_back(::sdfg::symbolic::integer(entry));
-    }
-    ::sdfg::symbolic::MultiExpression strides_rhs;
-    for (auto entry : tensor_info_rhs.strides()) {
-        strides_rhs.push_back(::sdfg::symbolic::integer(entry));
-    }
+    auto& block = builder.add_block(translator.insertion_point(), {}, deb_info);
+    auto& lhs_access = builder.add_access(block, lhs_container, deb_info);
+    auto& rhs_access = (lhs_container == rhs_container) ? lhs_access
+                                                        : builder.add_access(block, rhs_container, deb_info);
+    auto& result_access = builder.add_access(block, result_container, deb_info);
 
     auto& libnode = builder.add_library_node<::sdfg::math::tensor::MatMulNode>(
-        block,
-        deb_info,
-        ::sdfg::math::tensor::TensorLayout(shape_lhs, strides_lhs),
-        ::sdfg::math::tensor::TensorLayout(shape_rhs, strides_rhs)
+        block, deb_info, lhs_tensor_info.get_tensor_layout(), rhs_tensor_info.get_tensor_layout()
     );
 
-    auto lhs_primitive_type = translator.convertType(lhs_type)->primitive_type();
-    ::sdfg::types::Tensor lhs_tensor_type(lhs_primitive_type, shape_lhs, strides_lhs);
-    auto rhs_primitive_type = translator.convertType(rhs_type)->primitive_type();
-    ::sdfg::types::Tensor rhs_tensor_type(rhs_primitive_type, shape_rhs, strides_rhs);
-    auto output_primitive_type = translator.convertType(output_type)->primitive_type();
-    ::sdfg::types::Tensor output_tensor_type(output_primitive_type, shape_out);
-
-    builder.add_computational_memlet(block, *lhs_access, libnode, "A", {}, lhs_tensor_type, deb_info);
-    builder.add_computational_memlet(block, *rhs_access, libnode, "B", {}, rhs_tensor_type, deb_info);
-
-    auto& write_access = builder.add_access(block, out_container, deb_info);
-
-    builder.add_computational_memlet(block, write_access, libnode, "Y", {}, output_tensor_type, deb_info);
+    builder.add_computational_memlet(block, lhs_access, libnode, "A", {}, *lhs_sdfg_tensor, deb_info);
+    builder.add_computational_memlet(block, rhs_access, libnode, "B", {}, *rhs_sdfg_tensor, deb_info);
+    builder.add_computational_memlet(block, result_access, libnode, "Y", {}, *result_sdfg_tensor, deb_info);
 
     return success();
 }

--- a/mlir/lib/Target/SDFG/SDFGTranslator.cpp
+++ b/mlir/lib/Target/SDFG/SDFGTranslator.cpp
@@ -75,6 +75,19 @@ TensorInfo TensorInfo::from_tensor_type(TensorType type) {
     return TensorInfo(std::move(shape), std::move(strides), 0);
 }
 
+bool TensorInfo::has_basic_strides(ArrayRef<int64_t> shape, ArrayRef<int64_t> strides) {
+    auto expected_strides = compute_strides(shape);
+    if (expected_strides.size() != strides.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < expected_strides.size(); ++i) {
+        if (expected_strides[i] != strides[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
 TensorInfo TensorInfo::transpose(ArrayRef<int64_t> permutation) const {
     std::vector<int64_t> new_shape;
     std::vector<int64_t> new_strides;
@@ -112,17 +125,24 @@ bool TensorInfo::is_reshape_valid(ArrayRef<int64_t> new_shape) const {
     return has_basic_strides();
 }
 
-bool TensorInfo::has_basic_strides() const {
-    auto expected_strides = compute_strides(shape_);
-    if (expected_strides.size() != strides_.size()) {
+bool TensorInfo::has_basic_strides() const { return has_basic_strides(shape_, strides_); }
+
+bool TensorInfo::has_transposed_strides_last_two_dims() const {
+    auto rank = shape_.size();
+    if (rank < 2) {
         return false;
     }
-    for (size_t i = 0; i < expected_strides.size(); ++i) {
-        if (expected_strides[i] != strides_[i]) {
-            return false;
-        }
+    std::vector<int64_t> new_shape;
+    new_shape.reserve(rank);
+    for (size_t i = 0; i < rank - 2; i++) {
+        new_shape.push_back(shape_[i]);
     }
-    return true;
+    new_shape.push_back(shape_[rank - 1]);
+    new_shape.push_back(shape_[rank - 2]);
+    std::vector<int64_t> transposed_strides(strides_);
+    transposed_strides[rank - 2] = strides_[rank - 1];
+    transposed_strides[rank - 1] = strides_[rank - 2];
+    return has_basic_strides(new_shape, transposed_strides);
 }
 
 TensorInfo TensorInfo::reshape(ArrayRef<int64_t> new_shape) const {
@@ -132,6 +152,10 @@ TensorInfo TensorInfo::reshape(ArrayRef<int64_t> new_shape) const {
 }
 
 std::unique_ptr<::sdfg::types::Tensor> TensorInfo::get_sdfg_tensor(const ::sdfg::types::Scalar& element_type) const {
+    return std::make_unique<::sdfg::types::Tensor>(element_type, get_tensor_layout());
+}
+
+::sdfg::math::tensor::TensorLayout TensorInfo::get_tensor_layout() const {
     ::sdfg::symbolic::MultiExpression shape, strides;
     for (int64_t dim : this->shape_) {
         shape.push_back(::sdfg::symbolic::integer(dim));
@@ -140,7 +164,7 @@ std::unique_ptr<::sdfg::types::Tensor> TensorInfo::get_sdfg_tensor(const ::sdfg:
         strides.push_back(::sdfg::symbolic::integer(stride));
     }
     ::sdfg::symbolic::Expression offset = ::sdfg::symbolic::integer(this->offset_);
-    return std::make_unique<::sdfg::types::Tensor>(element_type, shape, strides, offset);
+    return ::sdfg::math::tensor::TensorLayout(shape, strides, offset);
 }
 
 std::string TensorInfo::shape_str() const {

--- a/mlir/lib/Target/SDFG/TensorToSDFGTranslator.cpp
+++ b/mlir/lib/Target/SDFG/TensorToSDFGTranslator.cpp
@@ -22,6 +22,7 @@
 #include "sdfg/symbolic/symbolic.h"
 #include "sdfg/types/scalar.h"
 #include "sdfg/types/tensor.h"
+#include "sdfg/types/type.h"
 
 namespace mlir {
 namespace sdfg {
@@ -254,6 +255,7 @@ LogicalResult translateTensorInsertSliceOp(SDFGTranslator& translator, tensor::I
     Value source = insert_slice_op->getSource();
     Value dest = insert_slice_op->getDest();
     Value result = insert_slice_op->getResult();
+    auto deb_info = translator.get_debug_info(insert_slice_op->getOperationName(), insert_slice_op->getLoc());
 
     auto source_tensor_type = llvm::dyn_cast<TensorType>(source.getType());
     auto dest_tensor_type = llvm::dyn_cast<TensorType>(dest.getType());
@@ -325,7 +327,8 @@ LogicalResult translateTensorInsertSliceOp(SDFGTranslator& translator, tensor::I
     }
     translator.handle_malloc(
         result_container,
-        ::sdfg::symbolic::mul(::sdfg::symbolic::integer(size), ::sdfg::symbolic::size_of_type(*result_element_type))
+        ::sdfg::symbolic::mul(::sdfg::symbolic::integer(size), ::sdfg::symbolic::size_of_type(*result_element_type)),
+        deb_info
     );
 
     // Step 1: Copy destination to result (full copy)
@@ -350,18 +353,23 @@ LogicalResult translateTensorInsertSliceOp(SDFGTranslator& translator, tensor::I
             condition,
             init,
             update,
-            ::sdfg::structured_control_flow::ScheduleType_Sequential::create()
+            ::sdfg::structured_control_flow::ScheduleType_Sequential::create(),
+            {},
+            deb_info
         );
         current_seq = &map.root();
     }
 
-    auto& dest_block = builder.add_block(*current_seq);
-    auto& dest_access = builder.add_access(dest_block, dest_container);
-    auto& result_access_1 = builder.add_access(dest_block, result_container);
-    auto& dest_tasklet = builder.add_tasklet(dest_block, ::sdfg::data_flow::TaskletCode::assign, "_out", {"_in"});
-    builder.add_computational_memlet(dest_block, dest_access, dest_tasklet, "_in", dest_subset, *dest_sdfg_tensor);
+    auto& dest_block = builder.add_block(*current_seq, {}, deb_info);
+    auto& dest_access = builder.add_access(dest_block, dest_container, deb_info);
+    auto& result_access_1 = builder.add_access(dest_block, result_container, deb_info);
+    auto& dest_tasklet =
+        builder.add_tasklet(dest_block, ::sdfg::data_flow::TaskletCode::assign, "_out", {"_in"}, deb_info);
     builder
-        .add_computational_memlet(dest_block, dest_tasklet, "_out", result_access_1, dest_subset, *result_sdfg_tensor);
+        .add_computational_memlet(dest_block, dest_access, dest_tasklet, "_in", dest_subset, *dest_sdfg_tensor, deb_info);
+    builder.add_computational_memlet(
+        dest_block, dest_tasklet, "_out", result_access_1, dest_subset, *result_sdfg_tensor, deb_info
+    );
 
     // Step 2: Insert source at offset
     current_seq = &translator.insertion_point();
@@ -391,20 +399,137 @@ LogicalResult translateTensorInsertSliceOp(SDFGTranslator& translator, tensor::I
             condition,
             init,
             update,
-            ::sdfg::structured_control_flow::ScheduleType_Sequential::create()
+            ::sdfg::structured_control_flow::ScheduleType_Sequential::create(),
+            {},
+            deb_info
         );
         current_seq = &map.root();
     }
 
-    auto& source_block = builder.add_block(*current_seq);
-    auto& source_access = builder.add_access(source_block, source_container);
-    auto& result_access_2 = builder.add_access(source_block, result_container);
-    auto& source_tasklet = builder.add_tasklet(source_block, ::sdfg::data_flow::TaskletCode::assign, "_out", {"_in"});
-    builder
-        .add_computational_memlet(source_block, source_access, source_tasklet, "_in", source_subset, *source_sdfg_tensor);
+    auto& source_block = builder.add_block(*current_seq, {}, deb_info);
+    auto& source_access = builder.add_access(source_block, source_container, deb_info);
+    auto& result_access_2 = builder.add_access(source_block, result_container, deb_info);
+    auto& source_tasklet =
+        builder.add_tasklet(source_block, ::sdfg::data_flow::TaskletCode::assign, "_out", {"_in"}, deb_info);
     builder.add_computational_memlet(
-        source_block, source_tasklet, "_out", result_access_2, result_offset_subset, *result_sdfg_tensor
+        source_block, source_access, source_tasklet, "_in", source_subset, *source_sdfg_tensor, deb_info
     );
+    builder.add_computational_memlet(
+        source_block, source_tasklet, "_out", result_access_2, result_offset_subset, *result_sdfg_tensor, deb_info
+    );
+
+    return success();
+}
+
+LogicalResult translateTensorExtractSliceOp(SDFGTranslator& translator, tensor::ExtractSliceOp* extract_slice_op) {
+    Value source = extract_slice_op->getSource();
+    Value result = extract_slice_op->getResult();
+    auto deb_info = translator.get_debug_info(extract_slice_op->getOperationName(), extract_slice_op->getLoc());
+
+    auto source_container = translator.get_or_create_container(source);
+    auto result_container = translator.get_or_create_container(result);
+
+    auto source_type = llvm::dyn_cast<TensorType>(source.getType());
+    auto& source_tensor_info = translator.get_or_create_tensor_info(source_container, source_type);
+    auto source_element_type = translator.convertType(source_type.getElementType());
+    auto source_sdfg_tensor =
+        source_tensor_info.get_sdfg_tensor(static_cast<::sdfg::types::Scalar&>(*source_element_type));
+
+    auto result_type = llvm::dyn_cast<TensorType>(result.getType());
+    auto& result_tensor_info = translator.get_or_create_tensor_info(result_container, result_type);
+    auto result_element_type = translator.convertType(result_type.getElementType());
+    auto result_sdfg_tensor =
+        result_tensor_info.get_sdfg_tensor(static_cast<::sdfg::types::Scalar&>(*result_element_type));
+
+    // Get offsets, sizes, and strides
+    SmallVector<OpFoldResult> mixed_offsets = extract_slice_op->getMixedOffsets();
+    SmallVector<OpFoldResult> mixed_sizes = extract_slice_op->getMixedSizes();
+    SmallVector<OpFoldResult> mixed_strides = extract_slice_op->getMixedStrides();
+
+    // Convert to symbolic expressions
+    std::vector<::sdfg::symbolic::Expression> offsets, sizes, strides;
+    offsets.reserve(mixed_offsets.size());
+    sizes.reserve(mixed_sizes.size());
+    strides.reserve(mixed_strides.size());
+
+    for (const auto& offset : mixed_offsets) {
+        if (offset.is<Attribute>()) {
+            auto attr = mlir::cast<IntegerAttr>(offset.get<Attribute>());
+            offsets.push_back(::sdfg::symbolic::integer(attr.getInt()));
+        } else {
+            Value offset_val = offset.get<Value>();
+            offsets.push_back(::sdfg::symbolic::symbol(translator.get_or_create_container(offset_val)));
+        }
+    }
+
+    for (const auto& size : mixed_sizes) {
+        if (size.is<Attribute>()) {
+            auto attr = mlir::cast<IntegerAttr>(size.get<Attribute>());
+            sizes.push_back(::sdfg::symbolic::integer(attr.getInt()));
+        } else {
+            Value size_val = size.get<Value>();
+            sizes.push_back(::sdfg::symbolic::symbol(translator.get_or_create_container(size_val)));
+        }
+    }
+
+    for (const auto& stride : mixed_strides) {
+        if (stride.is<Attribute>()) {
+            auto attr = mlir::cast<IntegerAttr>(stride.get<Attribute>());
+            strides.push_back(::sdfg::symbolic::integer(attr.getInt()));
+        } else {
+            Value stride_val = stride.get<Value>();
+            strides.push_back(::sdfg::symbolic::symbol(translator.get_or_create_container(stride_val)));
+        }
+    }
+
+    translator.handle_malloc(
+        result_container,
+        ::sdfg::symbolic::mul(result_sdfg_tensor->total_elements(), ::sdfg::symbolic::size_of_type(*result_element_type)),
+        deb_info
+    );
+
+    auto& builder = translator.builder();
+    ::sdfg::structured_control_flow::Sequence* current_seq = &translator.insertion_point();
+    ::sdfg::types::Scalar indvar_type(::sdfg::types::PrimitiveType::UInt64);
+
+    int64_t dims = sizes.size();
+    std::vector<::sdfg::symbolic::Symbol> indvars;
+    for (int64_t i = 0; i < dims; i++) {
+        auto indvar_container = builder.find_new_name("_i");
+        builder.add_container(indvar_container, indvar_type);
+        auto indvar = ::sdfg::symbolic::symbol(indvar_container);
+        indvars.push_back(indvar);
+        auto& map = builder.add_map(
+            *current_seq,
+            indvar,
+            ::sdfg::symbolic::Lt(indvar, sizes[i]),
+            ::sdfg::symbolic::zero(),
+            ::sdfg::symbolic::add(indvar, ::sdfg::symbolic::one()),
+            ::sdfg::structured_control_flow::ScheduleType_Sequential::create(),
+            {},
+            deb_info
+        );
+        current_seq = &map.root();
+    }
+
+    ::sdfg::data_flow::Subset source_subset, result_subset;
+    source_subset.reserve(dims);
+    result_subset.reserve(dims);
+    int64_t dropped_dims = dims - result_sdfg_tensor->shape().size();
+    for (int64_t i = 0; i < dims; i++) {
+        source_subset.push_back(::sdfg::symbolic::add(offsets[i], ::sdfg::symbolic::mul(indvars[i], strides[i])));
+        if (i >= dropped_dims) {
+            result_subset.push_back(indvars[i]);
+        }
+    }
+
+    auto& block = builder.add_block(*current_seq, {}, deb_info);
+    auto& source_access = builder.add_access(block, source_container, deb_info);
+    auto& result_access = builder.add_access(block, result_container, deb_info);
+    auto& tasklet = builder.add_tasklet(block, ::sdfg::data_flow::TaskletCode::assign, "_out", {"_in"}, deb_info);
+    builder.add_computational_memlet(block, source_access, tasklet, "_in", source_subset, *source_sdfg_tensor, deb_info);
+    builder
+        .add_computational_memlet(block, tasklet, "_out", result_access, result_subset, *result_sdfg_tensor, deb_info);
 
     return success();
 }
@@ -600,6 +725,9 @@ LogicalResult translateTensorOp(SDFGTranslator& translator, Operation* op) {
         })
         .Case<tensor::InsertSliceOp>([&](tensor::InsertSliceOp insert_slice_op) {
             return translateTensorInsertSliceOp(translator, &insert_slice_op);
+        })
+        .Case<tensor::ExtractSliceOp>([&](tensor::ExtractSliceOp extract_slice_op) {
+            return translateTensorExtractSliceOp(translator, &extract_slice_op);
         })
         .Case<tensor::PadOp>([&](tensor::PadOp pad_op) { return translateTensorPadOp(translator, &pad_op); })
         .Default([&](Operation* op) {

--- a/opt/include/sdfg/passes/map_fusion_by_domain_pass.h
+++ b/opt/include/sdfg/passes/map_fusion_by_domain_pass.h
@@ -66,6 +66,8 @@ struct FusionLoopCandidate {
 
     void non_indvar_writes();
 
+    void aliasing_encountered();
+
     void replace(const symbolic::ExpressionMapping& mapping);
 };
 

--- a/opt/src/passes/map_fusion_by_domain_pass.cpp
+++ b/opt/src/passes/map_fusion_by_domain_pass.cpp
@@ -4,6 +4,7 @@
 #include "sdfg/analysis/base_user_visitor.h"
 #include "sdfg/data_flow/library_nodes/stdlib/malloc.h"
 #include "sdfg/deepcopy/structured_sdfg_deep_copy.h"
+#include "sdfg/structured_sdfg.h"
 #include "sdfg/symbolic/utils.h"
 #include "sdfg/visitor/structured_sdfg_visitor.h"
 #include "sdfg/visualizer/dot_visualizer.h"
@@ -14,6 +15,7 @@ namespace sdfg::passes {
 static const symbolic::Symbol lower_indvar_placeholder = symbolic::symbol("__lower_it");
 
 class LoopIndirectAccessFinder : public analysis::BaseUserVisitor {
+    const StructuredSDFG& sdfg_;
     analysis::LoopAnalysis& loop_analysis_;
     std::unordered_map<analysis::ElementId, std::unique_ptr<FusionLoopCandidate>>& fuse_candidates_;
     struct LoopEntry {
@@ -68,10 +70,11 @@ class LoopIndirectAccessFinder : public analysis::BaseUserVisitor {
 
 public:
     LoopIndirectAccessFinder(
+        const StructuredSDFG& sdfg,
         analysis::LoopAnalysis& loops,
         std::unordered_map<analysis::ElementId, std::unique_ptr<FusionLoopCandidate>>& fuse_candidates
     )
-        : loop_analysis_(loops), fuse_candidates_(fuse_candidates) {}
+        : sdfg_(sdfg), loop_analysis_(loops), fuse_candidates_(fuse_candidates) {}
 
     bool visit(sdfg::structured_control_flow::For& node) override {
         auto cand_it = fuse_candidates_.find(node.element_id());
@@ -189,7 +192,9 @@ public:
         const Block& block
     ) override {
         auto current = get_current_loop();
-        if (current && edge.is_src_pointed_to_read()) {
+        if (current && (edge.is_src_address_leak() || edge.is_src_pointed_to_address_leak(sdfg_.type(container)))) {
+            current->fusion_candidate.aliasing_encountered();
+        } else if (current && edge.is_src_pointed_to_read()) {
             found_indirect_arg_access(container, edge, current, false);
         }
     }
@@ -248,7 +253,7 @@ bool MapFusionByDomainPass::run_pass(builder::StructuredSDFGBuilder& builder, an
         }
     }
 
-    LoopIndirectAccessFinder indirect_access_finder(*state.loop_analysis, state.fuse_candidates);
+    LoopIndirectAccessFinder indirect_access_finder(builder.subject(), *state.loop_analysis, state.fuse_candidates);
     indirect_access_finder.dispatch(builder.subject().root());
 
     const std::string* dir = nullptr;
@@ -386,8 +391,16 @@ PatternHandler::MatchResult MapFusionHandler::match(Map& first, Map& second, boo
     SymEngine::map_basic_basic indvar_mapping;
     int current_level = -1;
     int last_matched_level = -1;
-    auto first_max_stack_depth = state_.loop_analysis->loop_info(&first).map_stack_depth - 1;
-    auto second_max_stack_depth = state_.loop_analysis->loop_info(&second).map_stack_depth - 1;
+    auto first_info = state_.loop_analysis->loop_info(&first);
+    auto second_info = state_.loop_analysis->loop_info(&second);
+
+    // Skip if both have side effects
+    if (first_info.has_side_effects && second_info.has_side_effects) {
+        return {};
+    }
+
+    auto first_max_stack_depth = first_info.map_stack_depth - 1;
+    auto second_max_stack_depth = second_info.map_stack_depth - 1;
     bool more_first = true;
     bool more_second = true;
     bool fusing_option = true;
@@ -467,9 +480,9 @@ bool MapFusionHandler::
 
 bool MapFusionHandler::
     loop_match(FusionLoopCandidate& first, FusionLoopCandidate& second, SymEngine::map_basic_basic& canonical_indvars) {
-    // if (first.incompatible || second.incompatible) {
-    //     return false;
-    // }
+    if (first.incompatible || second.incompatible) {
+        return false;
+    }
 
     bool lower_match =
         symbolic::eq(first.indvar_boundaries->tight_lower_bound(), second.indvar_boundaries->tight_lower_bound());
@@ -602,6 +615,8 @@ void MapFusionHandler::update_fused_seq(Sequence& sequence, const symbolic::Expr
 bool FusionArg::saw_access_locally() const { return not_understood || subset.has_value(); }
 
 void FusionLoopCandidate::non_indvar_writes() { this->incompatible = true; }
+
+void FusionLoopCandidate::aliasing_encountered() { this->incompatible = true; }
 
 void FusionLoopCandidate::replace(const symbolic::ExpressionMapping& mapping) {
     for (auto& [name, arg] : args) {

--- a/sdfg/include/sdfg/codegen/code_snippet_factory.h
+++ b/sdfg/include/sdfg/codegen/code_snippet_factory.h
@@ -1,6 +1,8 @@
 #pragma once
+#include <optional>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 #include "utils.h"
 


### PR DESCRIPTION
- Implemented translation of MLIR op tensor.extract_slice to SDFG
- Fixed handling of transposed inputs for batched matmul's
- Fixed MapFusionByDomainPass to not fuse maps with leaked pointers inside
- Fixed MapFusionByDomainPass to not fuse maps with side effects in both maps
- Enabled attention and refplication padding integration tests