### PR TITLE
Add stack buffer out of kernel check to local storage

### DIFF
--- a/opt/src/transformations/in_local_storage.cpp
+++ b/opt/src/transformations/in_local_storage.cpp
@@ -202,6 +202,18 @@ bool InLocalStorage::can_be_applied(builder::StructuredSDFGBuilder& builder, ana
             return false;
         }
     } else {
+        // CPU_Stack must not be applied when the loop itself is a
+        // GPU-scheduled outermost map. In that case the init/writeback copies
+        // would be placed on the host while the compute runs on the device.
+        if (auto* self_map = dynamic_cast<structured_control_flow::Map*>(&loop_)) {
+            if (gpu::is_gpu_schedule(self_map->schedule_type())) {
+                auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();
+                if (loop_analysis.is_outermost_loop(&this->loop_)) {
+                    return false;
+                }
+            }
+        }
+
         // CPU_Stack inside a GPU region is only valid for per-thread locals
         // (all GPU map indvars appear in the tile bases). If there is a
         // cooperative dimension (a GPU indvar NOT in the bases), the buffer

--- a/opt/src/transformations/out_local_storage.cpp
+++ b/opt/src/transformations/out_local_storage.cpp
@@ -192,6 +192,18 @@ bool OutLocalStorage::can_be_applied(builder::StructuredSDFGBuilder& builder, an
             }
         }
 
+        // CPU_Stack must not be applied when the loop itself is a
+        // GPU-scheduled outermost map. In that case the init/writeback copies
+        // would be placed on the host while the compute runs on the device.
+        if (auto* self_map = dynamic_cast<structured_control_flow::Map*>(&loop_)) {
+            if (gpu::is_gpu_schedule(self_map->schedule_type())) {
+                auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();
+                if (loop_analysis.is_outermost_loop(&this->loop_)) {
+                    return false;
+                }
+            }
+        }
+
         // Criterion: CPU_Stack inside a GPU region is only valid for per-thread
         // locals (all GPU map indvars appear in the tile bases). If there is a
         // cooperative dimension (a GPU indvar NOT in the bases), the buffer must

--- a/opt/tests/transformations/in_local_storage_test.cpp
+++ b/opt/tests/transformations/in_local_storage_test.cpp
@@ -2652,3 +2652,74 @@ TEST(InLocalStorageTest, GPU_CPUStack_InsideGPU_Rejected) {
     transformations::InLocalStorage ils(loop, a_in);
     EXPECT_FALSE(ils.can_be_applied(builder_opt, am));
 }
+
+/**
+ * Test: InLocalStorage with CPU_Stack rejects when applied to the outermost
+ * GPU-scheduled map itself.
+ *
+ * Setup:
+ *   Map X (i, 0..32, CUDA) → For k = 0..4
+ *   C[i] = A[i*4 + k]  (A is read-only)
+ *
+ * The GPU indvar 'i' appears in A's tile bases (per-thread), so there is no
+ * cooperative dimension — the existing cooperative check would NOT reject this.
+ * However, applying CPU_Stack ILS to the outermost CUDA map would place the
+ * copy-in loop outside the kernel on the host, which is invalid.
+ */
+TEST(InLocalStorageTest, GPU_CPUStack_OutermostCUDAMap_Rejected) {
+    builder::StructuredSDFGBuilder builder("ils_cpustack_outermost_cuda", FunctionType_CPU);
+    auto& seq = builder.subject().root();
+
+    types::Scalar loop_var(types::PrimitiveType::Int32);
+    types::Scalar elem(types::PrimitiveType::Float);
+    types::Pointer ptr(elem);
+
+    builder.add_container("A", ptr, true);
+    builder.add_container("C", ptr);
+    builder.add_container("i", loop_var);
+    builder.add_container("k", loop_var);
+
+    // GPU Map X: i = 0..32 (outermost — this is the kernel boundary)
+    auto sched_x = cuda::ScheduleType_CUDA::create();
+    gpu::gpu_block_size(sched_x, symbolic::integer(32));
+    auto& map_x = builder.add_map(
+        seq,
+        symbolic::symbol("i"),
+        symbolic::Lt(symbolic::symbol("i"), symbolic::integer(32)),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("i"), symbolic::integer(1)),
+        sched_x
+    );
+
+    // For loop k = 0..4
+    auto& loop = builder.add_for(
+        map_x.root(),
+        symbolic::symbol("k"),
+        symbolic::Lt(symbolic::symbol("k"), symbolic::integer(4)),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("k"), symbolic::integer(1))
+    );
+
+    // C[i] = A[i*4 + k] — 'i' in A's base → per-thread (no coop dim)
+    auto& block = builder.add_block(loop.root());
+    auto& a_in = builder.add_access(block, "A");
+    auto& c_out = builder.add_access(block, "C");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(
+        block,
+        a_in,
+        tasklet,
+        "_in",
+        {symbolic::add(symbolic::mul(symbolic::symbol("i"), symbolic::integer(4)), symbolic::symbol("k"))},
+        ptr
+    );
+    builder.add_computational_memlet(block, tasklet, "_out", c_out, {symbolic::symbol("i")}, ptr);
+
+    auto structured_sdfg = builder.move();
+    builder::StructuredSDFGBuilder builder_opt(structured_sdfg);
+    analysis::AnalysisManager am(builder_opt.subject());
+
+    // CPU_Stack applied to the outermost CUDA map → must be rejected
+    transformations::InLocalStorage ils(map_x, a_in);
+    EXPECT_FALSE(ils.can_be_applied(builder_opt, am));
+}

--- a/opt/tests/transformations/out_local_storage_test.cpp
+++ b/opt/tests/transformations/out_local_storage_test.cpp
@@ -3053,3 +3053,74 @@ TEST(OutLocalStorageTest, GPU_CPUStack_InsideGPU_Rejected) {
     transformations::OutLocalStorage ols(loop, c_out);
     EXPECT_FALSE(ols.can_be_applied(builder_opt, am));
 }
+
+/**
+ * Test: OutLocalStorage with CPU_Stack rejects when applied to the outermost
+ * GPU-scheduled map itself.
+ *
+ * Setup:
+ *   Map X (i, 0..32, CUDA) → For k = 0..4
+ *   C[i*4 + k] = A[k]
+ *
+ * The GPU indvar 'i' appears in C's tile bases (per-thread), so there is no
+ * cooperative dimension — the existing cooperative check would NOT reject this.
+ * However, applying CPU_Stack OLS to the outermost CUDA map would place the
+ * init/writeback copies outside the kernel on the host, which is invalid.
+ */
+TEST(OutLocalStorageTest, GPU_CPUStack_OutermostCUDAMap_Rejected) {
+    builder::StructuredSDFGBuilder builder("ols_cpustack_outermost_cuda", FunctionType_CPU);
+    auto& seq = builder.subject().root();
+
+    types::Scalar loop_var(types::PrimitiveType::Int32);
+    types::Scalar elem(types::PrimitiveType::Float);
+    types::Pointer ptr(elem);
+
+    builder.add_container("A", ptr, true);
+    builder.add_container("C", ptr);
+    builder.add_container("i", loop_var);
+    builder.add_container("k", loop_var);
+
+    // GPU Map X: i = 0..32 (outermost — this is the kernel boundary)
+    auto sched_x = cuda::ScheduleType_CUDA::create();
+    gpu::gpu_block_size(sched_x, symbolic::integer(32));
+    auto& map_x = builder.add_map(
+        seq,
+        symbolic::symbol("i"),
+        symbolic::Lt(symbolic::symbol("i"), symbolic::integer(32)),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("i"), symbolic::integer(1)),
+        sched_x
+    );
+
+    // For loop k = 0..4
+    auto& loop = builder.add_for(
+        map_x.root(),
+        symbolic::symbol("k"),
+        symbolic::Lt(symbolic::symbol("k"), symbolic::integer(4)),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("k"), symbolic::integer(1))
+    );
+
+    auto& block = builder.add_block(loop.root());
+    auto& a_in = builder.add_access(block, "A");
+    auto& c_out = builder.add_access(block, "C");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(block, a_in, tasklet, "_in", {symbolic::symbol("k")}, ptr);
+    // C[i*4 + k] — base depends on 'i' (GPU indvar), so per-thread (no coop dim)
+    builder.add_computational_memlet(
+        block,
+        tasklet,
+        "_out",
+        c_out,
+        {symbolic::add(symbolic::mul(symbolic::symbol("i"), symbolic::integer(4)), symbolic::symbol("k"))},
+        ptr
+    );
+
+    auto structured_sdfg = builder.move();
+    builder::StructuredSDFGBuilder builder_opt(structured_sdfg);
+    analysis::AnalysisManager am(builder_opt.subject());
+
+    // CPU_Stack applied to the outermost CUDA map → must be rejected
+    transformations::OutLocalStorage ols(map_x, c_out);
+    EXPECT_FALSE(ols.can_be_applied(builder_opt, am));
+}


### PR DESCRIPTION
Adds a check to the local storage transformations to avoids a buffer being created on the stack outside of a GPU kernel, i.e. storage type CPU_STACK and the loop is outermost and has schedule type cuda.

Otherwise, we try to code-gen code for a pointer that is passed to the GPU kernel.