### PR TITLE
Fixed miniAMR2 verifiers

### DIFF
--- a/llvm/integration/apps_openmp_test.py
+++ b/llvm/integration/apps_openmp_test.py
@@ -396,7 +396,7 @@ def test_miniAMR2():
         verification={
             "sdfgs": 48,
             "MAP": 1,
-            "FOR": 22,
+            "FOR": 21,
             "WHILE": 59,
             "CPU_PARALLEL": 1,
         }


### PR DESCRIPTION
One "for" less because the map was counted as a for before and, now, is not anymore.