### PR TITLE
Guard application to for loop in gpu kernel

### DIFF
--- a/opt/src/transformations/in_local_storage.cpp
+++ b/opt/src/transformations/in_local_storage.cpp
@@ -202,24 +202,36 @@ bool InLocalStorage::can_be_applied(builder::StructuredSDFGBuilder& builder, ana
             return false;
         }
     } else {
-        // CPU_Stack must not be applied when the loop itself is a
-        // GPU-scheduled map at the kernel boundary (no GPU-scheduled ancestors).
-        // In that case the init/writeback copies would be placed on the host
-        // while the compute runs on the device.
-        if (auto* self_map = dynamic_cast<structured_control_flow::Map*>(&loop_)) {
-            if (gpu::is_gpu_schedule(self_map->schedule_type())) {
-                auto ancestors = ControlFlowNode::parent_chain(loop_);
-                bool has_gpu_ancestor = false;
-                for (auto* node : ancestors) {
-                    if (auto* ancestor_map = dynamic_cast<structured_control_flow::Map*>(node)) {
-                        if (gpu::is_gpu_schedule(ancestor_map->schedule_type())) {
-                            has_gpu_ancestor = true;
-                            break;
-                        }
-                    }
+        // CPU_Stack must not be applied at or above the GPU kernel boundary.
+        // Check whether the loop is outside any GPU region by looking for
+        // GPU-scheduled ancestors.
+        auto ancestors = ControlFlowNode::parent_chain(loop_);
+        bool has_gpu_ancestor = false;
+        for (auto* node : ancestors) {
+            if (auto* ancestor_map = dynamic_cast<structured_control_flow::Map*>(node)) {
+                if (gpu::is_gpu_schedule(ancestor_map->schedule_type())) {
+                    has_gpu_ancestor = true;
+                    break;
                 }
-                if (!has_gpu_ancestor) {
+            }
+        }
+
+        if (!has_gpu_ancestor) {
+            // The loop is outside any GPU kernel.  Reject if the loop itself
+            // is GPU-scheduled (it IS the kernel boundary) or if its body
+            // contains GPU-scheduled maps (buffer on host, referenced in kernel).
+            if (auto* self_map = dynamic_cast<structured_control_flow::Map*>(&loop_)) {
+                if (gpu::is_gpu_schedule(self_map->schedule_type())) {
                     return false;
+                }
+            }
+
+            auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();
+            for (auto* desc : loop_analysis.descendants(&loop_)) {
+                if (auto* desc_map = dynamic_cast<structured_control_flow::Map*>(desc)) {
+                    if (gpu::is_gpu_schedule(desc_map->schedule_type())) {
+                        return false;
+                    }
                 }
             }
         }
@@ -228,7 +240,6 @@ bool InLocalStorage::can_be_applied(builder::StructuredSDFGBuilder& builder, ana
         // (all GPU map indvars appear in the tile bases). If there is a
         // cooperative dimension (a GPU indvar NOT in the bases), the buffer
         // must be NV_Shared so all threads in the block can see each other's reads.
-        auto ancestors = ControlFlowNode::parent_chain(loop_);
         for (auto* node : ancestors) {
             if (auto* ancestor_map = dynamic_cast<structured_control_flow::Map*>(node)) {
                 if (!gpu::is_gpu_schedule(ancestor_map->schedule_type())) {

--- a/opt/src/transformations/out_local_storage.cpp
+++ b/opt/src/transformations/out_local_storage.cpp
@@ -192,24 +192,36 @@ bool OutLocalStorage::can_be_applied(builder::StructuredSDFGBuilder& builder, an
             }
         }
 
-        // CPU_Stack must not be applied when the loop itself is a
-        // GPU-scheduled map at the kernel boundary (no GPU-scheduled ancestors).
-        // In that case the init/writeback copies would be placed on the host
-        // while the compute runs on the device.
-        if (auto* self_map = dynamic_cast<structured_control_flow::Map*>(&loop_)) {
-            if (gpu::is_gpu_schedule(self_map->schedule_type())) {
-                auto ancestors = ControlFlowNode::parent_chain(loop_);
-                bool has_gpu_ancestor = false;
-                for (auto* node : ancestors) {
-                    if (auto* ancestor_map = dynamic_cast<structured_control_flow::Map*>(node)) {
-                        if (gpu::is_gpu_schedule(ancestor_map->schedule_type())) {
-                            has_gpu_ancestor = true;
-                            break;
-                        }
-                    }
+        // CPU_Stack must not be applied at or above the GPU kernel boundary.
+        // Check whether the loop is outside any GPU region by looking for
+        // GPU-scheduled ancestors.
+        auto ancestors = ControlFlowNode::parent_chain(loop_);
+        bool has_gpu_ancestor = false;
+        for (auto* node : ancestors) {
+            if (auto* ancestor_map = dynamic_cast<structured_control_flow::Map*>(node)) {
+                if (gpu::is_gpu_schedule(ancestor_map->schedule_type())) {
+                    has_gpu_ancestor = true;
+                    break;
                 }
-                if (!has_gpu_ancestor) {
+            }
+        }
+
+        if (!has_gpu_ancestor) {
+            // The loop is outside any GPU kernel.  Reject if the loop itself
+            // is GPU-scheduled (it IS the kernel boundary) or if its body
+            // contains GPU-scheduled maps (buffer on host, referenced in kernel).
+            if (auto* self_map = dynamic_cast<structured_control_flow::Map*>(&loop_)) {
+                if (gpu::is_gpu_schedule(self_map->schedule_type())) {
                     return false;
+                }
+            }
+
+            auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();
+            for (auto* desc : loop_analysis.descendants(&loop_)) {
+                if (auto* desc_map = dynamic_cast<structured_control_flow::Map*>(desc)) {
+                    if (gpu::is_gpu_schedule(desc_map->schedule_type())) {
+                        return false;
+                    }
                 }
             }
         }
@@ -218,7 +230,6 @@ bool OutLocalStorage::can_be_applied(builder::StructuredSDFGBuilder& builder, an
         // locals (all GPU map indvars appear in the tile bases). If there is a
         // cooperative dimension (a GPU indvar NOT in the bases), the buffer must
         // be NV_Shared so all threads in the block can see each other's writes.
-        auto ancestors = ControlFlowNode::parent_chain(loop_);
         for (auto* node : ancestors) {
             if (auto* ancestor_map = dynamic_cast<structured_control_flow::Map*>(node)) {
                 if (!gpu::is_gpu_schedule(ancestor_map->schedule_type())) {

--- a/opt/tests/transformations/in_local_storage_test.cpp
+++ b/opt/tests/transformations/in_local_storage_test.cpp
@@ -2793,3 +2793,63 @@ TEST(InLocalStorageTest, GPU_CPUStack_CUDAMapWrappedByFor_Rejected) {
     transformations::InLocalStorage ils(map_x, a_in);
     EXPECT_FALSE(ils.can_be_applied(builder_opt, am));
 }
+
+// For loop wrapping a CUDA map — CPU_Stack applied to the For loop itself.
+// Buffer would be host-allocated but referenced inside the descendant kernel.
+TEST(InLocalStorageTest, GPU_CPUStack_ForContainingCUDAMap_Rejected) {
+    builder::StructuredSDFGBuilder builder("ils_cpustack_for_contains_cuda", FunctionType_CPU);
+    auto& seq = builder.subject().root();
+
+    types::Scalar loop_var(types::PrimitiveType::Int32);
+    types::Scalar elem(types::PrimitiveType::Float);
+    types::Pointer ptr(elem);
+
+    builder.add_container("A", ptr, true);
+    builder.add_container("C", ptr);
+    builder.add_container("i", loop_var);
+    builder.add_container("k", loop_var);
+
+    // Outer For loop k = 0..4 (regular, not GPU)
+    auto& outer_for = builder.add_for(
+        seq,
+        symbolic::symbol("k"),
+        symbolic::Lt(symbolic::symbol("k"), symbolic::integer(4)),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("k"), symbolic::integer(1))
+    );
+
+    // GPU Map: i = 0..32 (inside the For loop)
+    auto sched_x = cuda::ScheduleType_CUDA::create();
+    gpu::gpu_block_size(sched_x, symbolic::integer(32));
+    auto& map_x = builder.add_map(
+        outer_for.root(),
+        symbolic::symbol("i"),
+        symbolic::Lt(symbolic::symbol("i"), symbolic::integer(32)),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("i"), symbolic::integer(1)),
+        sched_x
+    );
+
+    // A[i*4 + k] read inside GPU map
+    auto& block = builder.add_block(map_x.root());
+    auto& a_in = builder.add_access(block, "A");
+    auto& c_out = builder.add_access(block, "C");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(
+        block,
+        a_in,
+        tasklet,
+        "_in",
+        {symbolic::add(symbolic::mul(symbolic::symbol("i"), symbolic::integer(4)), symbolic::symbol("k"))},
+        ptr
+    );
+    builder.add_computational_memlet(block, tasklet, "_out", c_out, {symbolic::symbol("i")}, ptr);
+
+    auto structured_sdfg = builder.move();
+    builder::StructuredSDFGBuilder builder_opt(structured_sdfg);
+    analysis::AnalysisManager am(builder_opt.subject());
+
+    // CPU_Stack on the For loop that contains a CUDA map — must reject
+    transformations::InLocalStorage ils(outer_for, a_in);
+    EXPECT_FALSE(ils.can_be_applied(builder_opt, am));
+}

--- a/opt/tests/transformations/out_local_storage_test.cpp
+++ b/opt/tests/transformations/out_local_storage_test.cpp
@@ -3193,3 +3193,63 @@ TEST(OutLocalStorageTest, GPU_CPUStack_CUDAMapWrappedByFor_Rejected) {
     transformations::OutLocalStorage ols(map_x, c_out);
     EXPECT_FALSE(ols.can_be_applied(builder_opt, am));
 }
+
+// For loop wrapping a CUDA map — CPU_Stack applied to the For loop itself.
+// Buffer would be host-allocated but referenced inside the descendant kernel.
+TEST(OutLocalStorageTest, GPU_CPUStack_ForContainingCUDAMap_Rejected) {
+    builder::StructuredSDFGBuilder builder("ols_cpustack_for_contains_cuda", FunctionType_CPU);
+    auto& seq = builder.subject().root();
+
+    types::Scalar loop_var(types::PrimitiveType::Int32);
+    types::Scalar elem(types::PrimitiveType::Float);
+    types::Pointer ptr(elem);
+
+    builder.add_container("A", ptr, true);
+    builder.add_container("C", ptr);
+    builder.add_container("i", loop_var);
+    builder.add_container("k", loop_var);
+
+    // Outer For loop k = 0..4 (regular, not GPU)
+    auto& outer_for = builder.add_for(
+        seq,
+        symbolic::symbol("k"),
+        symbolic::Lt(symbolic::symbol("k"), symbolic::integer(4)),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("k"), symbolic::integer(1))
+    );
+
+    // GPU Map: i = 0..32 (inside the For loop)
+    auto sched_x = cuda::ScheduleType_CUDA::create();
+    gpu::gpu_block_size(sched_x, symbolic::integer(32));
+    auto& map_x = builder.add_map(
+        outer_for.root(),
+        symbolic::symbol("i"),
+        symbolic::Lt(symbolic::symbol("i"), symbolic::integer(32)),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("i"), symbolic::integer(1)),
+        sched_x
+    );
+
+    // C[i*4 + k] write inside GPU map
+    auto& block = builder.add_block(map_x.root());
+    auto& a_in = builder.add_access(block, "A");
+    auto& c_out = builder.add_access(block, "C");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(block, a_in, tasklet, "_in", {symbolic::symbol("k")}, ptr);
+    builder.add_computational_memlet(
+        block,
+        tasklet,
+        "_out",
+        c_out,
+        {symbolic::add(symbolic::mul(symbolic::symbol("i"), symbolic::integer(4)), symbolic::symbol("k"))},
+        ptr
+    );
+
+    auto structured_sdfg = builder.move();
+    builder::StructuredSDFGBuilder builder_opt(structured_sdfg);
+    analysis::AnalysisManager am(builder_opt.subject());
+
+    // CPU_Stack on the For loop that contains a CUDA map — must reject
+    transformations::OutLocalStorage ols(outer_for, c_out);
+    EXPECT_FALSE(ols.can_be_applied(builder_opt, am));
+}


### PR DESCRIPTION
Goards stack buffer creation for for loops within GPU kernels.

So far, the first check was if a loop is a map. But applying  Local storage with storage type CPU_Stack with cooperative dimensions on a for loop within a kernel is also not valid. 