### PR TITLE
Fix missing functions for CallNode in LLVM frontend

### DIFF
--- a/llvm/integration/llvm_test_suite.py
+++ b/llvm/integration/llvm_test_suite.py
@@ -136,19 +136,19 @@ def setup():
     [
         pytest.param("MultiSource/Applications/aha", "aha", "YES", "PASS"),
         pytest.param(
-            "MultiSource/Applications/ALAC/decode", "alacconvert-decode", "SEGFAULT", ""
+            "MultiSource/Applications/ALAC/decode", "alacconvert-decode", "YES", "FAIL"
         ),
         pytest.param(
-            "MultiSource/Applications/ALAC/encode", "alacconvert-encode", "SEGFAULT", ""
+            "MultiSource/Applications/ALAC/encode", "alacconvert-encode", "YES", "FAIL"
         ),
         pytest.param("MultiSource/Applications/ClamAV", "clamscan", "YES", "FAIL"),
         pytest.param("MultiSource/Applications/d", "make_dparser", "TIMEOUT", ""),
         pytest.param("MultiSource/Applications/hbd", "hbd", "YES", "PASS"),
-        pytest.param("MultiSource/Applications/hexxagon", "hexxagon", "SEGFAULT", ""),
+        pytest.param("MultiSource/Applications/hexxagon", "hexxagon", "YES", "TIMEOUT"),
         pytest.param("MultiSource/Applications/JM/ldecod", "ldecod", "YES", "FAIL"),
         pytest.param("MultiSource/Applications/JM/lencod", "lencod", "YES", "FAIL"),
         pytest.param("MultiSource/Applications/kimwitu++", "kc", "TIMEOUT", ""),
-        pytest.param("MultiSource/Applications/lambda-0.1.3", "lambda", "SEGFAULT", ""),
+        pytest.param("MultiSource/Applications/lambda-0.1.3", "lambda", "YES", "PASS"),
         pytest.param("MultiSource/Applications/lua", "lua", "SEGFAULT", ""),
         pytest.param("MultiSource/Applications/minisat", "minisat", "YES", "PASS"),
         pytest.param("MultiSource/Applications/obsequi", "Obsequi", "YES", "PASS"),
@@ -160,7 +160,7 @@ def setup():
         pytest.param("MultiSource/Applications/spiff", "spiff", "SEGFAULT", ""),
         pytest.param("MultiSource/Applications/sqlite3", "sqlite3", "TIMEOUT", ""),
         pytest.param("MultiSource/Applications/viterbi", "viterbi", "YES", "PASS"),
-        pytest.param("MultiSource/Benchmarks/7zip", "7zip-benchmark", "SEGFAULT", ""),
+        pytest.param("MultiSource/Benchmarks/7zip", "7zip-benchmark", "TIMEOUT", ""),
         pytest.param(
             "MultiSource/Benchmarks/ASC_Sequoia/AMGmk", "AMGmk", "YES", "PASS"
         ),

--- a/llvm/src/lifting/functions/function_lifting.cpp
+++ b/llvm/src/lifting/functions/function_lifting.cpp
@@ -4,6 +4,7 @@
 #include "docc/lifting/functions/intrinsic_lifting.h"
 #include "docc/lifting/functions/libfunc_lifting.h"
 
+#include <llvm-19/llvm/IR/DebugInfoMetadata.h>
 #include <sdfg/data_flow/library_nodes/call_node.h>
 #include <sdfg/data_flow/library_nodes/invoke_node.h>
 
@@ -134,7 +135,30 @@ sdfg::control_flow::State& FunctionLifting::visit_call(
     if (called_func) {
         callee_name = called_func->getName().str();
     } else if (instruction->getCalledOperand()) {
-        callee_name = utils::get_name(instruction->getCalledOperand());
+        llvm::Value* called_operand = instruction->getCalledOperand()->stripPointerCasts();
+        llvm::FunctionType* callee_llvm_type = instruction->getFunctionType();
+        if (auto* global_alias = llvm::dyn_cast<llvm::GlobalAlias>(called_operand)) {
+            if (auto* called_operand_func = llvm::dyn_cast<llvm::Function>(global_alias->getAliaseeObject())) {
+                // This is not 100% safe but a good heuristic for now: Only replace the aliased function with its
+                // aliasee if the function is guaranteed to never throw an exception.
+                if (called_operand_func->getAttributes().getFnAttrs().hasAttribute(llvm::Attribute::AttrKind::NoUnwind
+                    )) {
+                    called_operand = global_alias->getAliaseeObject();
+                    callee_llvm_type = called_operand_func->getFunctionType();
+                }
+            }
+        }
+        callee_name = utils::get_name(called_operand);
+        if (!this->builder_.subject().exists(callee_name)) {
+            auto callee_type = utils::get_type(
+                this->builder_,
+                this->anonymous_types_mapping_,
+                this->DL_,
+                callee_llvm_type,
+                utils::get_storage_type(this->target_type_, 0)
+            );
+            this->builder_.add_container(callee_name, *callee_type, false, true);
+        }
     } else {
         throw NotImplementedException(
             "Unsupported call instruction with no function or operand",

--- a/llvm/tests/lifting/function_lifting_test.cpp
+++ b/llvm/tests/lifting/function_lifting_test.cpp
@@ -8,7 +8,7 @@
 
 using namespace docc;
 
-TEST(FunctionListingTest, VisitCall) {
+TEST(FunctionLiftingTest, VisitCall) {
     const std::string ir = R"(
 ; ModuleID = 'test'
 source_filename = "test.ll"
@@ -76,7 +76,7 @@ entry:
     EXPECT_TRUE(found_call);
 }
 
-TEST(FunctionListingTest, VisitCall_ReadonlyArgs) {
+TEST(FunctionLiftingTest, VisitCall_ReadonlyArgs) {
     const std::string ir = R"(
 ; ModuleID = 'test'
 source_filename = "test.ll"
@@ -154,7 +154,149 @@ entry:
     EXPECT_TRUE(found_call);
 }
 
-TEST(FunctionListingTest, VisitInvoke) {
+TEST(FunctionLiftingTest, VisitCall_alias) {
+    const std::string ir = R"(
+; ModuleID = 'test'
+source_filename = "test.ll"
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare dso_local void @bar1(ptr)
+
+@bar2 = dso_local unnamed_addr alias void (ptr), ptr @bar1
+
+define void @foo(ptr %p) {
+entry:
+  tail call void @bar2(ptr %p)
+  ret void
+}
+)";
+
+    llvm::LLVMContext context;
+    auto module = loadModuleFromIR(ir, context);
+    ASSERT_NE(module, nullptr);
+
+    // Construct the TargetLibraryInfo required by the lifting pass
+    llvm::TargetLibraryInfoImpl TLIImpl(llvm::Triple(module->getTargetTriple()));
+    llvm::TargetLibraryInfo TLI(TLIImpl);
+
+    llvm::Function* function = module->getFunction("foo");
+    ASSERT_NE(function, nullptr);
+
+    // Run the lifting pass
+    lifting::Lifting lifting(TLI, *function, sdfg::FunctionType_CPU);
+    auto sdfg = lifting.run();
+
+    EXPECT_EQ(sdfg->containers().size(), 2);
+    EXPECT_TRUE(sdfg->exists("p"));
+    EXPECT_TRUE(sdfg->exists("bar2"));
+    EXPECT_TRUE(sdfg->is_external("bar2"));
+
+    bool found_call = false;
+    for (auto& state : sdfg->states()) {
+        if (state.dataflow().nodes().size() == 0) {
+            continue;
+        }
+        EXPECT_FALSE(found_call);
+
+        const sdfg::data_flow::CallNode* call_node = nullptr;
+        for (auto& node : state.dataflow().nodes()) {
+            if (auto lib_node = dynamic_cast<const sdfg::data_flow::CallNode*>(&node)) {
+                call_node = lib_node;
+                found_call = true;
+                break;
+            }
+        }
+        EXPECT_NE(call_node, nullptr);
+        EXPECT_EQ(call_node->callee_name(), "bar2");
+
+        EXPECT_EQ(state.dataflow().in_degree(*call_node), 1);
+        EXPECT_EQ(state.dataflow().out_degree(*call_node), 0);
+
+        auto& iedge = *state.dataflow().in_edges(*call_node).begin();
+        EXPECT_EQ(iedge.src_conn(), "void");
+        EXPECT_EQ(iedge.dst_conn(), "_arg0");
+        EXPECT_EQ(iedge.subset().size(), 0);
+        EXPECT_EQ(iedge.base_type(), sdfg::types::Pointer());
+
+        auto& src = static_cast<const sdfg::data_flow::AccessNode&>(iedge.src());
+        EXPECT_EQ(src.data(), "p");
+    }
+    EXPECT_TRUE(found_call);
+}
+
+TEST(FunctionLiftingTest, VisitCall_alias_nounwind) {
+    const std::string ir = R"(
+; ModuleID = 'test'
+source_filename = "test.ll"
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare dso_local void @bar1(ptr) nounwind
+
+@bar2 = dso_local unnamed_addr alias void (ptr), ptr @bar1
+
+define void @foo(ptr %p) {
+entry:
+  tail call void @bar2(ptr %p)
+  ret void
+}
+)";
+
+    llvm::LLVMContext context;
+    auto module = loadModuleFromIR(ir, context);
+    ASSERT_NE(module, nullptr);
+
+    // Construct the TargetLibraryInfo required by the lifting pass
+    llvm::TargetLibraryInfoImpl TLIImpl(llvm::Triple(module->getTargetTriple()));
+    llvm::TargetLibraryInfo TLI(TLIImpl);
+
+    llvm::Function* function = module->getFunction("foo");
+    ASSERT_NE(function, nullptr);
+
+    // Run the lifting pass
+    lifting::Lifting lifting(TLI, *function, sdfg::FunctionType_CPU);
+    auto sdfg = lifting.run();
+
+    EXPECT_EQ(sdfg->containers().size(), 2);
+    EXPECT_TRUE(sdfg->exists("p"));
+    EXPECT_TRUE(sdfg->exists("bar1"));
+    EXPECT_TRUE(sdfg->is_external("bar1"));
+
+    bool found_call = false;
+    for (auto& state : sdfg->states()) {
+        if (state.dataflow().nodes().size() == 0) {
+            continue;
+        }
+        EXPECT_FALSE(found_call);
+
+        const sdfg::data_flow::CallNode* call_node = nullptr;
+        for (auto& node : state.dataflow().nodes()) {
+            if (auto lib_node = dynamic_cast<const sdfg::data_flow::CallNode*>(&node)) {
+                call_node = lib_node;
+                found_call = true;
+                break;
+            }
+        }
+        EXPECT_NE(call_node, nullptr);
+        EXPECT_EQ(call_node->callee_name(), "bar1");
+
+        EXPECT_EQ(state.dataflow().in_degree(*call_node), 1);
+        EXPECT_EQ(state.dataflow().out_degree(*call_node), 0);
+
+        auto& iedge = *state.dataflow().in_edges(*call_node).begin();
+        EXPECT_EQ(iedge.src_conn(), "void");
+        EXPECT_EQ(iedge.dst_conn(), "_arg0");
+        EXPECT_EQ(iedge.subset().size(), 0);
+        EXPECT_EQ(iedge.base_type(), sdfg::types::Pointer());
+
+        auto& src = static_cast<const sdfg::data_flow::AccessNode&>(iedge.src());
+        EXPECT_EQ(src.data(), "p");
+    }
+    EXPECT_TRUE(found_call);
+}
+
+TEST(FunctionLiftingTest, VisitInvoke) {
     const std::string ir = R"(
 ; ModuleID = 'test'
 source_filename = "test.ll"
@@ -246,7 +388,7 @@ declare i32 @__gxx_personality_v0(...)
     EXPECT_TRUE(found_unwind);
 }
 
-TEST(FunctionListingTest, VisitCall_ByVal) {
+TEST(FunctionLiftingTest, VisitCall_ByVal) {
     const std::string ir = R"(
 ; ModuleID = 'test'
 source_filename = "test.ll"


### PR DESCRIPTION
When lifting a LLVM call instruction, the LLVM frontend expects that the function container already exists. This works most of the time because the declarations are handled beforehand. However, function aliases were ignored. Now, the frontend detects function aliases and adds a function container if necessary.

Now, 5 tests from the LLVM test suite compile that previously segfaulted. However, one timeouts during compilation and one timeouts during execution. Two tests fail the execution and one passes.