### PR TITLE
Adds script to locally build the need boost-stacktrace library to LD_PRELOAD

### DIFF
--- a/.github/workflows/unit_tests_linux.yml
+++ b/.github/workflows/unit_tests_linux.yml
@@ -154,7 +154,7 @@ jobs:
         --device /dev/dri
 
     env:
-      DOCC_INFERENCE: "ON" #skips certain tests only when inference enabled. 
+      DOCC_INFERENCE: "ON" #skips certain tests only when inference enabled.
     steps:
       - uses: actions/checkout@v4
         with:
@@ -198,8 +198,6 @@ jobs:
             -DPYTHON_BUILD_FRONTEND=ON \
             -Dpybind11_DIR=$(python -c "import pybind11; print(pybind11.get_cmake_dir())") \
             -DMLIR_BUILD_FRONTEND=ON \
-            -DMLIR_BUILD_BINDINGS=ON \
-            -DMLIR_BUILD_TESTS=ON \
             -DMLIR_DIR=/usr/lib/llvm-19/lib/cmake/mlir \
             -DLLVM_EXTERNAL_LIT=/usr/lib/llvm-19/build/utils/lit/lit.py \
             ..
@@ -364,8 +362,6 @@ jobs:
             -DPYTHON_BUILD_FRONTEND=ON \
             -Dpybind11_DIR=$GITHUB_WORKSPACE/.venv/lib/python${{ matrix.python-version }}/site-packages/pybind11/share/cmake/pybind11 \
             -DMLIR_BUILD_FRONTEND=ON \
-            -DMLIR_BUILD_BINDINGS=ON \
-            -DMLIR_BUILD_TESTS=ON \
             -DMLIR_DIR=/usr/lib/llvm-19/lib/cmake/mlir \
             -DLLVM_EXTERNAL_LIT=/usr/lib/llvm-19/build/utils/lit/lit.py \
             -DINSTALL_GTEST=OFF \
@@ -536,8 +532,6 @@ jobs:
             -DPYTHON_BUILD_FRONTEND=ON \
             -Dpybind11_DIR=$GITHUB_WORKSPACE/.venv/lib/python${{ matrix.python-version }}/site-packages/pybind11/share/cmake/pybind11 \
             -DMLIR_BUILD_FRONTEND=ON \
-            -DMLIR_BUILD_BINDINGS=ON \
-            -DMLIR_BUILD_TESTS=ON \
             -DMLIR_DIR=/usr/lib/llvm-19/lib/cmake/mlir \
             -DLLVM_EXTERNAL_LIT=/usr/lib/llvm-19/build/utils/lit/lit.py \
             -DINSTALL_GTEST=OFF \
@@ -624,8 +618,6 @@ jobs:
             -DPYTHON_BUILD_FRONTEND=ON \
             -Dpybind11_DIR=$GITHUB_WORKSPACE/.venv/lib/python${{ matrix.python-version }}/site-packages/pybind11/share/cmake/pybind11 \
             -DMLIR_BUILD_FRONTEND=ON \
-            -DMLIR_BUILD_BINDINGS=ON \
-            -DMLIR_BUILD_TESTS=ON \
             -DMLIR_DIR=/usr/lib/llvm-19/lib/cmake/mlir \
             -DLLVM_EXTERNAL_LIT=/usr/lib/llvm-19/build/utils/lit/lit.py \
             -DINSTALL_GTEST=OFF \
@@ -703,8 +695,6 @@ jobs:
             -DPYTHON_BUILD_FRONTEND=ON \
             -Dpybind11_DIR=$GITHUB_WORKSPACE/.venv/lib/python${{ matrix.python-version }}/site-packages/pybind11/share/cmake/pybind11 \
             -DMLIR_BUILD_FRONTEND=ON \
-            -DMLIR_BUILD_BINDINGS=ON \
-            -DMLIR_BUILD_TESTS=ON \
             -DMLIR_DIR=/usr/lib/llvm-19/lib/cmake/mlir \
             -DLLVM_EXTERNAL_LIT=/usr/lib/llvm-19/build/utils/lit/lit.py \
             -DINSTALL_GTEST=OFF \

--- a/scripts/build-boost-stacktrace-lib.sh
+++ b/scripts/build-boost-stacktrace-lib.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+curl -O https://github.com/boostorg/boost/releases/download/boost-1.90.0/boost-1.90.0-cmake.tar.xz
+tar -xJf boost-1.90.0-cmake.tar.xz
+cd boost-1.90.0
+
+cmake -B build -DBOOST_STACKTRACE_ENABLE_BACKTRACE=ON -DBOOST_STACKTRACE_ENABLE_FROM_EXCEPTION=ON -DBOOST_STACKTRACE_ENABLE_NOOP=OFF -DBUILD_SHARED_LIBS=ON -G Ninja
+cmake --build build -- libs/stacktrace/all
+
+ls -al build/stage/lib


### PR DESCRIPTION
 * also removes cmake option to explicitly enable MLIR bindings & tests in github workflows, now that it is the default