### PR TITLE
fixed issue where tensors with grad causes runtime error

### DIFF
--- a/python/docc/compiler/compiled_sdfg.py
+++ b/python/docc/compiler/compiled_sdfg.py
@@ -54,11 +54,11 @@ def _is_device_array(arg):
     torch tensor reports its location via ``is_cuda``. Host arrays (numpy, CPU
     torch tensors) return False.
     """
-    if getattr(arg, "__cuda_array_interface__", None) is not None:
-        return True
     is_cuda = getattr(arg, "is_cuda", None)
     if is_cuda is not None:
         return bool(is_cuda)
+    if getattr(arg, "__cuda_array_interface__", None) is not None:
+        return True
     return False
 
 
@@ -68,12 +68,12 @@ def _device_array_ptr(arg):
     Both cupy arrays and CUDA torch tensors expose ``__cuda_array_interface__``;
     torch tensors additionally expose ``data_ptr()``. Returns an integer address.
     """
-    cai = getattr(arg, "__cuda_array_interface__", None)
-    if cai is not None:
-        return cai["data"][0]
     data_ptr = getattr(arg, "data_ptr", None)
     if callable(data_ptr):
         return data_ptr()
+    cai = getattr(arg, "__cuda_array_interface__", None)
+    if cai is not None:
+        return cai["data"][0]
     raise TypeError(
         f"Device-resident execution requires a GPU array exposing "
         f"__cuda_array_interface__ or data_ptr(), got {type(arg).__name__}"
@@ -121,30 +121,28 @@ _GPU_CALL_MODES = frozenset({_CALL_MODE_NUMPY_GPU, _CALL_MODE_TORCH_GPU})
 
 
 def _is_torch_tensor(arg):
-    """Return True if ``arg`` is a torch tensor (without importing torch)."""
-    return type(arg).__module__.split(".", 1)[0] == "torch"
+    """Return True if ``arg`` is a torch tensor or Parameter (without importing torch)."""
+    return any(
+        cls.__module__.startswith("torch") and cls.__name__ in ("Tensor", "Parameter")
+        for cls in type(arg).__mro__
+    )
 
 
 def _classify_array_kind(arg):
-    """Classify a single argument into one of the four call modes.
-
-    Returns one of the ``_CALL_MODE_*`` constants for array arguments, or None
-    for mode-agnostic values (Python/numpy scalars, structures, ...). Neither
-    torch nor cupy is imported: classification relies on the defining module and
-    the array's own attributes.
-    """
-    root = type(arg).__module__.split(".", 1)[0]
-    if root == "torch":
+    """Classify a single argument into one of the four call modes."""
+    if _is_torch_tensor(arg):
         return (
             _CALL_MODE_TORCH_GPU
             if getattr(arg, "is_cuda", False)
             else _CALL_MODE_TORCH_CPU
         )
+    root = type(arg).__module__.split(".", 1)[0]
     if root == "cupy":
         return _CALL_MODE_NUMPY_GPU
     if isinstance(arg, np.ndarray):
         return _CALL_MODE_NUMPY_CPU
     # Any other object exposing the CUDA array interface is a device array.
+
     if getattr(arg, "__cuda_array_interface__", None) is not None:
         return _CALL_MODE_NUMPY_GPU
     return None


### PR DESCRIPTION
Modified is_torch_tensor and classify_array_kind to fix bug where some tensors were getting misclassified and causing unsupported mixed arrays issue. 

Reversed the order of checks for data_ptr and cuda_array_interface to avoid runtime error when tensors contain require_grad=True