### PR TITLE
Add tensor concatenation to PyTorch frontend (and MLIR frontend)

### DIFF
--- a/mlir/lib/Target/SDFG/TensorToSDFGTranslator.cpp
+++ b/mlir/lib/Target/SDFG/TensorToSDFGTranslator.cpp
@@ -2,19 +2,24 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include <llvm/ADT/TypeSwitch.h>
 #include <llvm/Support/Casting.h>
 #include <llvm/Support/LogicalResult.h>
 
-#include <memory>
-#include <string>
-#include <vector>
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Target/SDFG/SDFGTranslator.h"
 #include "mlir/Target/SDFG/helper.h"
+#include "sdfg/data_flow/access_node.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/concat_node.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/tensor_layout.h"
 #include "sdfg/data_flow/memlet.h"
 #include "sdfg/data_flow/tasklet.h"
 #include "sdfg/structured_control_flow/map.h"
@@ -22,7 +27,6 @@
 #include "sdfg/symbolic/symbolic.h"
 #include "sdfg/types/scalar.h"
 #include "sdfg/types/tensor.h"
-#include "sdfg/types/type.h"
 
 namespace mlir {
 namespace sdfg {
@@ -86,10 +90,11 @@ LogicalResult translateTensorCollapseOp(SDFGTranslator& translator, tensor::Coll
 
 LogicalResult translateTensorConcatOp(SDFGTranslator& translator, tensor::ConcatOp* concat_op) {
     OperandRange inputs = concat_op->getInputs();
+    size_t num_inputs = inputs.size();
     std::vector<std::string> inputs_container;
-    inputs_container.reserve(inputs.size());
+    inputs_container.reserve(num_inputs);
     std::vector<std::unique_ptr<::sdfg::types::Tensor>> inputs_sdfg_tensor;
-    inputs_sdfg_tensor.reserve(inputs.size());
+    inputs_sdfg_tensor.reserve(num_inputs);
     for (Value input : inputs) {
         auto input_container = translator.get_or_create_container(input);
         inputs_container.push_back(input_container);
@@ -127,62 +132,38 @@ LogicalResult translateTensorConcatOp(SDFGTranslator& translator, tensor::Concat
         deb_info
     );
 
-    // Create maps
+    // Create concat node
     auto& builder = translator.builder();
-    ::sdfg::structured_control_flow::Sequence* current_seq = &translator.insertion_point();
-    std::vector<std::string> indvars;
-    ::sdfg::data_flow::Subset subset;
-    for (size_t i = 0; i < result_tensor_info.shape().size(); i++) {
-        int64_t dim = result_tensor_info.shape().at(i);
-        auto indvar_container = builder.find_new_name("_i");
-        builder.add_container(indvar_container, ::sdfg::types::Scalar(sdfg_index_type));
-        indvars.push_back(indvar_container);
-        subset.push_back(::sdfg::symbolic::symbol(indvar_container));
-        auto indvar = ::sdfg::symbolic::symbol(indvar_container);
-        auto bound = ::sdfg::symbolic::integer(dim);
-        auto condition = ::sdfg::symbolic::Lt(indvar, bound);
-        auto init = ::sdfg::symbolic::zero();
-        auto update = ::sdfg::symbolic::add(indvar, ::sdfg::symbolic::one());
-
-        auto& map = builder.add_map(
-            *current_seq,
-            indvar,
-            condition,
-            init,
-            update,
-            ::sdfg::structured_control_flow::ScheduleType_Sequential::create(),
-            {},
-            deb_info
-        );
-        current_seq = &map.root();
+    auto& block = builder.add_block(translator.insertion_point(), {}, deb_info);
+    std::vector<::sdfg::data_flow::AccessNode*> input_accesses;
+    input_accesses.reserve(num_inputs);
+    std::unordered_map<std::string, ::sdfg::data_flow::AccessNode*> input_access_map;
+    std::vector<std::string> in_conns;
+    in_conns.reserve(num_inputs);
+    std::vector<::sdfg::math::tensor::TensorLayout> in_layouts;
+    in_layouts.reserve(num_inputs);
+    for (size_t i = 0; i < num_inputs; i++) {
+        auto& input_container = inputs_container[i];
+        if (input_access_map.contains(input_container)) {
+            input_accesses.push_back(input_access_map.at(input_container));
+        } else {
+            auto& input_access = builder.add_access(block, input_container, deb_info);
+            input_accesses.push_back(&input_access);
+            input_access_map.insert({input_container, &input_access});
+        }
+        in_conns.push_back("X" + std::to_string(i));
+        in_layouts.push_back(inputs_sdfg_tensor[i]->layout());
     }
+    auto& result_access = builder.add_access(block, result_container, deb_info);
+    auto& libnode = builder.add_library_node<
+        ::sdfg::math::tensor::ConcatNode>(block, deb_info, "Y", result_sdfg_tensor->layout(), in_conns, in_layouts, dim);
 
-    // Create if/else
-    auto& if_else = builder.add_if_else(*current_seq, {}, deb_info);
-    auto dim_indvar = subset.at(dim);
-
-    // Create conditional copy for every input
-    ::sdfg::symbolic::Expression offset = ::sdfg::symbolic::zero();
-    for (size_t i = 0; i < inputs.size(); i++) {
-        auto new_offset = ::sdfg::symbolic::add(offset, inputs_sdfg_tensor.at(i)->shape().at(dim));
-        auto condition =
-            ::sdfg::symbolic::And(::sdfg::symbolic::Ge(dim_indvar, offset), ::sdfg::symbolic::Lt(dim_indvar, new_offset));
-        auto& sequence = builder.add_case(if_else, condition, deb_info);
-
-        ::sdfg::data_flow::Subset offset_subset(subset);
-        offset_subset[dim] = ::sdfg::symbolic::sub(dim_indvar, offset);
-
-        auto& block = builder.add_block(sequence, {}, deb_info);
-        auto& input_access = builder.add_access(block, inputs_container.at(i), deb_info);
-        auto& result_access = builder.add_access(block, result_container, deb_info);
-        auto& tasklet = builder.add_tasklet(block, ::sdfg::data_flow::TaskletCode::assign, "_out", {"_in"}, deb_info);
+    for (size_t i = 0; i < num_inputs; i++) {
         builder.add_computational_memlet(
-            block, input_access, tasklet, "_in", offset_subset, *inputs_sdfg_tensor.at(i), deb_info
+            block, *input_accesses[i], libnode, in_conns[i], {}, *inputs_sdfg_tensor[i], deb_info
         );
-        builder.add_computational_memlet(block, tasklet, "_out", result_access, subset, *result_sdfg_tensor, deb_info);
-
-        offset = new_offset;
     }
+    builder.add_computational_memlet(block, result_access, libnode, "Y", {}, *result_sdfg_tensor, deb_info);
 
     return success();
 }
@@ -490,7 +471,7 @@ LogicalResult translateTensorExtractSliceOp(SDFGTranslator& translator, tensor::
 
     auto& builder = translator.builder();
     ::sdfg::structured_control_flow::Sequence* current_seq = &translator.insertion_point();
-    ::sdfg::types::Scalar indvar_type(::sdfg::types::PrimitiveType::UInt64);
+    ::sdfg::types::Scalar indvar_type(sdfg_index_type);
 
     int64_t dims = sizes.size();
     std::vector<::sdfg::symbolic::Symbol> indvars;

--- a/opt/CMakeLists.txt
+++ b/opt/CMakeLists.txt
@@ -69,6 +69,7 @@ set(SOURCE_FILES
     src/targets/cuda/cuda_map_dispatcher.cpp
     src/targets/cuda/cuda.cpp
     src/targets/cuda/math/tensor/batched_matmul_expander.cpp
+    src/targets/cuda/math/tensor/concat_expander.cpp
     src/targets/cuda/math/tensor/conv_expander.cpp
     src/targets/cuda/math/tensor/softmax.cpp
     src/targets/cuda/plugin.cpp
@@ -84,6 +85,7 @@ set(SOURCE_FILES
     src/targets/rocm/blas/gemm.cpp
     src/targets/rocm/blas/utils.cpp
     src/targets/rocm/math/tensor/batched_matmul_expander.cpp
+    src/targets/rocm/math/tensor/concat_expander.cpp
     src/targets/rocm/math/tensor/conv_expander.cpp
     src/targets/rocm/plugin.cpp
     src/targets/rocm/rocm_data_offloading_node.cpp

--- a/opt/include/sdfg/targets/cuda/math/tensor/concat_expander.h
+++ b/opt/include/sdfg/targets/cuda/math/tensor/concat_expander.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "sdfg/analysis/analysis.h"
+#include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/data_flow/library_node.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/concat_node.h"
+#include "sdfg/targets/offloading/target_expansion.h"
+
+namespace sdfg {
+namespace offloading {
+
+class CudaConcatExpander : public TargetLibNodeExpander {
+private:
+    math::tensor::ConcatNode& node_;
+
+public:
+    CudaConcatExpander(math::tensor::ConcatNode& library_node)
+        : TargetLibNodeExpander(library_node), node_(library_node) {};
+
+    bool expand(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager);
+
+    static bool expand_concat_separately(
+        builder::StructuredSDFGBuilder& builder,
+        analysis::AnalysisManager& analysis_manager,
+        math::tensor::ConcatNode& node
+    );
+};
+
+} // namespace offloading
+} // namespace sdfg

--- a/opt/include/sdfg/targets/rocm/math/tensor/concat_expander.h
+++ b/opt/include/sdfg/targets/rocm/math/tensor/concat_expander.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "sdfg/analysis/analysis.h"
+#include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/data_flow/library_node.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/concat_node.h"
+#include "sdfg/targets/offloading/target_expansion.h"
+
+namespace sdfg {
+namespace offloading {
+
+class RocmConcatExpander : public TargetLibNodeExpander {
+private:
+    math::tensor::ConcatNode& node_;
+
+public:
+    RocmConcatExpander(math::tensor::ConcatNode& library_node)
+        : TargetLibNodeExpander(library_node), node_(library_node) {};
+
+    bool expand(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager);
+};
+
+} // namespace offloading
+} // namespace sdfg

--- a/opt/src/passes/offloading/cuda_library_node_expansion_pass.cpp
+++ b/opt/src/passes/offloading/cuda_library_node_expansion_pass.cpp
@@ -1,9 +1,12 @@
 #include "sdfg/passes/offloading/cuda_library_node_expansion_pass.h"
+
+#include "sdfg/data_flow/library_nodes/math/tensor/concat_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/conv_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/matmul_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/reduce_ops/softmax_node.h"
 #include "sdfg/targets/cuda/cuda.h"
 #include "sdfg/targets/cuda/math/tensor/batched_matmul_expander.h"
+#include "sdfg/targets/cuda/math/tensor/concat_expander.h"
 #include "sdfg/targets/cuda/math/tensor/conv_expander.h"
 
 namespace sdfg {
@@ -35,6 +38,10 @@ bool CudaExpansion::accept(structured_control_flow::Block& node) {
         } else if (lib_node_code == math::tensor::LibraryNodeType_Softmax) {
             library_node->implementation_type() = cuda::ImplementationType_CUDAWithTransfers;
             made_changes = true;
+        } else if (lib_node_code == math::tensor::LibraryNodeType_TensorConcat) {
+            auto& concat_node = static_cast<math::tensor::ConcatNode&>(*library_node);
+            sdfg::offloading::CudaConcatExpander expander(concat_node);
+            made_changes |= expander.expand(builder_, analysis_manager_);
         } else {
             continue;
         }

--- a/opt/src/passes/offloading/rocm_library_node_expansion_pass.cpp
+++ b/opt/src/passes/offloading/rocm_library_node_expansion_pass.cpp
@@ -1,7 +1,10 @@
 #include "sdfg/passes/offloading/rocm_library_node_expansion_pass.h"
+
+#include "sdfg/data_flow/library_nodes/math/tensor/concat_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/conv_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/matmul_node.h"
 #include "sdfg/targets/rocm/math/tensor/batched_matmul_expander.h"
+#include "sdfg/targets/rocm/math/tensor/concat_expander.h"
 #include "sdfg/targets/rocm/math/tensor/conv_expander.h"
 
 namespace sdfg {
@@ -30,6 +33,10 @@ bool RocmExpansion::accept(structured_control_flow::Block& node) {
         } else if (lib_node_code == math::tensor::LibraryNodeType_MatMul) {
             auto& matmul_node = static_cast<math::tensor::MatMulNode&>(*library_node);
             sdfg::offloading::RocmBatchedMatMulExpander expander(matmul_node);
+            made_changes |= expander.expand(builder_, analysis_manager_);
+        } else if (lib_node_code == math::tensor::LibraryNodeType_TensorConcat) {
+            auto& concat_node = static_cast<math::tensor::ConcatNode&>(*library_node);
+            sdfg::offloading::RocmConcatExpander expander(concat_node);
             made_changes |= expander.expand(builder_, analysis_manager_);
         } else {
             continue;

--- a/opt/src/targets/cuda/math/tensor/concat_expander.cpp
+++ b/opt/src/targets/cuda/math/tensor/concat_expander.cpp
@@ -1,0 +1,107 @@
+#include "sdfg/targets/cuda/math/tensor/concat_expander.h"
+
+#include <cstddef>
+
+#include "sdfg/analysis/analysis.h"
+#include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/data_flow/access_node.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/concat_node.h"
+#include "sdfg/data_flow/memlet.h"
+#include "sdfg/exceptions.h"
+#include "sdfg/structured_control_flow/block.h"
+#include "sdfg/structured_control_flow/sequence.h"
+#include "sdfg/structured_control_flow/structured_loop.h"
+#include "sdfg/symbolic/symbolic.h"
+#include "sdfg/types/scalar.h"
+#include "sdfg/types/type.h"
+
+namespace sdfg {
+namespace offloading {
+
+bool CudaConcatExpander::expand(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {
+    return CudaConcatExpander::expand_concat_separately(builder, analysis_manager, this->node_);
+}
+
+bool CudaConcatExpander::expand_concat_separately(
+    builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager, math::tensor::ConcatNode& node
+) {
+    auto& dfg = node.get_parent();
+    auto* parent_block = dyn_cast<structured_control_flow::Block*>(dfg.get_parent());
+    if (!parent_block) {
+        return false;
+    }
+    auto* parent_sequence = dyn_cast<structured_control_flow::Sequence*>(parent_block->get_parent());
+    if (!parent_sequence) {
+        return false;
+    }
+    int parent_block_index = parent_sequence->index(*parent_block);
+    auto& new_sequence = builder.add_sequence_before(
+        *parent_sequence,
+        *parent_block,
+        parent_sequence->at(parent_block_index).second.assignments(),
+        parent_block->debug_info()
+    );
+
+    types::Scalar indvar_type(types::PrimitiveType::UInt64);
+    size_t num_tensors = node.inputs().size() - 1;
+    const auto* iedge_result = dfg.in_edge_for_connector(node, node.result());
+    if (!iedge_result) {
+        throw InvalidSDFGException("ConcatNode: Cannot get in edge for connector: " + node.result());
+    }
+    const auto& iedge_result_src = static_cast<const data_flow::AccessNode&>(iedge_result->src());
+    symbolic::Expression offset = symbolic::zero();
+
+    for (size_t i = 0; i < num_tensors; i++) {
+        structured_control_flow::Sequence* current_seq = &new_sequence;
+        data_flow::Subset subset;
+        subset.reserve(node.tensor_layouts()[i].dims());
+        for (auto dim : node.tensor_layouts()[i].shape()) {
+            auto indvar_container = builder.find_new_name("_i");
+            builder.add_container(indvar_container, indvar_type);
+            auto indvar = symbolic::symbol(indvar_container);
+            subset.push_back(indvar);
+            auto& map = builder.add_map(
+                *current_seq,
+                indvar,
+                symbolic::Lt(indvar, dim),
+                symbolic::zero(),
+                symbolic::add(indvar, symbolic::one()),
+                structured_control_flow::ScheduleType_Sequential::create(),
+                {},
+                parent_block->debug_info()
+            );
+            current_seq = &map.root();
+        }
+
+        const auto* iedge_tensor = dfg.in_edge_for_connector(node, node.input(i));
+        if (!iedge_tensor) {
+            throw InvalidSDFGException("ConcatNode: Cannot get in edge for connector: " + node.input(i));
+        }
+        const auto& iedge_tensor_src = static_cast<const data_flow::AccessNode&>(iedge_tensor->src());
+
+        auto& block = builder.add_block(*current_seq, {}, parent_block->debug_info());
+        auto& tensor_access = builder.add_access(block, iedge_tensor_src.data(), iedge_tensor_src.debug_info());
+        auto& result_access = builder.add_access(block, iedge_result_src.data(), iedge_result_src.debug_info());
+        auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"}, node.debug_info());
+
+        builder.add_computational_memlet(
+            block, tensor_access, tasklet, "_in", subset, iedge_tensor->base_type(), iedge_tensor->debug_info()
+        );
+
+        data_flow::Subset offset_subset(subset);
+        offset_subset[node.dim()] = symbolic::add(subset[node.dim()], offset);
+        builder.add_computational_memlet(
+            block, tasklet, "_out", result_access, offset_subset, iedge_result->base_type(), iedge_result->debug_info()
+        );
+        offset = symbolic::add(offset, node.tensor_layouts()[i].get_dim(node.dim()));
+    }
+
+    // Clean up the original block
+    builder.clear_code_node_legacy(*parent_block, node);
+    builder.remove_child(*parent_sequence, parent_block_index + 1);
+
+    return true;
+}
+
+} // namespace offloading
+} // namespace sdfg

--- a/opt/src/targets/rocm/math/tensor/concat_expander.cpp
+++ b/opt/src/targets/rocm/math/tensor/concat_expander.cpp
@@ -1,0 +1,15 @@
+#include "sdfg/targets/rocm/math/tensor/concat_expander.h"
+
+#include "sdfg/analysis/analysis.h"
+#include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/targets/cuda/math/tensor/concat_expander.h"
+
+namespace sdfg {
+namespace offloading {
+
+bool RocmConcatExpander::expand(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {
+    return CudaConcatExpander::expand_concat_separately(builder, analysis_manager, this->node_);
+}
+
+} // namespace offloading
+} // namespace sdfg

--- a/opt/tests/passes/offloading/cuda_library_node_expand_tests.cpp
+++ b/opt/tests/passes/offloading/cuda_library_node_expand_tests.cpp
@@ -2,7 +2,9 @@
 
 #include "sdfg/analysis/analysis.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/concat_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/conv_node.h"
+#include "sdfg/targets/cuda/math/tensor/concat_expander.h"
 #include "sdfg/targets/cuda/math/tensor/conv_expander.h"
 
 #include "sdfg_debug_dump.h"
@@ -427,4 +429,51 @@ TEST(CudaConvExpanderTest, ExpandsValidConv1D_Group1) {
     bool expanded = expander.expand(builder, analysis_manager);
 
     EXPECT_TRUE(expanded);
+}
+
+TEST(CudaConcatExpanderTest, expands) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    builder.add_container("A", desc, true);
+    builder.add_container("B", desc, true);
+    builder.add_container("C", desc, true);
+
+    math::tensor::TensorLayout A_layout({symbolic::integer(1), symbolic::integer(2), symbolic::integer(3)});
+    types::Tensor A_tensor(base_desc, A_layout);
+    math::tensor::TensorLayout B_layout({symbolic::integer(1), symbolic::integer(4), symbolic::integer(3)});
+    types::Tensor B_tensor(base_desc, B_layout);
+    math::tensor::TensorLayout C_layout({symbolic::integer(1), symbolic::integer(6), symbolic::integer(3)});
+    types::Tensor C_tensor(base_desc, C_layout);
+
+    auto& block = builder.add_block(root);
+    auto& A_access = builder.add_access(block, "A");
+    auto& B_access = builder.add_access(block, "B");
+    auto& C_access = builder.add_access(block, "C");
+    auto& libnode = builder.add_library_node<math::tensor::ConcatNode>(
+        block,
+        DebugInfo(),
+        "Y",
+        C_layout,
+        std::vector<std::string>({"X0", "X1"}),
+        std::vector<math::tensor::TensorLayout>({A_layout, B_layout}),
+        1
+    );
+    builder.add_computational_memlet(block, A_access, libnode, "X0", {}, A_tensor);
+    builder.add_computational_memlet(block, B_access, libnode, "X1", {}, B_tensor);
+    builder.add_computational_memlet(block, C_access, libnode, "Y", {}, C_tensor);
+
+    ASSERT_NO_THROW(sdfg.validate());
+    dump_sdfg(sdfg, "0.before");
+
+    auto& concat_node = static_cast<math::tensor::ConcatNode&>(libnode);
+    analysis::AnalysisManager analysis_manager(sdfg);
+    offloading::CudaConcatExpander expander(concat_node);
+    ASSERT_TRUE(expander.expand(builder, analysis_manager));
+
+    ASSERT_NO_THROW(sdfg.validate());
+    dump_sdfg(sdfg, "1.after");
 }

--- a/opt/tests/passes/offloading/rocm_library_node_expand_tests.cpp
+++ b/opt/tests/passes/offloading/rocm_library_node_expand_tests.cpp
@@ -2,7 +2,9 @@
 
 #include "sdfg/analysis/analysis.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/concat_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/conv_node.h"
+#include "sdfg/targets/rocm/math/tensor/concat_expander.h"
 #include "sdfg/targets/rocm/math/tensor/conv_expander.h"
 
 #include "sdfg_debug_dump.h"
@@ -427,4 +429,51 @@ TEST(RocmConvExpanderTest, ExpandsValidConv1D_Group1) {
     bool expanded = expander.expand(builder, analysis_manager);
 
     EXPECT_TRUE(expanded);
+}
+
+TEST(RocmConcatExpanderTest, expands) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    builder.add_container("A", desc, true);
+    builder.add_container("B", desc, true);
+    builder.add_container("C", desc, true);
+
+    math::tensor::TensorLayout A_layout({symbolic::integer(1), symbolic::integer(2), symbolic::integer(3)});
+    types::Tensor A_tensor(base_desc, A_layout);
+    math::tensor::TensorLayout B_layout({symbolic::integer(1), symbolic::integer(4), symbolic::integer(3)});
+    types::Tensor B_tensor(base_desc, B_layout);
+    math::tensor::TensorLayout C_layout({symbolic::integer(1), symbolic::integer(6), symbolic::integer(3)});
+    types::Tensor C_tensor(base_desc, C_layout);
+
+    auto& block = builder.add_block(root);
+    auto& A_access = builder.add_access(block, "A");
+    auto& B_access = builder.add_access(block, "B");
+    auto& C_access = builder.add_access(block, "C");
+    auto& libnode = builder.add_library_node<math::tensor::ConcatNode>(
+        block,
+        DebugInfo(),
+        "Y",
+        C_layout,
+        std::vector<std::string>({"X0", "X1"}),
+        std::vector<math::tensor::TensorLayout>({A_layout, B_layout}),
+        1
+    );
+    builder.add_computational_memlet(block, A_access, libnode, "X0", {}, A_tensor);
+    builder.add_computational_memlet(block, B_access, libnode, "X1", {}, B_tensor);
+    builder.add_computational_memlet(block, C_access, libnode, "Y", {}, C_tensor);
+
+    ASSERT_NO_THROW(sdfg.validate());
+    dump_sdfg(sdfg, "0.before");
+
+    auto& concat_node = static_cast<math::tensor::ConcatNode&>(libnode);
+    analysis::AnalysisManager analysis_manager(sdfg);
+    offloading::RocmConcatExpander expander(concat_node);
+    ASSERT_TRUE(expander.expand(builder, analysis_manager));
+
+    ASSERT_NO_THROW(sdfg.validate());
+    dump_sdfg(sdfg, "1.after");
 }

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -627,6 +627,16 @@ PYBIND11_MODULE(_sdfg, m) {
             py::arg("debug_info") = sdfg::DebugInfo()
         )
         .def(
+            "add_concat_op",
+            &PyStructuredSDFGBuilder::add_concat_op,
+            py::arg("tensors"),
+            py::arg("tensor_types"),
+            py::arg("result"),
+            py::arg("result_type"),
+            py::arg("dim"),
+            py::arg("debug_info") = sdfg::DebugInfo()
+        )
+        .def(
             "add_reduce_op",
             &PyStructuredSDFGBuilder::add_reduce_op,
             py::arg("op_type"),

--- a/python/bindings/builder/py_structured_sdfg_builder.cpp
+++ b/python/bindings/builder/py_structured_sdfg_builder.cpp
@@ -1470,6 +1470,45 @@ void PyStructuredSDFGBuilder::add_copy_op(
     builder_.add_computational_memlet(block, Y_access, libnode, "Y", {}, Y_type, debug_info);
 }
 
+void PyStructuredSDFGBuilder::add_concat_op(
+    const std::vector<std::string>& tensors,
+    const std::vector<const sdfg::types::Tensor*>& tensor_types,
+    const std::string& result,
+    const sdfg::types::Tensor& result_type,
+    long long dim,
+    const sdfg::DebugInfo& debug_info
+) {
+    size_t num_inputs = tensors.size();
+    auto& block = builder_.add_block(current_sequence(), {}, debug_info);
+    std::vector<sdfg::data_flow::AccessNode*> tensor_accesses;
+    tensor_accesses.reserve(num_inputs);
+    std::unordered_map<std::string, sdfg::data_flow::AccessNode*> tensor_access_map;
+    std::vector<std::string> inputs;
+    inputs.reserve(num_inputs);
+    std::vector<sdfg::math::tensor::TensorLayout> input_layouts;
+    input_layouts.reserve(num_inputs);
+    for (size_t i = 0; i < num_inputs; i++) {
+        const auto& tensor = tensors[i];
+        if (tensor_access_map.contains(tensor)) {
+            tensor_accesses.push_back(tensor_access_map.at(tensor));
+        } else {
+            auto& tensor_access = builder_.add_access(block, tensor, debug_info);
+            tensor_access_map.insert({tensor, &tensor_access});
+            tensor_accesses.push_back(&tensor_access);
+        }
+        inputs.push_back("X" + std::to_string(i));
+        input_layouts.push_back(tensor_types[i]->layout());
+    }
+    auto& result_access = builder_.add_access(block, result, debug_info);
+    auto& libnode = builder_.add_library_node<
+        sdfg::math::tensor::ConcatNode>(block, debug_info, "Y", result_type.layout(), inputs, input_layouts, dim);
+    for (size_t i = 0; i < num_inputs; i++) {
+        builder_
+            .add_computational_memlet(block, *tensor_accesses[i], libnode, inputs[i], {}, *tensor_types[i], debug_info);
+    }
+    builder_.add_computational_memlet(block, result_access, libnode, "Y", {}, result_type, debug_info);
+}
+
 void PyStructuredSDFGBuilder::add_reduce_op(
     const std::string& op_type,
     const std::string& input,

--- a/python/bindings/builder/py_structured_sdfg_builder.h
+++ b/python/bindings/builder/py_structured_sdfg_builder.h
@@ -325,6 +325,15 @@ public:
         const sdfg::DebugInfo& debug_info = sdfg::DebugInfo()
     );
 
+    void add_concat_op(
+        const std::vector<std::string>& tensors,
+        const std::vector<const sdfg::types::Tensor*>& tensor_types,
+        const std::string& result,
+        const sdfg::types::Tensor& result_type,
+        long long dim,
+        const sdfg::DebugInfo& debug_info = sdfg::DebugInfo()
+    );
+
     void add_reduce_op(
         const std::string& op_type,
         const std::string& input,

--- a/pytorch/docc/pytorch/graph_parser/reshaping.py
+++ b/pytorch/docc/pytorch/graph_parser/reshaping.py
@@ -4,7 +4,7 @@ GraphParser modules for parsing indexing, slicing, joining, and mutating operati
 
 import torch.fx
 
-from docc.sdfg import StructuredSDFGBuilder
+from docc.sdfg import StructuredSDFGBuilder, Tensor, DebugInfo
 
 from docc.pytorch.graph_parser.utils import (
     ContainerInfoBase,
@@ -15,6 +15,70 @@ from docc.pytorch.graph_parser.utils import (
     register_pre_module,
     register_module,
 )
+
+
+class ConcatParser(GraphParserModule):
+    def parse(
+        self,
+        node: torch.fx.Node,
+        builder: StructuredSDFGBuilder,
+        container_info: ContainerInfos,
+    ) -> None:
+        if len(node.args) < 1 or len(node.args) > 2:
+            raise GraphParserError(
+                self,
+                node,
+                "Expected between 1 and 2 arguments but got " + str(len(node.args)),
+            )
+        if len(node.kwargs) != 0:
+            raise GraphParserError(
+                self, node, "Unsupported kwargs: " + str(node.kwargs)
+            )
+        if not isinstance(node.args[0], list):
+            raise GraphParserError(
+                self,
+                node,
+                "First argument must be a list type but got: "
+                + str(type(node.args[0])),
+            )
+        num_args: int = len(node.args[0])
+        tensor_containers: list[str] = []
+        tensor_tensors: list[Tensor] = []
+        for arg in node.args[0]:
+            tensor_container: str = self.convert_arg_to_container(
+                node, container_info, arg
+            )
+            tensor_containers.append(tensor_container)
+            tensor_tensors.append(
+                self.get_tensor_type(node, container_info, tensor_container)
+            )
+        if len(node.args) == 2:
+            if not isinstance(node.args[1], int):
+                raise GraphParserError(
+                    self,
+                    node,
+                    "Second argument must be an int type but got: "
+                    + str(type(node.args[1])),
+                )
+            dim: int = node.args[1]
+        else:
+            dim: int = 0
+        if dim < 0:
+            dim: int = dim + num_args
+        result_container = self.get_result_container(node, builder, container_info)
+        result_tensor = self.get_tensor_type(node, container_info, result_container)
+        debug_info: DebugInfo = self.get_debug_info(node)
+        builder.add_concat_op(
+            tensor_containers,
+            tensor_tensors,
+            result_container,
+            result_tensor,
+            dim,
+            debug_info,
+        )
+
+
+register_module("aten.cat.default", ConcatParser())
 
 
 class TensorReshape2dParser(GraphParserModule):

--- a/pytorch/tests/ops/test_reshaping.py
+++ b/pytorch/tests/ops/test_reshaping.py
@@ -3,6 +3,61 @@ import torch.nn as nn
 
 from tests import check
 
+# --- argwhere ---
+
+
+def test_argwhere_simple(target: str) -> None:
+    class ArgwhereSimpleNet(nn.Module):
+        def forward(self, input: torch.Tensor) -> torch.Tensor:
+            return torch.argwhere(input)
+
+    check(ArgwhereSimpleNet(), torch.tensor([1, 0, 1]), target=target)
+
+
+def test_argwhere_bigger(target: str) -> None:
+    class ArgwhereBiggerNet(nn.Module):
+        def forward(self, input: torch.Tensor) -> torch.Tensor:
+            return torch.argwhere(input)
+
+    check(ArgwhereBiggerNet(), torch.tensor([[1, 0, 1], [0, 1, 1]]), target=target)
+
+
+# --- cat ---
+
+
+def test_cat_simple(target: str) -> None:
+    class CatSimpleNet(nn.Module):
+        def forward(self, input1: torch.Tensor, input2: torch.Tensor) -> torch.Tensor:
+            return torch.cat((input1, input2), 0)
+
+    check(CatSimpleNet(), *(torch.randn(2, 3), torch.randn(2, 3)), target=target)
+
+
+def test_cat_dim_1(target: str) -> None:
+    class CatDim1Net(nn.Module):
+        def forward(self, input1: torch.Tensor, input2: torch.Tensor) -> torch.Tensor:
+            return torch.cat((input1, input2), 1)
+
+    check(CatDim1Net(), *(torch.randn(2, 3), torch.randn(2, 3)), target=target)
+
+
+def test_cat_dim_neg1(target: str) -> None:
+    class CatDimNeg1Net(nn.Module):
+        def forward(self, input1: torch.Tensor, input2: torch.Tensor) -> torch.Tensor:
+            return torch.cat((input1, input2), -1)
+
+    check(CatDimNeg1Net(), *(torch.randn(2, 3), torch.randn(2, 3)), target=target)
+
+
+def test_cat_many(target: str) -> None:
+    class CatManyNet(nn.Module):
+        def forward(self, inputs: tuple[torch.Tensor, ...]) -> torch.Tensor:
+            return torch.cat(inputs, 0)
+
+    x = torch.randn(2, 3)
+    check(CatManyNet(), (x, x, x, x, x, x, x, x, x, x), target=target)
+
+
 # --- permute ---
 
 

--- a/sdfg/CMakeLists.txt
+++ b/sdfg/CMakeLists.txt
@@ -85,6 +85,7 @@ set(SOURCE_FILES
     src/data_flow/library_nodes/math/math_node.cpp
     src/data_flow/library_nodes/math/tensor/batchnorm_node.cpp
     src/data_flow/library_nodes/math/tensor/broadcast_node.cpp
+    src/data_flow/library_nodes/math/tensor/concat_node.cpp
     src/data_flow/library_nodes/math/tensor/conv_node.cpp
     src/data_flow/library_nodes/math/tensor/copy_node.cpp
     src/data_flow/library_nodes/math/tensor/einsum_node.cpp

--- a/sdfg/include/sdfg/builder/function_builder.h
+++ b/sdfg/include/sdfg/builder/function_builder.h
@@ -44,6 +44,14 @@ public:
 
     void set_element_counter(size_t element_counter);
 
+    /**
+     * @brief Replace symbolic expressions on the whole SDFG
+     * @param old_expression Expression to replace
+     * @param new_expression Replacement expression
+     */
+    virtual void replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression);
+    virtual void replace_symbols(const symbolic::ExpressionMapping& replacements);
+
     /** Common Dataflow Operations **/
 
     void update_tasklet(data_flow::Tasklet& tasklet, const data_flow::TaskletCode code);

--- a/sdfg/include/sdfg/builder/structured_sdfg_builder.h
+++ b/sdfg/include/sdfg/builder/structured_sdfg_builder.h
@@ -149,6 +149,15 @@ public:
 
     Element* find_element_by_id(const size_t& element_id) const;
 
+    /**
+     * @brief Replace symbolic expressions on the whole SDFG
+     * @param old_expression Expression to replace
+     * @param new_expression Replacement expression
+     */
+    virtual void replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression)
+        override;
+    virtual void replace_symbols(const symbolic::ExpressionMapping& replacements) override;
+
     Sequence& add_sequence(
         Sequence& parent,
         const sdfg::control_flow::Assignments& assignments = {},

--- a/sdfg/include/sdfg/codegen/utils.h
+++ b/sdfg/include/sdfg/codegen/utils.h
@@ -79,6 +79,17 @@ public:
     bool operator==(const types::IType& other) const override;
 
     std::string print() const override;
+
+    /**
+     * @brief Replace symbolic expressions on this type
+     * @param old_expression Expression to replace
+     * @param new_expression Replacement expression
+     *
+     * Replaces occurrences of symbolic expressions on the type.
+     */
+    virtual void replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression)
+        override;
+    virtual void replace_symbols(const symbolic::ExpressionMapping& replacements) override;
 };
 
 } // namespace codegen

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/math.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/math.h
@@ -14,6 +14,7 @@
 // Tensor
 #include "sdfg/data_flow/library_nodes/math/tensor/batchnorm_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/broadcast_node.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/concat_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/conv_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/copy_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/einsum_node.h"

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/concat_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/concat_node.h
@@ -32,18 +32,6 @@ private:
     std::vector<TensorLayout> tensor_layouts_;
     long long dim_;
 
-    void expand_naive(
-        passes::LibNodeExpander::AccessNodeExpand& standalone,
-        builder::StructuredSDFGBuilder& builder,
-        structured_control_flow::Sequence& sequence
-    );
-
-    void expand_separately(
-        passes::LibNodeExpander::AccessNodeExpand& standalone,
-        builder::StructuredSDFGBuilder& builder,
-        structured_control_flow::Sequence& sequence
-    );
-
 public:
     ConcatNode(
         size_t element_id,

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/concat_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/concat_node.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json_fwd.hpp>
+
+#include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/data_flow/data_flow_graph.h"
+#include "sdfg/data_flow/data_flow_node.h"
+#include "sdfg/data_flow/library_node.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/tensor_layout.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/tensor_node.h"
+#include "sdfg/element.h"
+#include "sdfg/function.h"
+#include "sdfg/graph/graph.h"
+#include "sdfg/serializer/json_serializer.h"
+#include "sdfg/structured_control_flow/block.h"
+#include "sdfg/symbolic/symbolic.h"
+
+namespace sdfg {
+namespace math {
+namespace tensor {
+
+inline data_flow::LibraryNodeCode LibraryNodeType_TensorConcat("ml::Concat");
+
+class ConcatNode : public TensorNode {
+private:
+    TensorLayout result_layout_;
+    std::vector<TensorLayout> tensor_layouts_;
+    long long dim_;
+
+    void expand_naive(
+        passes::LibNodeExpander::AccessNodeExpand& standalone,
+        builder::StructuredSDFGBuilder& builder,
+        structured_control_flow::Sequence& sequence
+    );
+
+    void expand_separately(
+        passes::LibNodeExpander::AccessNodeExpand& standalone,
+        builder::StructuredSDFGBuilder& builder,
+        structured_control_flow::Sequence& sequence
+    );
+
+public:
+    ConcatNode(
+        size_t element_id,
+        const DebugInfo& debug_info,
+        const graph::Vertex vertex,
+        data_flow::DataFlowGraph& parent,
+        const std::string& result,
+        const TensorLayout& result_layout,
+        const std::vector<std::string>& tensors,
+        const std::vector<TensorLayout>& tensor_layouts,
+        long long dim,
+        const data_flow::ImplementationType& impl_type = data_flow::ImplementationType_NONE
+    );
+
+    const std::string& result() const;
+    const TensorLayout& result_layout() const;
+
+    std::vector<std::string> tensors() const;
+    const std::vector<TensorLayout>& tensor_layouts() const;
+
+    long long dim() const;
+
+    void validate(const Function& function) const override;
+
+    virtual bool supports_integer_types() const override;
+
+    virtual passes::LibNodeExpander::ExpandOutcome
+    expand(passes::LibNodeExpander::ExpandContext& context, structured_control_flow::Block& block) override;
+
+    virtual std::string toStr() const override;
+
+    virtual symbolic::SymbolSet symbols() const override;
+
+    virtual symbolic::Expression flop() const override;
+
+    virtual std::unique_ptr<data_flow::DataFlowNode>
+    clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent) const override;
+
+    virtual void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
+
+    void replace(const symbolic::ExpressionMapping& replacements) override;
+};
+
+class ConcatNodeSerializer : public serializer::LibraryNodeSerializer {
+public:
+    nlohmann::json serialize(const data_flow::LibraryNode& library_node) override;
+
+    data_flow::LibraryNode& deserialize(
+        const nlohmann::json& j, builder::StructuredSDFGBuilder& builder, structured_control_flow::Block& parent
+    ) override;
+};
+
+} // namespace tensor
+} // namespace math
+} // namespace sdfg

--- a/sdfg/include/sdfg/data_flow/memlet.h
+++ b/sdfg/include/sdfg/data_flow/memlet.h
@@ -346,7 +346,7 @@ public:
      * @param old_expression Expression to replace
      * @param new_expression Replacement expression
      *
-     * Replaces occurrences in the subset vector.
+     * Replaces occurrences in the subset vector & the base type.
      */
     void replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) override;
     void replace(const symbolic::ExpressionMapping& replacements) override;

--- a/sdfg/include/sdfg/types/array.h
+++ b/sdfg/include/sdfg/types/array.h
@@ -99,6 +99,17 @@ public:
 
     /// @brief Returns a string representation of this array type
     virtual std::string print() const override;
+
+    /**
+     * @brief Replace symbolic expressions on this type
+     * @param old_expression Expression to replace
+     * @param new_expression Replacement expression
+     *
+     * Replaces occurrences of symbolic expressions on the type.
+     */
+    virtual void replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression)
+        override;
+    virtual void replace_symbols(const symbolic::ExpressionMapping& replacements) override;
 };
 
 } // namespace types

--- a/sdfg/include/sdfg/types/function.h
+++ b/sdfg/include/sdfg/types/function.h
@@ -118,6 +118,17 @@ public:
 
     /// @brief Returns a string representation of this function type
     virtual std::string print() const override;
+
+    /**
+     * @brief Replace symbolic expressions on this type
+     * @param old_expression Expression to replace
+     * @param new_expression Replacement expression
+     *
+     * Replaces occurrences of symbolic expressions on the type.
+     */
+    virtual void replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression)
+        override;
+    virtual void replace_symbols(const symbolic::ExpressionMapping& replacements) override;
 };
 
 } // namespace types

--- a/sdfg/include/sdfg/types/pointer.h
+++ b/sdfg/include/sdfg/types/pointer.h
@@ -110,6 +110,17 @@ public:
 
     /// @brief Returns a string representation of this pointer type
     virtual std::string print() const override;
+
+    /**
+     * @brief Replace symbolic expressions on this type
+     * @param old_expression Expression to replace
+     * @param new_expression Replacement expression
+     *
+     * Replaces occurrences of symbolic expressions on the type.
+     */
+    virtual void replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression)
+        override;
+    virtual void replace_symbols(const symbolic::ExpressionMapping& replacements) override;
 };
 } // namespace types
 } // namespace sdfg

--- a/sdfg/include/sdfg/types/scalar.h
+++ b/sdfg/include/sdfg/types/scalar.h
@@ -90,6 +90,17 @@ public:
 
     /// @brief Returns a string representation of this scalar type
     virtual std::string print() const override;
+
+    /**
+     * @brief Replace symbolic expressions on this type
+     * @param old_expression Expression to replace
+     * @param new_expression Replacement expression
+     *
+     * Nothing to do.
+     */
+    virtual void replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression)
+        override {}
+    virtual void replace_symbols(const symbolic::ExpressionMapping& replacements) override {}
 };
 } // namespace types
 } // namespace sdfg

--- a/sdfg/include/sdfg/types/structure.h
+++ b/sdfg/include/sdfg/types/structure.h
@@ -92,6 +92,17 @@ public:
      * @return true if this structure is pointer-like, false otherwise
      */
     bool is_pointer_like() const override;
+
+    /**
+     * @brief Replace symbolic expressions on this type
+     * @param old_expression Expression to replace
+     * @param new_expression Replacement expression
+     *
+     * Nothing to do.
+     */
+    virtual void replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression)
+        override {}
+    virtual void replace_symbols(const symbolic::ExpressionMapping& replacements) override {}
 };
 
 /**
@@ -188,6 +199,16 @@ public:
      */
     static const Structure&
     create_vector_type(const builder::FunctionBuilder& builder, const Scalar& element_type, size_t vector_size);
+
+    /**
+     * @brief Replace symbolic expressions on the members
+     * @param old_expression Expression to replace
+     * @param new_expression Replacement expression
+     *
+     * Replaces occurrences of symbolic expressions on the member types.
+     */
+    void replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression);
+    void replace_symbols(const symbolic::ExpressionMapping& replacements);
 };
 
 } // namespace types

--- a/sdfg/include/sdfg/types/tensor.h
+++ b/sdfg/include/sdfg/types/tensor.h
@@ -106,6 +106,17 @@ public:
     std::unique_ptr<Tensor> squeeze() const;
 
     std::unique_ptr<Tensor> reshape(const symbolic::MultiExpression& new_shape) const;
+
+    /**
+     * @brief Replace symbolic expressions on this type
+     * @param old_expression Expression to replace
+     * @param new_expression Replacement expression
+     *
+     * Replaces occurrences of symbolic expressions on the type.
+     */
+    virtual void replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression)
+        override;
+    virtual void replace_symbols(const symbolic::ExpressionMapping& replacements) override;
 };
 
 } // namespace types

--- a/sdfg/include/sdfg/types/type.h
+++ b/sdfg/include/sdfg/types/type.h
@@ -627,6 +627,16 @@ public:
         os << type.print();
         return os;
     };
+
+    /**
+     * @brief Replace symbolic expressions on this type
+     * @param old_expression Expression to replace
+     * @param new_expression Replacement expression
+     *
+     * Replaces occurrences of symbolic expressions on the type.
+     */
+    virtual void replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression) = 0;
+    virtual void replace_symbols(const symbolic::ExpressionMapping& replacements) = 0;
 };
 
 } // namespace types

--- a/sdfg/src/builder/function_builder.cpp
+++ b/sdfg/src/builder/function_builder.cpp
@@ -67,6 +67,26 @@ void FunctionBuilder::set_element_counter(size_t element_counter) {
     this->function().element_counter_ = element_counter;
 };
 
+void FunctionBuilder::replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {
+    this->function().return_type_->replace_symbols(old_expression, new_expression);
+    for (auto& container : this->function().containers_) {
+        container.second->replace_symbols(old_expression, new_expression);
+    }
+    for (auto& structure : this->function().structures_) {
+        structure.second->replace_symbols(old_expression, new_expression);
+    }
+}
+
+void FunctionBuilder::replace_symbols(const symbolic::ExpressionMapping& replacements) {
+    this->function().return_type_->replace_symbols(replacements);
+    for (auto& container : this->function().containers_) {
+        container.second->replace_symbols(replacements);
+    }
+    for (auto& structure : this->function().structures_) {
+        structure.second->replace_symbols(replacements);
+    }
+}
+
 void FunctionBuilder::set_return_type(const types::IType& type) const { this->function().return_type_ = type.clone(); };
 
 const types::IType& FunctionBuilder::

--- a/sdfg/src/builder/structured_sdfg_builder.cpp
+++ b/sdfg/src/builder/structured_sdfg_builder.cpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 
+#include "sdfg/builder/function_builder.h"
 #include "sdfg/data_flow/library_node.h"
 #include "sdfg/structured_control_flow/map.h"
 #include "sdfg/structured_control_flow/sequence.h"
@@ -491,6 +492,17 @@ Element* StructuredSDFGBuilder::find_element_by_id(const size_t& element_id) con
 
     return nullptr;
 };
+
+void StructuredSDFGBuilder::
+    replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {
+    FunctionBuilder::replace_symbols(old_expression, new_expression);
+    this->structured_sdfg_->root_->replace(old_expression, new_expression);
+}
+
+void StructuredSDFGBuilder::replace_symbols(const symbolic::ExpressionMapping& replacements) {
+    FunctionBuilder::replace_symbols(replacements);
+    this->structured_sdfg_->root_->replace(replacements);
+}
 
 Sequence& StructuredSDFGBuilder::
     add_sequence(Sequence& parent, const sdfg::control_flow::Assignments& assignments, const DebugInfo& debug_info) {

--- a/sdfg/src/codegen/utils.cpp
+++ b/sdfg/src/codegen/utils.cpp
@@ -77,6 +77,14 @@ bool Reference::operator==(const types::IType& other) const {
 
 std::string Reference::print() const { return "Reference(" + this->reference_->print() + ")"; };
 
+void Reference::replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {
+    this->reference_->replace_symbols(old_expression, new_expression);
+}
+
+void Reference::replace_symbols(const symbolic::ExpressionMapping& replacements) {
+    this->reference_->replace_symbols(replacements);
+}
+
 
 } // namespace codegen
 } // namespace sdfg

--- a/sdfg/src/data_flow/library_nodes/math/tensor/concat_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/concat_node.cpp
@@ -34,129 +34,6 @@ namespace sdfg {
 namespace math {
 namespace tensor {
 
-void ConcatNode::expand_naive(
-    passes::LibNodeExpander::AccessNodeExpand& standalone,
-    builder::StructuredSDFGBuilder& builder,
-    structured_control_flow::Sequence& sequence
-) {
-    auto& dfg = this->get_parent();
-
-    types::Scalar indvar_type(types::PrimitiveType::UInt64);
-    structured_control_flow::Sequence* current_seq = &sequence;
-    data_flow::Subset subset;
-    subset.reserve(this->result_layout_.dims());
-    for (auto dim : this->result_layout_.shape()) {
-        auto indvar_container = builder.find_new_name("_i");
-        builder.add_container(indvar_container, indvar_type);
-        auto indvar = symbolic::symbol(indvar_container);
-        subset.push_back(indvar);
-        auto& map = builder.add_map(
-            *current_seq,
-            indvar,
-            symbolic::Lt(indvar, dim),
-            symbolic::zero(),
-            symbolic::add(indvar, symbolic::one()),
-            structured_control_flow::ScheduleType_Sequential::create(),
-            {},
-            this->debug_info_
-        );
-        current_seq = &map.root();
-    }
-
-    auto& if_else = builder.add_if_else(*current_seq, {}, this->debug_info_);
-    auto dim_indvar = subset.at(this->dim_);
-    const auto* iedge_result = dfg.in_edge_for_connector(*this, this->result());
-    if (!iedge_result) {
-        throw InvalidSDFGException("ConcatNode: Cannot get in edge for connector: " + this->result());
-    }
-
-    symbolic::Expression offset = symbolic::zero();
-    for (size_t i = 0; i < this->tensor_layouts_.size(); i++) {
-        auto new_offset = symbolic::add(offset, this->tensor_layouts_[i].get_dim(this->dim_));
-        auto condition = symbolic::And(symbolic::Ge(dim_indvar, offset), symbolic::Lt(dim_indvar, new_offset));
-        auto& case_seq = builder.add_case(if_else, condition, this->debug_info_);
-
-        data_flow::Subset offset_subset(subset);
-        offset_subset[this->dim_] = symbolic::sub(dim_indvar, offset);
-
-        auto& block = builder.add_block(case_seq, {}, this->debug_info_);
-        auto& tensor_access = standalone.add_scalar_input_access(block, i);
-        auto& result_access = standalone.add_scalar_input_access(block, this->tensor_layouts_.size());
-        auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"}, this->debug_info_);
-
-        const auto* iedge_tensor = dfg.in_edge_for_connector(*this, this->inputs_[i]);
-        if (!iedge_tensor) {
-            throw InvalidSDFGException("ConcatNode: Cannot get in edge for connector: " + this->inputs_[i]);
-        }
-        builder.add_computational_memlet(
-            block, tensor_access, tasklet, "_in", offset_subset, iedge_tensor->base_type(), iedge_tensor->debug_info()
-        );
-        builder.add_computational_memlet(
-            block, tasklet, "_out", result_access, subset, iedge_result->base_type(), iedge_result->debug_info()
-        );
-
-        offset = new_offset;
-    }
-}
-
-void ConcatNode::expand_separately(
-    passes::LibNodeExpander::AccessNodeExpand& standalone,
-    builder::StructuredSDFGBuilder& builder,
-    structured_control_flow::Sequence& sequence
-) {
-    auto& dfg = this->get_parent();
-    types::Scalar indvar_type(types::PrimitiveType::UInt64);
-    size_t num_tensors = this->inputs().size() - 1;
-    const auto* iedge_result = dfg.in_edge_for_connector(*this, this->result());
-    if (!iedge_result) {
-        throw InvalidSDFGException("ConcatNode: Cannot get in edge for connector: " + this->result());
-    }
-    symbolic::Expression offset = symbolic::zero();
-
-    for (size_t i = 0; i < num_tensors; i++) {
-        structured_control_flow::Sequence* current_seq = &sequence;
-        data_flow::Subset subset;
-        subset.reserve(this->tensor_layouts_[i].dims());
-        for (auto dim : this->tensor_layouts_[i].shape()) {
-            auto indvar_container = builder.find_new_name("_i");
-            builder.add_container(indvar_container, indvar_type);
-            auto indvar = symbolic::symbol(indvar_container);
-            subset.push_back(indvar);
-            auto& map = builder.add_map(
-                *current_seq,
-                indvar,
-                symbolic::Lt(indvar, dim),
-                symbolic::zero(),
-                symbolic::add(indvar, symbolic::one()),
-                structured_control_flow::ScheduleType_Sequential::create(),
-                {},
-                this->debug_info_
-            );
-            current_seq = &map.root();
-        }
-
-        auto& block = builder.add_block(*current_seq, {}, this->debug_info_);
-        auto& tensor_access = standalone.add_scalar_input_access(block, i);
-        auto& result_access = standalone.add_scalar_input_access(block, this->tensor_layouts_.size());
-        auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"}, this->debug_info_);
-
-        const auto* iedge_tensor = dfg.in_edge_for_connector(*this, this->inputs_[i]);
-        if (!iedge_tensor) {
-            throw InvalidSDFGException("ConcatNode: Cannot get in edge for connector: " + this->inputs_[i]);
-        }
-        builder.add_computational_memlet(
-            block, tensor_access, tasklet, "_in", subset, iedge_tensor->base_type(), iedge_tensor->debug_info()
-        );
-
-        data_flow::Subset offset_subset(subset);
-        offset_subset[this->dim_] = symbolic::add(subset[this->dim_], offset);
-        builder.add_computational_memlet(
-            block, tasklet, "_out", result_access, offset_subset, iedge_result->base_type(), iedge_result->debug_info()
-        );
-        offset = symbolic::add(offset, this->tensor_layouts_[i].get_dim(this->dim_));
-    }
-}
-
 ConcatNode::ConcatNode(
     size_t element_id,
     const DebugInfo& debug_info,
@@ -292,8 +169,64 @@ passes::LibNodeExpander::ExpandOutcome ConcatNode::
     // Add a graph after the current block
     auto& new_sequence = standalone->replace_with_sequence();
 
-    this->expand_naive(*standalone, builder, new_sequence);
-    // this->expand_separately(*standalone, builder, new_sequence);
+    auto& dfg = this->get_parent();
+
+    types::Scalar indvar_type(types::PrimitiveType::UInt64);
+    structured_control_flow::Sequence* current_seq = &new_sequence;
+    data_flow::Subset subset;
+    subset.reserve(this->result_layout_.dims());
+    for (auto dim : this->result_layout_.shape()) {
+        auto indvar_container = builder.find_new_name("_i");
+        builder.add_container(indvar_container, indvar_type);
+        auto indvar = symbolic::symbol(indvar_container);
+        subset.push_back(indvar);
+        auto& map = builder.add_map(
+            *current_seq,
+            indvar,
+            symbolic::Lt(indvar, dim),
+            symbolic::zero(),
+            symbolic::add(indvar, symbolic::one()),
+            structured_control_flow::ScheduleType_Sequential::create(),
+            {},
+            this->debug_info_
+        );
+        current_seq = &map.root();
+    }
+
+    auto& if_else = builder.add_if_else(*current_seq, {}, this->debug_info_);
+    auto dim_indvar = subset.at(this->dim_);
+    const auto* iedge_result = dfg.in_edge_for_connector(*this, this->result());
+    if (!iedge_result) {
+        throw InvalidSDFGException("ConcatNode: Cannot get in edge for connector: " + this->result());
+    }
+
+    symbolic::Expression offset = symbolic::zero();
+    for (size_t i = 0; i < this->tensor_layouts_.size(); i++) {
+        auto new_offset = symbolic::add(offset, this->tensor_layouts_[i].get_dim(this->dim_));
+        auto condition = symbolic::And(symbolic::Ge(dim_indvar, offset), symbolic::Lt(dim_indvar, new_offset));
+        auto& case_seq = builder.add_case(if_else, condition, this->debug_info_);
+
+        data_flow::Subset offset_subset(subset);
+        offset_subset[this->dim_] = symbolic::sub(dim_indvar, offset);
+
+        auto& block = builder.add_block(case_seq, {}, this->debug_info_);
+        auto& tensor_access = standalone->add_scalar_input_access(block, i);
+        auto& result_access = standalone->add_scalar_input_access(block, this->tensor_layouts_.size());
+        auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"}, this->debug_info_);
+
+        const auto* iedge_tensor = dfg.in_edge_for_connector(*this, this->inputs_[i]);
+        if (!iedge_tensor) {
+            throw InvalidSDFGException("ConcatNode: Cannot get in edge for connector: " + this->inputs_[i]);
+        }
+        builder.add_computational_memlet(
+            block, tensor_access, tasklet, "_in", offset_subset, iedge_tensor->base_type(), iedge_tensor->debug_info()
+        );
+        builder.add_computational_memlet(
+            block, tasklet, "_out", result_access, subset, iedge_result->base_type(), iedge_result->debug_info()
+        );
+
+        offset = new_offset;
+    }
 
     return standalone->successfully_expanded();
 }

--- a/sdfg/src/data_flow/library_nodes/math/tensor/concat_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/concat_node.cpp
@@ -1,0 +1,426 @@
+#include "sdfg/data_flow/library_nodes/math/tensor/concat_node.h"
+
+#include <cstddef>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json_fwd.hpp>
+
+#include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/data_flow/data_flow_graph.h"
+#include "sdfg/data_flow/data_flow_node.h"
+#include "sdfg/data_flow/library_node.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/tensor_layout.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/tensor_node.h"
+#include "sdfg/data_flow/memlet.h"
+#include "sdfg/data_flow/tasklet.h"
+#include "sdfg/element.h"
+#include "sdfg/exceptions.h"
+#include "sdfg/function.h"
+#include "sdfg/graph/graph.h"
+#include "sdfg/passes/expansion/lib_node_expander.h"
+#include "sdfg/serializer/json_serializer.h"
+#include "sdfg/structured_control_flow/block.h"
+#include "sdfg/structured_control_flow/sequence.h"
+#include "sdfg/structured_control_flow/structured_loop.h"
+#include "sdfg/symbolic/symbolic.h"
+#include "sdfg/types/scalar.h"
+#include "sdfg/types/tensor.h"
+#include "sdfg/types/type.h"
+
+namespace sdfg {
+namespace math {
+namespace tensor {
+
+void ConcatNode::expand_naive(
+    passes::LibNodeExpander::AccessNodeExpand& standalone,
+    builder::StructuredSDFGBuilder& builder,
+    structured_control_flow::Sequence& sequence
+) {
+    auto& dfg = this->get_parent();
+
+    types::Scalar indvar_type(types::PrimitiveType::UInt64);
+    structured_control_flow::Sequence* current_seq = &sequence;
+    data_flow::Subset subset;
+    subset.reserve(this->result_layout_.dims());
+    for (auto dim : this->result_layout_.shape()) {
+        auto indvar_container = builder.find_new_name("_i");
+        builder.add_container(indvar_container, indvar_type);
+        auto indvar = symbolic::symbol(indvar_container);
+        subset.push_back(indvar);
+        auto& map = builder.add_map(
+            *current_seq,
+            indvar,
+            symbolic::Lt(indvar, dim),
+            symbolic::zero(),
+            symbolic::add(indvar, symbolic::one()),
+            structured_control_flow::ScheduleType_Sequential::create(),
+            {},
+            this->debug_info_
+        );
+        current_seq = &map.root();
+    }
+
+    auto& if_else = builder.add_if_else(*current_seq, {}, this->debug_info_);
+    auto dim_indvar = subset.at(this->dim_);
+    const auto* iedge_result = dfg.in_edge_for_connector(*this, this->result());
+    if (!iedge_result) {
+        throw InvalidSDFGException("ConcatNode: Cannot get in edge for connector: " + this->result());
+    }
+
+    symbolic::Expression offset = symbolic::zero();
+    for (size_t i = 0; i < this->tensor_layouts_.size(); i++) {
+        auto new_offset = symbolic::add(offset, this->tensor_layouts_[i].get_dim(this->dim_));
+        auto condition = symbolic::And(symbolic::Ge(dim_indvar, offset), symbolic::Lt(dim_indvar, new_offset));
+        auto& case_seq = builder.add_case(if_else, condition, this->debug_info_);
+
+        data_flow::Subset offset_subset(subset);
+        offset_subset[this->dim_] = symbolic::sub(dim_indvar, offset);
+
+        auto& block = builder.add_block(case_seq, {}, this->debug_info_);
+        auto& tensor_access = standalone.add_scalar_input_access(block, i);
+        auto& result_access = standalone.add_scalar_input_access(block, this->tensor_layouts_.size());
+        auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"}, this->debug_info_);
+
+        const auto* iedge_tensor = dfg.in_edge_for_connector(*this, this->inputs_[i]);
+        if (!iedge_tensor) {
+            throw InvalidSDFGException("ConcatNode: Cannot get in edge for connector: " + this->inputs_[i]);
+        }
+        builder.add_computational_memlet(
+            block, tensor_access, tasklet, "_in", offset_subset, iedge_tensor->base_type(), iedge_tensor->debug_info()
+        );
+        builder.add_computational_memlet(
+            block, tasklet, "_out", result_access, subset, iedge_result->base_type(), iedge_result->debug_info()
+        );
+
+        offset = new_offset;
+    }
+}
+
+void ConcatNode::expand_separately(
+    passes::LibNodeExpander::AccessNodeExpand& standalone,
+    builder::StructuredSDFGBuilder& builder,
+    structured_control_flow::Sequence& sequence
+) {
+    auto& dfg = this->get_parent();
+    types::Scalar indvar_type(types::PrimitiveType::UInt64);
+    size_t num_tensors = this->inputs().size() - 1;
+    const auto* iedge_result = dfg.in_edge_for_connector(*this, this->result());
+    if (!iedge_result) {
+        throw InvalidSDFGException("ConcatNode: Cannot get in edge for connector: " + this->result());
+    }
+    symbolic::Expression offset = symbolic::zero();
+
+    for (size_t i = 0; i < num_tensors; i++) {
+        structured_control_flow::Sequence* current_seq = &sequence;
+        data_flow::Subset subset;
+        subset.reserve(this->tensor_layouts_[i].dims());
+        for (auto dim : this->tensor_layouts_[i].shape()) {
+            auto indvar_container = builder.find_new_name("_i");
+            builder.add_container(indvar_container, indvar_type);
+            auto indvar = symbolic::symbol(indvar_container);
+            subset.push_back(indvar);
+            auto& map = builder.add_map(
+                *current_seq,
+                indvar,
+                symbolic::Lt(indvar, dim),
+                symbolic::zero(),
+                symbolic::add(indvar, symbolic::one()),
+                structured_control_flow::ScheduleType_Sequential::create(),
+                {},
+                this->debug_info_
+            );
+            current_seq = &map.root();
+        }
+
+        auto& block = builder.add_block(*current_seq, {}, this->debug_info_);
+        auto& tensor_access = standalone.add_scalar_input_access(block, i);
+        auto& result_access = standalone.add_scalar_input_access(block, this->tensor_layouts_.size());
+        auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"}, this->debug_info_);
+
+        const auto* iedge_tensor = dfg.in_edge_for_connector(*this, this->inputs_[i]);
+        if (!iedge_tensor) {
+            throw InvalidSDFGException("ConcatNode: Cannot get in edge for connector: " + this->inputs_[i]);
+        }
+        builder.add_computational_memlet(
+            block, tensor_access, tasklet, "_in", subset, iedge_tensor->base_type(), iedge_tensor->debug_info()
+        );
+
+        data_flow::Subset offset_subset(subset);
+        offset_subset[this->dim_] = symbolic::add(subset[this->dim_], offset);
+        builder.add_computational_memlet(
+            block, tasklet, "_out", result_access, offset_subset, iedge_result->base_type(), iedge_result->debug_info()
+        );
+        offset = symbolic::add(offset, this->tensor_layouts_[i].get_dim(this->dim_));
+    }
+}
+
+ConcatNode::ConcatNode(
+    size_t element_id,
+    const DebugInfo& debug_info,
+    const graph::Vertex vertex,
+    data_flow::DataFlowGraph& parent,
+    const std::string& result,
+    const TensorLayout& result_layout,
+    const std::vector<std::string>& tensors,
+    const std::vector<TensorLayout>& tensor_layouts,
+    long long dim,
+    const data_flow::ImplementationType& impl_type
+)
+    : TensorNode(element_id, debug_info, vertex, parent, LibraryNodeType_TensorConcat, {}, tensors, impl_type),
+      result_layout_(result_layout), tensor_layouts_(tensor_layouts), dim_(dim) {
+    this->inputs_.push_back(result);
+}
+
+const std::string& ConcatNode::result() const { return this->inputs_.back(); }
+
+const TensorLayout& ConcatNode::result_layout() const { return this->result_layout_; }
+
+std::vector<std::string> ConcatNode::tensors() const {
+    return std::vector<std::string>(this->inputs_.begin(), this->inputs_.end() - 1);
+}
+
+const std::vector<TensorLayout>& ConcatNode::tensor_layouts() const { return this->tensor_layouts_; }
+
+long long ConcatNode::dim() const { return this->dim_; }
+
+void ConcatNode::validate(const Function& function) const {
+    TensorNode::validate(function);
+
+    auto& graph = this->get_parent();
+
+    if (graph.out_degree(*this) != 0) {
+        throw InvalidSDFGException("ConcatNode: Expected no outputs but got: " + std::to_string(graph.out_degree(*this)));
+    }
+
+    // Check that the tensor layouts match with the tensor types on the edges
+    const data_flow::Memlet* result_iedge = graph.in_edge_for_connector(*this, this->result());
+    if (!result_iedge) {
+        throw InvalidSDFGException("ConcatNode: No memlet connected at connector: " + this->result());
+    }
+    if (result_iedge->base_type().type_id() != types::TypeID::Tensor) {
+        throw InvalidSDFGException(
+            "ConcatNode: Expected tensor type at connector '" + this->result() +
+            "' but got: " + result_iedge->base_type().print()
+        );
+    }
+    const types::Tensor& result_tensor = static_cast<const types::Tensor&>(result_iedge->base_type());
+    if (result_tensor.layout() != this->result_layout_) {
+        throw InvalidSDFGException(
+            "ConcatNode: Provided tensor layout does not match the tensor type on the edge for connector '" +
+            this->result() + "': " + result_tensor.layout().toStr() + " != " + this->result_layout_.toStr()
+        );
+    }
+    for (long long i = 0; i < this->tensor_layouts_.size(); i++) {
+        const std::string& tensor = this->inputs_[i];
+        const data_flow::Memlet* tensor_iedge = graph.in_edge_for_connector(*this, tensor);
+        if (!tensor_iedge) {
+            throw InvalidSDFGException("ConcatNode: No memlet connected at connector: " + tensor);
+        }
+        if (tensor_iedge->base_type().type_id() != types::TypeID::Tensor) {
+            throw InvalidSDFGException(
+                "ConcatNode: Expected tensor type at connector '" + tensor +
+                "' but got: " + tensor_iedge->base_type().print()
+            );
+        }
+        const types::Tensor& tensor_tensor = static_cast<const types::Tensor&>(tensor_iedge->base_type());
+        if (tensor_tensor.layout() != this->tensor_layouts_[i]) {
+            throw InvalidSDFGException(
+                "ConcatNode: Provided tensor layout does not match the tensor type on the edge for connector '" +
+                tensor + "': " + tensor_tensor.layout().toStr() + " != " + this->tensor_layouts_[i].toStr()
+            );
+        }
+    }
+
+    // Check that the cat dimension is < the tensor layout dimensions
+    if (this->dim_ < 0 || this->dim_ >= this->result_layout_.dims()) {
+        throw InvalidSDFGException(
+            "ConcatNode: Cat dimension must be in [0, " + std::to_string(this->result_layout_.dims() - 1) +
+            "] but got: " + std::to_string(this->dim_)
+        );
+    }
+
+    // Check that all tensor layout have the same shape except in the cat dimension
+    symbolic::Expression cat_dim = symbolic::zero();
+    for (const TensorLayout& tensor_layout : this->tensor_layouts_) {
+        int dims = tensor_layout.dims();
+        if (dims != this->result_layout_.dims()) {
+            throw InvalidSDFGException(
+                "ConcatNode: Tensor layouts have different dimensions: " + tensor_layout.toStr() +
+                " != " + this->result_layout_.toStr()
+            );
+        }
+        for (long long i = 0; i < dims; i++) {
+            if (i == this->dim_) {
+                cat_dim = symbolic::add(cat_dim, tensor_layout.get_dim(i));
+                continue; // Skip the cat dimension
+            }
+            if (!symbolic::eq(tensor_layout.get_dim(i), this->result_layout_.get_dim(i))) {
+                throw InvalidSDFGException(
+                    "ConcatNode: Shapes do not match at position " + std::to_string(i) + ": " + tensor_layout.toStr() +
+                    " != " + this->result_layout_.toStr()
+                );
+            }
+        }
+    }
+    if (!symbolic::eq(cat_dim, this->result_layout_.get_dim(this->dim_))) {
+        throw InvalidSDFGException(
+            "ConcatNode: Cat dimension does not match with the sum of tensor dimensions: " + cat_dim->__str__() +
+            " != " + this->result_layout_.get_dim(this->dim_)->__str__()
+        );
+    }
+}
+
+bool ConcatNode::supports_integer_types() const { return true; }
+
+using Dir = passes::LibNodeExpander::InputUse;
+
+passes::LibNodeExpander::ExpandOutcome ConcatNode::
+    expand(passes::LibNodeExpander::ExpandContext& context, structured_control_flow::Block& block) {
+    std::vector<Dir> access_dirs(this->inputs_.size(), Dir::IndirectRead);
+    access_dirs.back() = Dir::IndirectWrite;
+    auto standalone = context.replacement_requires_access_nodes(access_dirs);
+
+    if (!standalone) {
+        return context.unable();
+    }
+
+    auto& builder = standalone->builder();
+
+    // Add a graph after the current block
+    auto& new_sequence = standalone->replace_with_sequence();
+
+    this->expand_naive(*standalone, builder, new_sequence);
+    // this->expand_separately(*standalone, builder, new_sequence);
+
+    return standalone->successfully_expanded();
+}
+
+std::string ConcatNode::toStr() const {
+    std::stringstream stream;
+    stream << "ConcatNode(" << this->result() << ": [";
+    for (long long i = 0; i < this->result_layout_.dims(); i++) {
+        if (i > 0) {
+            stream << ",";
+        }
+        stream << this->result_layout_.get_dim(i)->__str__();
+    }
+    stream << "], {";
+    for (long long i = 0; i < this->tensor_layouts_.size(); i++) {
+        if (i > 0) {
+            stream << ", ";
+        }
+        stream << this->inputs_[i] << ": [";
+        for (long long j = 0; j < this->tensor_layouts_[i].dims(); j++) {
+            if (j > 0) {
+                stream << ",";
+            }
+            stream << this->tensor_layouts_[i].get_dim(j)->__str__();
+        }
+        stream << "]";
+    }
+    stream << "}, dim: " << this->dim_ << ")";
+    return stream.str();
+}
+
+symbolic::SymbolSet ConcatNode::symbols() const {
+    symbolic::SymbolSet syms;
+    this->result_layout_.collect_symbols(syms);
+    for (const TensorLayout& tensor_layout : this->tensor_layouts_) {
+        tensor_layout.collect_symbols(syms);
+    }
+    return syms;
+}
+
+symbolic::Expression ConcatNode::flop() const { return symbolic::zero(); }
+
+std::unique_ptr<data_flow::DataFlowNode> ConcatNode::
+    clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent) const {
+    return std::make_unique<ConcatNode>(
+        element_id,
+        this->debug_info_,
+        vertex,
+        parent,
+        this->result(),
+        this->result_layout_,
+        this->tensors(),
+        this->tensor_layouts_,
+        this->dim_,
+        this->implementation_type_
+    );
+}
+
+void ConcatNode::replace(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {
+    this->result_layout_.replace_symbols(old_expression, new_expression);
+    for (TensorLayout& tensor_layout : this->tensor_layouts_) {
+        tensor_layout.replace_symbols(old_expression, new_expression);
+    }
+}
+
+void ConcatNode::replace(const symbolic::ExpressionMapping& replacements) {
+    this->result_layout_.replace_symbols(replacements);
+    for (TensorLayout& tensor_layout : this->tensor_layouts_) {
+        tensor_layout.replace_symbols(replacements);
+    }
+}
+
+nlohmann::json ConcatNodeSerializer::serialize(const data_flow::LibraryNode& library_node) {
+    const ConcatNode& concat_node = static_cast<const ConcatNode&>(library_node);
+    nlohmann::json j;
+
+    j["code"] = concat_node.code().value();
+
+    j["result"] = concat_node.result();
+    concat_node.result_layout().serialize_to_json(j["result_layout"]);
+
+    j["tensors"] = nlohmann::json::array();
+    for (std::string& tensor : concat_node.tensors()) {
+        j["tensors"].push_back(tensor);
+    }
+    j["tensor_layouts"] = nlohmann::json::array();
+    for (const TensorLayout& tensor_layout : concat_node.tensor_layouts()) {
+        nlohmann::json tensor_layout_j;
+        tensor_layout.serialize_to_json(tensor_layout_j);
+        j["tensor_layouts"].push_back(tensor_layout_j);
+    }
+
+    j["dim"] = concat_node.dim();
+
+    return j;
+}
+
+data_flow::LibraryNode& ConcatNodeSerializer::deserialize(
+    const nlohmann::json& j, builder::StructuredSDFGBuilder& builder, structured_control_flow::Block& parent
+) {
+    assert(j.contains("element_id"));
+    assert(j.contains("code"));
+    assert(j.contains("result"));
+    assert(j.contains("result_layout"));
+    assert(j.contains("tensors"));
+    assert(j.contains("tensor_layouts"));
+    assert(j.contains("dim"));
+    assert(j.contains("debug_info"));
+
+    std::string result = j.at("result").get<std::string>();
+    TensorLayout result_layout = TensorLayout::deserialize_from_json(j.at("result_layout"));
+
+    std::vector<std::string> tensors = j.at("tensors").get<std::vector<std::string>>();
+    std::vector<TensorLayout> tensor_layouts;
+    tensor_layouts.reserve(j.at("tensor_layouts").size());
+    for (long long i = 0; i < j.at("tensor_layouts").size(); i++) {
+        tensor_layouts.push_back(TensorLayout::deserialize_from_json(j.at("tensor_layouts").at(i)));
+    }
+
+    long long dim = j.at("dim").get<long long>();
+
+    sdfg::serializer::JSONSerializer serializer;
+    DebugInfo debug_info = serializer.json_to_debug_info(j.at("debug_info"));
+
+    return builder.add_library_node<ConcatNode>(parent, debug_info, result, result_layout, tensors, tensor_layouts, dim);
+}
+
+} // namespace tensor
+} // namespace math
+} // namespace sdfg

--- a/sdfg/src/data_flow/memlet.cpp
+++ b/sdfg/src/data_flow/memlet.cpp
@@ -473,6 +473,7 @@ void Memlet::replace(const symbolic::Expression old_expression, const symbolic::
         new_subset.push_back(symbolic::subs(dim, old_expression, new_expression));
     }
     this->subset_ = new_subset;
+    this->base_type_->replace_symbols(old_expression, new_expression);
 }
 
 void Memlet::replace(const symbolic::ExpressionMapping& replacements) {
@@ -481,7 +482,8 @@ void Memlet::replace(const symbolic::ExpressionMapping& replacements) {
         new_subset.push_back(SymEngine::subs(dim, replacements));
     }
     this->subset_ = new_subset;
-};
+    this->base_type_->replace_symbols(replacements);
+}
 
 } // namespace data_flow
 } // namespace sdfg

--- a/sdfg/src/serializer/json_serializer.cpp
+++ b/sdfg/src/serializer/json_serializer.cpp
@@ -1504,6 +1504,10 @@ void register_default_serializers() {
         .register_library_node_serializer(math::tensor::LibraryNodeType_TensorCopy.value(), []() {
             return std::make_unique<math::tensor::TensorCopyNodeSerializer>();
         });
+    LibraryNodeSerializerRegistry::instance()
+        .register_library_node_serializer(math::tensor::LibraryNodeType_TensorConcat.value(), []() {
+            return std::make_unique<math::tensor::ConcatNodeSerializer>();
+        });
 
     // Elementwise
     LibraryNodeSerializerRegistry::instance()

--- a/sdfg/src/types/array.cpp
+++ b/sdfg/src/types/array.cpp
@@ -41,5 +41,15 @@ std::unique_ptr<IType> Array::clone() const {
 
 std::string Array::print() const { return "Array(" + this->element_type_->print() + ")"; };
 
+void Array::replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {
+    this->element_type_->replace_symbols(old_expression, new_expression);
+    this->num_elements_ = symbolic::subs(this->num_elements_, old_expression, new_expression);
+}
+
+void Array::replace_symbols(const symbolic::ExpressionMapping& replacements) {
+    this->element_type_->replace_symbols(replacements);
+    this->num_elements_ = symbolic::subs(this->num_elements_, replacements);
+}
+
 } // namespace types
 } // namespace sdfg

--- a/sdfg/src/types/function.cpp
+++ b/sdfg/src/types/function.cpp
@@ -83,5 +83,19 @@ std::string Function::print() const {
     return "Function(" + this->return_type_->print() + ", " + params + ")";
 };
 
+void Function::replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {
+    for (size_t i = 0; i < this->num_params(); i++) {
+        this->params_[i]->replace_symbols(old_expression, new_expression);
+    }
+    this->return_type_->replace_symbols(old_expression, new_expression);
+}
+
+void Function::replace_symbols(const symbolic::ExpressionMapping& replacements) {
+    for (size_t i = 0; i < this->num_params(); i++) {
+        this->params_[i]->replace_symbols(replacements);
+    }
+    this->return_type_->replace_symbols(replacements);
+}
+
 } // namespace types
 } // namespace sdfg

--- a/sdfg/src/types/pointer.cpp
+++ b/sdfg/src/types/pointer.cpp
@@ -61,5 +61,17 @@ std::string Pointer::print() const {
     }
 };
 
+void Pointer::replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {
+    if (this->has_pointee_type()) {
+        this->pointee_type_->get()->replace_symbols(old_expression, new_expression);
+    }
+}
+
+void Pointer::replace_symbols(const symbolic::ExpressionMapping& replacements) {
+    if (this->has_pointee_type()) {
+        this->pointee_type_->get()->replace_symbols(replacements);
+    }
+}
+
 } // namespace types
 } // namespace sdfg

--- a/sdfg/src/types/structure.cpp
+++ b/sdfg/src/types/structure.cpp
@@ -84,5 +84,18 @@ const size_t StructureDefinition::vector_size() const {
     return this->num_members();
 }
 
+void StructureDefinition::
+    replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {
+    for (size_t i = 0; i < this->num_members(); i++) {
+        this->members_[i]->replace_symbols(old_expression, new_expression);
+    }
+}
+
+void StructureDefinition::replace_symbols(const symbolic::ExpressionMapping& replacements) {
+    for (size_t i = 0; i < this->num_members(); i++) {
+        this->members_[i]->replace_symbols(replacements);
+    }
+}
+
 } // namespace types
 } // namespace sdfg

--- a/sdfg/src/types/tensor.cpp
+++ b/sdfg/src/types/tensor.cpp
@@ -144,5 +144,15 @@ std::unique_ptr<Tensor> Tensor::reshape(const symbolic::MultiExpression& new_sha
     );
 }
 
+void Tensor::replace_symbols(const symbolic::Expression old_expression, const symbolic::Expression new_expression) {
+    this->element_type_->replace_symbols(old_expression, new_expression);
+    this->layout_.replace_symbols(old_expression, new_expression);
+}
+
+void Tensor::replace_symbols(const symbolic::ExpressionMapping& replacements) {
+    this->element_type_->replace_symbols(replacements);
+    this->layout_.replace_symbols(replacements);
+}
+
 } // namespace types
 } // namespace sdfg

--- a/sdfg/tests/CMakeLists.txt
+++ b/sdfg/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ set(TEST_FILES
     data_flow/library_nodes/math/cmath/cmath_node_test.cpp
     data_flow/library_nodes/math/tensor/batchnorm_test.cpp
     data_flow/library_nodes/math/tensor/cmath_node_test.cpp
+    data_flow/library_nodes/math/tensor/concat_node_test.cpp
     data_flow/library_nodes/math/tensor/conv_test.cpp
     data_flow/library_nodes/math/tensor/copy_node_test.cpp
     data_flow/library_nodes/math/tensor/einsum_test.cpp

--- a/sdfg/tests/data_flow/library_nodes/math/tensor/concat_node_test.cpp
+++ b/sdfg/tests/data_flow/library_nodes/math/tensor/concat_node_test.cpp
@@ -1,0 +1,490 @@
+#include "sdfg/data_flow/library_nodes/math/tensor/concat_node.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <nlohmann/json_fwd.hpp>
+
+#include "sdfg/analysis/analysis.h"
+#include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/tensor_layout.h"
+#include "sdfg/element.h"
+#include "sdfg/function.h"
+#include "sdfg/passes/expansion/library_node_expansion_pass.h"
+#include "sdfg/serializer/json_serializer.h"
+#include "sdfg/structured_sdfg.h"
+#include "sdfg/symbolic/symbolic.h"
+#include "sdfg/types/pointer.h"
+#include "sdfg/types/scalar.h"
+#include "sdfg/types/tensor.h"
+#include "sdfg/types/type.h"
+#include "sdfg_debug_dump.h"
+
+using namespace sdfg;
+
+TEST(ConcatNodeTest, symbolic) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    builder.add_container("A", desc, true);
+    builder.add_container("B", desc, true);
+    builder.add_container("C", desc, true);
+
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
+    builder.add_container("i", sym_desc);
+    builder.add_container("j", sym_desc);
+    builder.add_container("m", sym_desc);
+    auto i = symbolic::symbol("i");
+    auto j = symbolic::symbol("j");
+    auto m = symbolic::symbol("m");
+
+    math::tensor::TensorLayout A_layout({symbolic::integer(1), i, m});
+    types::Tensor A_tensor(base_desc, A_layout);
+    math::tensor::TensorLayout B_layout({symbolic::integer(1), j, m});
+    types::Tensor B_tensor(base_desc, B_layout);
+    math::tensor::TensorLayout C_layout({symbolic::integer(1), symbolic::add(i, j), m});
+    types::Tensor C_tensor(base_desc, C_layout);
+
+    auto& block = builder.add_block(root);
+    auto& A_access = builder.add_access(block, "A");
+    auto& B_access = builder.add_access(block, "B");
+    auto& C_access = builder.add_access(block, "C");
+    auto& libnode = builder.add_library_node<math::tensor::ConcatNode>(
+        block,
+        DebugInfo(),
+        "Y",
+        C_layout,
+        std::vector<std::string>({"X0", "X1"}),
+        std::vector<math::tensor::TensorLayout>({A_layout, B_layout}),
+        1
+    );
+    auto& A_edge = builder.add_computational_memlet(block, A_access, libnode, "X0", {}, A_tensor);
+    auto& B_edge = builder.add_computational_memlet(block, B_access, libnode, "X1", {}, B_tensor);
+    auto& C_edge = builder.add_computational_memlet(block, C_access, libnode, "Y", {}, C_tensor);
+
+    ASSERT_NO_THROW(sdfg.validate());
+
+    auto& concat_node = static_cast<math::tensor::ConcatNode&>(libnode);
+    auto symbols = concat_node.symbols();
+    EXPECT_EQ(symbols.size(), 3);
+    EXPECT_TRUE(symbols.contains(i));
+    EXPECT_TRUE(symbols.contains(j));
+    EXPECT_TRUE(symbols.contains(m));
+
+    builder.add_container("k", sym_desc);
+    builder.add_container("n", sym_desc);
+    auto k = symbolic::symbol("k");
+    auto n = symbolic::symbol("n");
+
+    builder.replace_symbols(i, k);
+
+    symbolic::ExpressionMapping mapping({{m, n}});
+    builder.replace_symbols(mapping);
+
+    ASSERT_NO_THROW(sdfg.validate());
+
+    symbols = concat_node.symbols();
+    EXPECT_EQ(symbols.size(), 3);
+    EXPECT_TRUE(symbols.contains(k));
+    EXPECT_TRUE(symbols.contains(j));
+    EXPECT_TRUE(symbols.contains(n));
+}
+
+TEST(ConcatNodeTest, expand) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    builder.add_container("A", desc, true);
+    builder.add_container("B", desc, true);
+    builder.add_container("C", desc, true);
+
+    math::tensor::TensorLayout A_layout({symbolic::integer(1), symbolic::integer(2), symbolic::integer(3)});
+    types::Tensor A_tensor(base_desc, A_layout);
+    math::tensor::TensorLayout B_layout({symbolic::integer(1), symbolic::integer(4), symbolic::integer(3)});
+    types::Tensor B_tensor(base_desc, B_layout);
+    math::tensor::TensorLayout C_layout({symbolic::integer(1), symbolic::integer(6), symbolic::integer(3)});
+    types::Tensor C_tensor(base_desc, C_layout);
+
+    auto& block = builder.add_block(root);
+    auto& A_access = builder.add_access(block, "A");
+    auto& B_access = builder.add_access(block, "B");
+    auto& C_access = builder.add_access(block, "C");
+    auto& libnode = builder.add_library_node<math::tensor::ConcatNode>(
+        block,
+        DebugInfo(),
+        "Y",
+        C_layout,
+        std::vector<std::string>({"X0", "X1"}),
+        std::vector<math::tensor::TensorLayout>({A_layout, B_layout}),
+        1
+    );
+    builder.add_computational_memlet(block, A_access, libnode, "X0", {}, A_tensor);
+    builder.add_computational_memlet(block, B_access, libnode, "X1", {}, B_tensor);
+    builder.add_computational_memlet(block, C_access, libnode, "Y", {}, C_tensor);
+
+    ASSERT_NO_THROW(sdfg.validate());
+    dump_sdfg(sdfg, "0.before");
+
+    analysis::AnalysisManager analysis_manager(sdfg);
+    passes::LibraryNodeExpansionPass expansion;
+    ASSERT_TRUE(expansion.run(builder, analysis_manager));
+    ASSERT_NO_THROW(sdfg.validate());
+    dump_sdfg(sdfg, "1.after");
+}
+
+TEST(ConcatNodeTest, serialization) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    builder.add_container("A", desc, true);
+    builder.add_container("B", desc, true);
+    builder.add_container("C", desc, true);
+
+    math::tensor::TensorLayout A_layout({symbolic::integer(1), symbolic::integer(2), symbolic::integer(3)});
+    types::Tensor A_tensor(base_desc, A_layout);
+    math::tensor::TensorLayout B_layout({symbolic::integer(1), symbolic::integer(4), symbolic::integer(3)});
+    types::Tensor B_tensor(base_desc, B_layout);
+    math::tensor::TensorLayout C_layout({symbolic::integer(1), symbolic::integer(6), symbolic::integer(3)});
+    types::Tensor C_tensor(base_desc, C_layout);
+
+    auto& block = builder.add_block(root);
+    auto& A_access = builder.add_access(block, "A");
+    auto& B_access = builder.add_access(block, "B");
+    auto& C_access = builder.add_access(block, "C");
+    auto& libnode = builder.add_library_node<math::tensor::ConcatNode>(
+        block,
+        DebugInfo(),
+        "Y",
+        C_layout,
+        std::vector<std::string>({"X0", "X1"}),
+        std::vector<math::tensor::TensorLayout>({A_layout, B_layout}),
+        1
+    );
+    builder.add_computational_memlet(block, A_access, libnode, "X0", {}, A_tensor);
+    builder.add_computational_memlet(block, B_access, libnode, "X1", {}, B_tensor);
+    builder.add_computational_memlet(block, C_access, libnode, "Y", {}, C_tensor);
+
+    ASSERT_NO_THROW(sdfg.validate());
+
+    serializer::JSONSerializer serializer;
+    nlohmann::json j;
+    ASSERT_NO_THROW(j = serializer.serialize(sdfg));
+
+    std::unique_ptr<StructuredSDFG> new_sdfg;
+    ASSERT_NO_THROW(new_sdfg = serializer.deserialize(j));
+}
+
+TEST(ConcatNodeTest, validate_tensor_type_result) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    builder.add_container("A", desc, true);
+    builder.add_container("B", desc, true);
+    builder.add_container("C", desc, true);
+
+    math::tensor::TensorLayout A_layout({symbolic::integer(1), symbolic::integer(2), symbolic::integer(3)});
+    types::Tensor A_tensor(base_desc, A_layout);
+    math::tensor::TensorLayout B_layout({symbolic::integer(1), symbolic::integer(4), symbolic::integer(3)});
+    types::Tensor B_tensor(base_desc, B_layout);
+    math::tensor::TensorLayout C_layout({symbolic::integer(1), symbolic::integer(6), symbolic::integer(3)});
+    types::Tensor C_tensor(base_desc, C_layout);
+
+    auto& block = builder.add_block(root);
+    auto& A_access = builder.add_access(block, "A");
+    auto& B_access = builder.add_access(block, "B");
+    auto& C_access = builder.add_access(block, "C");
+    auto& libnode = builder.add_library_node<math::tensor::ConcatNode>(
+        block,
+        DebugInfo(),
+        "Y",
+        C_layout,
+        std::vector<std::string>({"X0", "X1"}),
+        std::vector<math::tensor::TensorLayout>({A_layout, B_layout}),
+        1
+    );
+    builder.add_computational_memlet(block, A_access, libnode, "X0", {}, A_tensor);
+    builder.add_computational_memlet(block, B_access, libnode, "X1", {}, B_tensor);
+    builder.add_computational_memlet(block, C_access, libnode, "Y", {}, desc);
+
+    EXPECT_THROW(sdfg.validate(), InvalidSDFGException);
+}
+
+TEST(ConcatNodeTest, validate_tensor_type_input) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    builder.add_container("A", desc, true);
+    builder.add_container("B", desc, true);
+    builder.add_container("C", desc, true);
+
+    math::tensor::TensorLayout A_layout({symbolic::integer(1), symbolic::integer(2), symbolic::integer(3)});
+    types::Tensor A_tensor(base_desc, A_layout);
+    math::tensor::TensorLayout B_layout({symbolic::integer(1), symbolic::integer(4), symbolic::integer(3)});
+    types::Tensor B_tensor(base_desc, B_layout);
+    math::tensor::TensorLayout C_layout({symbolic::integer(1), symbolic::integer(6), symbolic::integer(3)});
+    types::Tensor C_tensor(base_desc, C_layout);
+
+    auto& block = builder.add_block(root);
+    auto& A_access = builder.add_access(block, "A");
+    auto& B_access = builder.add_access(block, "B");
+    auto& C_access = builder.add_access(block, "C");
+    auto& libnode = builder.add_library_node<math::tensor::ConcatNode>(
+        block,
+        DebugInfo(),
+        "Y",
+        C_layout,
+        std::vector<std::string>({"X0", "X1"}),
+        std::vector<math::tensor::TensorLayout>({A_layout, B_layout}),
+        1
+    );
+    builder.add_computational_memlet(block, A_access, libnode, "X0", {}, desc);
+    builder.add_computational_memlet(block, B_access, libnode, "X1", {}, B_tensor);
+    builder.add_computational_memlet(block, C_access, libnode, "Y", {}, C_tensor);
+
+    EXPECT_THROW(sdfg.validate(), InvalidSDFGException);
+}
+
+TEST(ConcatNodeTest, validate_tensor_layout_mismatch_result) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    builder.add_container("A", desc, true);
+    builder.add_container("B", desc, true);
+    builder.add_container("C", desc, true);
+
+    math::tensor::TensorLayout A_layout({symbolic::integer(1), symbolic::integer(2), symbolic::integer(3)});
+    types::Tensor A_tensor(base_desc, A_layout);
+    math::tensor::TensorLayout B_layout({symbolic::integer(1), symbolic::integer(4), symbolic::integer(3)});
+    types::Tensor B_tensor(base_desc, B_layout);
+    math::tensor::TensorLayout C_layout({symbolic::integer(1), symbolic::integer(6), symbolic::integer(3)});
+    types::Tensor C_tensor(base_desc, C_layout);
+
+    auto& block = builder.add_block(root);
+    auto& A_access = builder.add_access(block, "A");
+    auto& B_access = builder.add_access(block, "B");
+    auto& C_access = builder.add_access(block, "C");
+    auto& libnode = builder.add_library_node<math::tensor::ConcatNode>(
+        block,
+        DebugInfo(),
+        "Y",
+        C_layout,
+        std::vector<std::string>({"X0", "X1"}),
+        std::vector<math::tensor::TensorLayout>({A_layout, B_layout}),
+        1
+    );
+    builder.add_computational_memlet(block, A_access, libnode, "X0", {}, A_tensor);
+    builder.add_computational_memlet(block, B_access, libnode, "X1", {}, B_tensor);
+    builder.add_computational_memlet(block, C_access, libnode, "Y", {}, A_tensor);
+
+    EXPECT_THROW(sdfg.validate(), InvalidSDFGException);
+}
+
+TEST(ConcatNodeTest, validate_tensor_layout_mismatch_input) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    builder.add_container("A", desc, true);
+    builder.add_container("B", desc, true);
+    builder.add_container("C", desc, true);
+
+    math::tensor::TensorLayout A_layout({symbolic::integer(1), symbolic::integer(2), symbolic::integer(3)});
+    types::Tensor A_tensor(base_desc, A_layout);
+    math::tensor::TensorLayout B_layout({symbolic::integer(1), symbolic::integer(4), symbolic::integer(3)});
+    types::Tensor B_tensor(base_desc, B_layout);
+    math::tensor::TensorLayout C_layout({symbolic::integer(1), symbolic::integer(6), symbolic::integer(3)});
+    types::Tensor C_tensor(base_desc, C_layout);
+
+    auto& block = builder.add_block(root);
+    auto& A_access = builder.add_access(block, "A");
+    auto& B_access = builder.add_access(block, "B");
+    auto& C_access = builder.add_access(block, "C");
+    auto& libnode = builder.add_library_node<math::tensor::ConcatNode>(
+        block,
+        DebugInfo(),
+        "Y",
+        C_layout,
+        std::vector<std::string>({"X0", "X1"}),
+        std::vector<math::tensor::TensorLayout>({A_layout, B_layout}),
+        1
+    );
+    builder.add_computational_memlet(block, A_access, libnode, "X0", {}, C_tensor);
+    builder.add_computational_memlet(block, B_access, libnode, "X1", {}, B_tensor);
+    builder.add_computational_memlet(block, C_access, libnode, "Y", {}, C_tensor);
+
+    EXPECT_THROW(sdfg.validate(), InvalidSDFGException);
+}
+
+TEST(ConcatNodeTest, validate_dim) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    builder.add_container("A", desc, true);
+    builder.add_container("B", desc, true);
+    builder.add_container("C", desc, true);
+
+    math::tensor::TensorLayout A_layout({symbolic::integer(1), symbolic::integer(2), symbolic::integer(3)});
+    types::Tensor A_tensor(base_desc, A_layout);
+    math::tensor::TensorLayout B_layout({symbolic::integer(1), symbolic::integer(4), symbolic::integer(3)});
+    types::Tensor B_tensor(base_desc, B_layout);
+    math::tensor::TensorLayout C_layout({symbolic::integer(1), symbolic::integer(6), symbolic::integer(3)});
+    types::Tensor C_tensor(base_desc, C_layout);
+
+    auto& block = builder.add_block(root);
+    auto& A_access = builder.add_access(block, "A");
+    auto& B_access = builder.add_access(block, "B");
+    auto& C_access = builder.add_access(block, "C");
+    auto& libnode = builder.add_library_node<math::tensor::ConcatNode>(
+        block,
+        DebugInfo(),
+        "Y",
+        C_layout,
+        std::vector<std::string>({"X0", "X1"}),
+        std::vector<math::tensor::TensorLayout>({A_layout, B_layout}),
+        5
+    );
+    builder.add_computational_memlet(block, A_access, libnode, "X0", {}, A_tensor);
+    builder.add_computational_memlet(block, B_access, libnode, "X1", {}, B_tensor);
+    builder.add_computational_memlet(block, C_access, libnode, "Y", {}, C_tensor);
+
+    EXPECT_THROW(sdfg.validate(), InvalidSDFGException);
+}
+
+TEST(ConcatNodeTest, validate_wrong_dims) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    builder.add_container("A", desc, true);
+    builder.add_container("B", desc, true);
+    builder.add_container("C", desc, true);
+
+    math::tensor::TensorLayout A_layout({symbolic::integer(2), symbolic::integer(3)});
+    types::Tensor A_tensor(base_desc, A_layout);
+    math::tensor::TensorLayout B_layout({symbolic::integer(1), symbolic::integer(4), symbolic::integer(3)});
+    types::Tensor B_tensor(base_desc, B_layout);
+    math::tensor::TensorLayout C_layout({symbolic::integer(1), symbolic::integer(6), symbolic::integer(3)});
+    types::Tensor C_tensor(base_desc, C_layout);
+
+    auto& block = builder.add_block(root);
+    auto& A_access = builder.add_access(block, "A");
+    auto& B_access = builder.add_access(block, "B");
+    auto& C_access = builder.add_access(block, "C");
+    auto& libnode = builder.add_library_node<math::tensor::ConcatNode>(
+        block,
+        DebugInfo(),
+        "Y",
+        C_layout,
+        std::vector<std::string>({"X0", "X1"}),
+        std::vector<math::tensor::TensorLayout>({A_layout, B_layout}),
+        1
+    );
+    builder.add_computational_memlet(block, A_access, libnode, "X0", {}, A_tensor);
+    builder.add_computational_memlet(block, B_access, libnode, "X1", {}, B_tensor);
+    builder.add_computational_memlet(block, C_access, libnode, "Y", {}, C_tensor);
+
+    EXPECT_THROW(sdfg.validate(), InvalidSDFGException);
+}
+
+TEST(ConcatNodeTest, validate_dim_shape) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    builder.add_container("A", desc, true);
+    builder.add_container("B", desc, true);
+    builder.add_container("C", desc, true);
+
+    math::tensor::TensorLayout A_layout({symbolic::integer(1), symbolic::integer(3), symbolic::integer(3)});
+    types::Tensor A_tensor(base_desc, A_layout);
+    math::tensor::TensorLayout B_layout({symbolic::integer(1), symbolic::integer(4), symbolic::integer(3)});
+    types::Tensor B_tensor(base_desc, B_layout);
+    math::tensor::TensorLayout C_layout({symbolic::integer(1), symbolic::integer(6), symbolic::integer(3)});
+    types::Tensor C_tensor(base_desc, C_layout);
+
+    auto& block = builder.add_block(root);
+    auto& A_access = builder.add_access(block, "A");
+    auto& B_access = builder.add_access(block, "B");
+    auto& C_access = builder.add_access(block, "C");
+    auto& libnode = builder.add_library_node<math::tensor::ConcatNode>(
+        block,
+        DebugInfo(),
+        "Y",
+        C_layout,
+        std::vector<std::string>({"X0", "X1"}),
+        std::vector<math::tensor::TensorLayout>({A_layout, B_layout}),
+        1
+    );
+    builder.add_computational_memlet(block, A_access, libnode, "X0", {}, A_tensor);
+    builder.add_computational_memlet(block, B_access, libnode, "X1", {}, B_tensor);
+    builder.add_computational_memlet(block, C_access, libnode, "Y", {}, C_tensor);
+
+    EXPECT_THROW(sdfg.validate(), InvalidSDFGException);
+}
+
+TEST(ConcatNodeTest, validate_non_dim_shape) {
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc(base_desc);
+    builder.add_container("A", desc, true);
+    builder.add_container("B", desc, true);
+    builder.add_container("C", desc, true);
+
+    math::tensor::TensorLayout A_layout({symbolic::integer(1), symbolic::integer(2), symbolic::integer(3)});
+    types::Tensor A_tensor(base_desc, A_layout);
+    math::tensor::TensorLayout B_layout({symbolic::integer(2), symbolic::integer(4), symbolic::integer(3)});
+    types::Tensor B_tensor(base_desc, B_layout);
+    math::tensor::TensorLayout C_layout({symbolic::integer(1), symbolic::integer(6), symbolic::integer(3)});
+    types::Tensor C_tensor(base_desc, C_layout);
+
+    auto& block = builder.add_block(root);
+    auto& A_access = builder.add_access(block, "A");
+    auto& B_access = builder.add_access(block, "B");
+    auto& C_access = builder.add_access(block, "C");
+    auto& libnode = builder.add_library_node<math::tensor::ConcatNode>(
+        block,
+        DebugInfo(),
+        "Y",
+        C_layout,
+        std::vector<std::string>({"X0", "X1"}),
+        std::vector<math::tensor::TensorLayout>({A_layout, B_layout}),
+        1
+    );
+    builder.add_computational_memlet(block, A_access, libnode, "X0", {}, A_tensor);
+    builder.add_computational_memlet(block, B_access, libnode, "X1", {}, B_tensor);
+    builder.add_computational_memlet(block, C_access, libnode, "Y", {}, C_tensor);
+
+    EXPECT_THROW(sdfg.validate(), InvalidSDFGException);
+}

--- a/sdfg/tests/data_flow/library_nodes/math/tensor/copy_node_test.cpp
+++ b/sdfg/tests/data_flow/library_nodes/math/tensor/copy_node_test.cpp
@@ -1,8 +1,11 @@
 #include "sdfg/data_flow/library_nodes/math/tensor/copy_node.h"
 
-#include <gtest/gtest.h>
+#include <memory>
+#include <nlohmann/json_fwd.hpp>
 #include <utility>
 #include <vector>
+
+#include <gtest/gtest.h>
 
 #include "sdfg/analysis/analysis.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
@@ -12,9 +15,11 @@
 #include "sdfg/element.h"
 #include "sdfg/function.h"
 #include "sdfg/passes/expansion/library_node_expansion_pass.h"
+#include "sdfg/serializer/json_serializer.h"
 #include "sdfg/structured_control_flow/block.h"
 #include "sdfg/structured_control_flow/map.h"
 #include "sdfg/structured_control_flow/sequence.h"
+#include "sdfg/structured_sdfg.h"
 #include "sdfg/symbolic/symbolic.h"
 #include "sdfg/types/pointer.h"
 #include "sdfg/types/scalar.h"
@@ -426,4 +431,40 @@ TEST(TensorCopyNodeTest, reshape_from_one_big) {
          symbolic::mod(symbolic::div(i, e), d),
          symbolic::mod(i, e)}
     ));
+}
+
+TEST(TensorCopyNodeTest, serialization) {
+    auto a = symbolic::integer(2);
+    auto b = symbolic::integer(3);
+    math::tensor::TensorLayout layout_x({a, b});
+    math::tensor::TensorLayout layout_y({a, b});
+
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar base_type(types::PrimitiveType::Float);
+    types::Pointer desc_type(base_type);
+    builder.add_container("X", desc_type, true);
+    builder.add_container("Y", desc_type, true);
+
+    types::Tensor X_tensor(base_type, layout_x);
+    types::Tensor Y_tensor(base_type, layout_y);
+
+    auto& block = builder.add_block(root);
+    auto& X_access = builder.add_access(block, "X");
+    auto& Y_access = builder.add_access(block, "Y");
+    auto& libnode =
+        builder.add_library_node<math::tensor::TensorCopyNode>(block, sdfg::DebugInfo(), layout_x, layout_y);
+    builder.add_computational_memlet(block, X_access, libnode, "X", {}, X_tensor);
+    builder.add_computational_memlet(block, Y_access, libnode, "Y", {}, Y_tensor);
+
+    ASSERT_NO_THROW(sdfg.validate());
+
+    serializer::JSONSerializer serializer;
+    nlohmann::json j;
+    ASSERT_NO_THROW(j = serializer.serialize(sdfg));
+
+    std::unique_ptr<StructuredSDFG> new_sdfg;
+    ASSERT_NO_THROW(new_sdfg = serializer.deserialize(j));
 }


### PR DESCRIPTION
- Added a concat tensor node that concatenates arbitrarily many tensors
- Mapped `torch.ops.aten.cat.default` to concat tensor node
- Changed translation of `tensor.concat` MLIR op to concat tensor node instead of loop nest
- Added replace_symbols method to all types to replace symbols in types like the tensor type
- Added target specific expansion for concat tensor node to avoid branching on GPUs