### PR TITLE
Fixing outstanding issues, post AssignmentBlock change

### DIFF
--- a/llvm/integration/polybench_transfertuning_test.py
+++ b/llvm/integration/polybench_transfertuning_test.py
@@ -633,7 +633,7 @@ def test_2mm(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
     )
 
     transformation_verification = TransformationVerification(
-        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 7}}
+        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 6}}
     )
 
     test_case = benchmark_path / "2mm.c"
@@ -686,7 +686,7 @@ def test_3mm(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
     )
 
     transformation_verification = TransformationVerification(
-        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 8}}
+        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 7}}
     )
 
     test_case = benchmark_path / "3mm.c"
@@ -1138,7 +1138,7 @@ def test_lu(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
     )
 
     transformation_verification = TransformationVerification(
-        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 5}}
+        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 6}}
     )
 
     test_case = benchmark_path / "lu.c"

--- a/llvm/integration/polybench_transfertuning_test.py
+++ b/llvm/integration/polybench_transfertuning_test.py
@@ -633,7 +633,7 @@ def test_2mm(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
     )
 
     transformation_verification = TransformationVerification(
-        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 6}}
+        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 7}}
     )
 
     test_case = benchmark_path / "2mm.c"
@@ -686,7 +686,7 @@ def test_3mm(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
     )
 
     transformation_verification = TransformationVerification(
-        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 7}}
+        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 8}}
     )
 
     test_case = benchmark_path / "3mm.c"
@@ -738,7 +738,7 @@ def test_atax(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
     )
 
     transformation_verification = TransformationVerification(
-        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 4}}
+        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 5}}
     )
 
     test_case = benchmark_path / "atax.c"
@@ -796,7 +796,7 @@ def test_bicg(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
     )
 
     transformation_verification = TransformationVerification(
-        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 4}}
+        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 3}}
     )
 
     test_case = benchmark_path / "bicg.c"
@@ -910,7 +910,7 @@ def test_mvt(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
     )
 
     transformation_verification = TransformationVerification(
-        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 1}}
+        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 2}}
     )
 
     test_case = benchmark_path / "mvt.c"
@@ -968,7 +968,7 @@ def test_cholesky(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
     )
 
     transformation_verification = TransformationVerification(
-        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 6}}
+        {"RPCNodeTransform": {"loop_nests": {}, "tuned_loops": 7}}
     )
 
     test_case = benchmark_path / "cholesky.c"

--- a/opt/src/passes/scheduler/loop_scheduling_pass.cpp
+++ b/opt/src/passes/scheduler/loop_scheduling_pass.cpp
@@ -17,6 +17,9 @@ bool LoopSchedulingPass::run_pass_target(
     scheduler.set_report(report_);
     scheduler.set_recorder(recorder_);
 
+    UniqueLoopIndvars unique_indvar_pass;
+    unique_indvar_pass.run_pass(builder, analysis_manager);
+
     // ===== Phase 1: Find all applicable loops =====
     auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();
     auto& flop_analysis = analysis_manager.get<analysis::FlopAnalysis>();

--- a/sdfg/include/sdfg/serializer/json_serializer.h
+++ b/sdfg/include/sdfg/serializer/json_serializer.h
@@ -39,6 +39,8 @@ private:
 public:
     JSONSerializer(bool recurse = true) : recurse_(recurse) {}
 
+    bool skip_empty_transitions = false;
+
     virtual nlohmann::json serialize(
         const sdfg::StructuredSDFG& sdfg,
         analysis::AnalysisManager* analysis_manager = nullptr,

--- a/sdfg/src/codegen/code_generators/c_code_generator.cpp
+++ b/sdfg/src/codegen/code_generators/c_code_generator.cpp
@@ -152,6 +152,7 @@ void CCodeGenerator::dispatch_globals() {
 };
 
 void CCodeGenerator::dispatch_schedule() {
+    this->main_stream_.changeIndent(+4);
     // Allocate variables
     for (auto& container : sdfg_.containers()) {
         if (sdfg_.is_external(container)) {
@@ -218,6 +219,7 @@ void CCodeGenerator::dispatch_schedule() {
             }
         }
     }
+    this->main_stream_.changeIndent(-4);
 };
 
 } // namespace codegen

--- a/sdfg/src/codegen/code_generators/cpp_code_generator.cpp
+++ b/sdfg/src/codegen/code_generators/cpp_code_generator.cpp
@@ -166,6 +166,7 @@ void CPPCodeGenerator::dispatch_globals() {
 };
 
 void CPPCodeGenerator::dispatch_schedule() {
+    this->main_stream_.changeIndent(+4);
     // Allocate variables
     for (auto& container : sdfg_.containers()) {
         if (sdfg_.is_external(container)) {
@@ -233,6 +234,7 @@ void CPPCodeGenerator::dispatch_schedule() {
             }
         }
     }
+    this->main_stream_.changeIndent(-4);
 };
 
 } // namespace codegen

--- a/sdfg/src/serializer/json_serializer.cpp
+++ b/sdfg/src/serializer/json_serializer.cpp
@@ -744,8 +744,10 @@ void JSONSerializer::parse_legacy_transition_to_assignment_block(
 
     auto assignments = parse_assignments(assignments_arr);
 
-    auto& block = builder.add_assignments(parent, assignments, json_to_debug_info(j["debug_info"]));
-    block.element_id_ = j["element_id"];
+    if (!skip_empty_transitions || !assignments.empty()) {
+        auto& block = builder.add_assignments(parent, assignments, json_to_debug_info(j["debug_info"]));
+        block.element_id_ = j["element_id"];
+    }
 }
 
 void JSONSerializer::json_to_sequence(

--- a/sdfg/tests/codegen/code_generators/c_code_generator_test.cpp
+++ b/sdfg/tests/codegen/code_generators/c_code_generator_test.cpp
@@ -51,7 +51,7 @@ TEST(CCodeGeneratorTest, Allocation_Stack_Transient) {
     codegen::CCodeGenerator generator(*sdfg, analysis_manager, *instrumentation_plan, *arg_capture_plan);
     generator.generate();
     auto result = generator.main().str();
-    EXPECT_EQ(result, "long long t0;\n");
+    EXPECT_EQ(result, "    long long t0;\n");
 }
 
 TEST(CCodeGeneratorTest, Allocation_Heap_Argument_Managed) {
@@ -75,7 +75,7 @@ TEST(CCodeGeneratorTest, Allocation_Heap_Argument_Managed) {
     codegen::CCodeGenerator generator(*sdfg, analysis_manager, *instrumentation_plan, *arg_capture_plan);
     generator.generate();
     auto result = generator.main().str();
-    EXPECT_EQ(result, "arg0 = malloc(8);\nfree(arg0);\n");
+    EXPECT_EQ(result, "    arg0 = malloc(8);\n    free(arg0);\n");
 }
 
 TEST(CCodeGeneratorTest, Allocation_Heap_Transient_Managed) {
@@ -99,7 +99,7 @@ TEST(CCodeGeneratorTest, Allocation_Heap_Transient_Managed) {
     codegen::CCodeGenerator generator(*sdfg, analysis_manager, *instrumentation_plan, *arg_capture_plan);
     generator.generate();
     auto result = generator.main().str();
-    EXPECT_EQ(result, "long long *t0;\nt0 = malloc(8);\nfree(t0);\n");
+    EXPECT_EQ(result, "    long long *t0;\n    t0 = malloc(8);\n    free(t0);\n");
 }
 
 TEST(CCodeGeneratorTest, Allocation_Heap_Argument_Default_Lifetime) {
@@ -123,7 +123,7 @@ TEST(CCodeGeneratorTest, Allocation_Heap_Argument_Default_Lifetime) {
     codegen::CCodeGenerator generator(*sdfg, analysis_manager, *instrumentation_plan, *arg_capture_plan);
     generator.generate();
     auto result = generator.main().str();
-    EXPECT_EQ(result, "arg0 = malloc(8);\n");
+    EXPECT_EQ(result, "    arg0 = malloc(8);\n");
 }
 
 TEST(CCodeGeneratorTest, Allocation_Heap_Transient_Default_Lifetime) {
@@ -147,7 +147,7 @@ TEST(CCodeGeneratorTest, Allocation_Heap_Transient_Default_Lifetime) {
     codegen::CCodeGenerator generator(*sdfg, analysis_manager, *instrumentation_plan, *arg_capture_plan);
     generator.generate();
     auto result = generator.main().str();
-    EXPECT_EQ(result, "long long *t0;\nt0 = malloc(8);\n");
+    EXPECT_EQ(result, "    long long *t0;\n    t0 = malloc(8);\n");
 }
 
 TEST(CCodeGeneratorTest, Deallocation_Heap_Argument_SDFG_Lifetime) {
@@ -171,7 +171,7 @@ TEST(CCodeGeneratorTest, Deallocation_Heap_Argument_SDFG_Lifetime) {
     codegen::CCodeGenerator generator(*sdfg, analysis_manager, *instrumentation_plan, *arg_capture_plan);
     generator.generate();
     auto result = generator.main().str();
-    EXPECT_EQ(result, "free(arg0);\n");
+    EXPECT_EQ(result, "    free(arg0);\n");
 }
 
 TEST(CCodeGeneratorTest, DispatchStructures_Basic) {

--- a/sdfg/tests/data_flow/library_nodes/load_const_node_test.cpp
+++ b/sdfg/tests/data_flow/library_nodes/load_const_node_test.cpp
@@ -52,15 +52,15 @@ TEST(LoadConstNodeTest, BuildInMemory2Code) {
         "0x0, 0x0, 0xb8, 0x41};\n";
     EXPECT_EQ(codeGen.globals().str(), expected_def);
 
-    auto expected_main = R"a(void* result;
-{
-    float *_out;
+    auto expected_main = R"a(    void* result;
+    {
+        float *_out;
 
-    _out = const_cast<float *>(reinterpret_cast<const float *>(&daisy_load_const_2[0]));
+        _out = const_cast<float *>(reinterpret_cast<const float *>(&daisy_load_const_2[0]));
 
-    result = _out;
-}
-return result;
+        result = _out;
+    }
+    return result;
 )a";
     EXPECT_EQ(codeGen.main().str(), expected_main);
 }

--- a/targets/tenstorrent/src/tenstorrent/blas/gemm.cpp
+++ b/targets/tenstorrent/src/tenstorrent/blas/gemm.cpp
@@ -43,8 +43,7 @@ find_gemm_access_nodes(const data_flow::DataFlowGraph& dfg, const math::blas::GE
         ++in_edges_it;
     }
 
-    auto& out_edge = *dfg.out_edges(node).begin();
-    access_nodes[5] = dynamic_cast<const data_flow::AccessNode*>(&out_edge.dst());
+    access_nodes[5] = access_nodes.at(2);
 
     return access_nodes;
 }


### PR DESCRIPTION
 * Update transfertune verifiers
 * let c code gen indent the function contents, closer diff to old codegen
 * option for jsonSerializer to strip out empty Transitions on the fly (default off, but for quick debugging)
 * reenabled UniqueLoopIndvar. test_adv of npbench reuses the same indvar across loops and OmpScheduler is currently not safe for that