### PR TITLE
Add Support for Elementwise Logical_Not Ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ test_outputs/
 *.dot
 *.externals.json
 *.resolution.txt
+*.egg-info
 
 
 # Prerequisites

--- a/python/bindings/builder/py_structured_sdfg_builder.cpp
+++ b/python/bindings/builder/py_structured_sdfg_builder.cpp
@@ -18,6 +18,7 @@
 #include "sdfg/data_flow/library_nodes/math/tensor/einsum_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/cast_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/cmath_node.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/logical_not_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/tensor_node.h"
 #include "sdfg/data_flow/library_nodes/stdlib/free.h"
 #include "sdfg/data_flow/library_nodes/stdlib/malloc.h"
@@ -1239,6 +1240,8 @@ void PyStructuredSDFGBuilder::add_elementwise_unary_op(
         node = &builder_.add_library_node<sdfg::math::tensor::TanhNode>(block, debug_info, C_type.shape());
     } else if (op_type == "exp") {
         node = &builder_.add_library_node<sdfg::math::tensor::ExpNode>(block, debug_info, C_type.shape());
+    } else if (op_type == "logical_not") {
+        node = &builder_.add_library_node<sdfg::math::tensor::LogicalNotNode>(block, debug_info, C_type.shape());
     } else {
         throw std::runtime_error("Unsupported elementwise unary op: " + op_type);
     }

--- a/pytorch/docc/pytorch/graph_parser/elementwise.py
+++ b/pytorch/docc/pytorch/graph_parser/elementwise.py
@@ -64,6 +64,7 @@ class UnaryTensorOpParser(GraphParserModule):
 
 
 register_module("aten.abs.default", UnaryTensorOpParser("abs"))
+register_module("aten.logical_not.default", UnaryTensorOpParser("logical_not"))
 
 
 class UnaryCMathTensorOpParser(GraphParserModule):

--- a/pytorch/tests/ops/pointwise/test_logical.py
+++ b/pytorch/tests/ops/pointwise/test_logical.py
@@ -1,0 +1,30 @@
+import torch
+import torch.nn as nn
+
+from tests import check
+
+
+def test_logical_not_bool(target: str) -> None:
+    class PointwiseLogicalNotSimpleNet(nn.Module):
+        def forward(self, input: torch.Tensor) -> torch.Tensor:
+            return torch.logical_not(input)
+
+    check(
+        PointwiseLogicalNotSimpleNet(), torch.tensor([True, False, True]), target=target
+    )
+
+
+def test_logical_not_int(target: str) -> None:
+    class PointwiseLogicalNotSimpleNet(nn.Module):
+        def forward(self, input: torch.Tensor) -> torch.Tensor:
+            return torch.logical_not(input)
+
+    check(PointwiseLogicalNotSimpleNet(), torch.tensor([1, 0, 1]), target=target)
+
+
+def test_logical_not_float(target: str) -> None:
+    class PointwiseLogicalNotSimpleNet(nn.Module):
+        def forward(self, input: torch.Tensor) -> torch.Tensor:
+            return torch.logical_not(input)
+
+    check(PointwiseLogicalNotSimpleNet(), torch.tensor([1.0, 0.0, 1.0]), target=target)

--- a/sdfg/CMakeLists.txt
+++ b/sdfg/CMakeLists.txt
@@ -100,6 +100,7 @@ set(SOURCE_FILES
     src/data_flow/library_nodes/math/tensor/elementwise_ops/fill_node.cpp
     src/data_flow/library_nodes/math/tensor/elementwise_ops/hard_sigmoid_node.cpp
     src/data_flow/library_nodes/math/tensor/elementwise_ops/leaky_relu_node.cpp
+    src/data_flow/library_nodes/math/tensor/elementwise_ops/logical_not_node.cpp
     src/data_flow/library_nodes/math/tensor/elementwise_ops/maximum_node.cpp
     src/data_flow/library_nodes/math/tensor/elementwise_ops/minimum_node.cpp
     src/data_flow/library_nodes/math/tensor/elementwise_ops/mul_node.cpp

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/logical_not_node.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/logical_not_node.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "sdfg/data_flow/library_nodes/math/tensor/elementwise_node.h"
+
+#include "sdfg/codegen/dispatchers/block_dispatcher.h"
+#include "sdfg/serializer/json_serializer.h"
+
+namespace sdfg {
+namespace math {
+namespace tensor {
+
+inline data_flow::LibraryNodeCode LibraryNodeType_LogicalNot("ml::LogicalNot");
+
+class LogicalNotNode : public ElementWiseDataflowTensorNode {
+public:
+    LogicalNotNode(
+        size_t element_id,
+        const DebugInfo& debug_info,
+        const graph::Vertex vertex,
+        data_flow::DataFlowGraph& parent,
+        const std::vector<symbolic::Expression>& shape,
+        QuantizationType quantization = QUANTIZATION_MATCH_INPUTS,
+        const data_flow::ImplementationType& impl_type = data_flow::ImplementationType_NONE
+    );
+
+    ElementOutput expand_operation_dataflow(
+        builder::StructuredSDFGBuilder& builder,
+        Block& block,
+        std::vector<ElementInput>& needed_inputs,
+        types::PrimitiveType expected_type
+    ) override;
+
+    bool supports_integer_types() const override { return true; }
+
+    void validate(const Function& function) const override;
+
+    std::unique_ptr<data_flow::DataFlowNode>
+    clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent) const override;
+};
+
+typedef SimpleElementWiseDataflowTensorNodeSerializer<LogicalNotNode> LogicalNotNodeSerializer;
+
+} // namespace tensor
+} // namespace math
+} // namespace sdfg

--- a/sdfg/src/data_flow/library_nodes/math/tensor/elementwise_ops/logical_not_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/elementwise_ops/logical_not_node.cpp
@@ -1,0 +1,75 @@
+#include "sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/logical_not_node.h"
+
+#include "sdfg/analysis/analysis.h"
+#include "sdfg/builder/structured_sdfg_builder.h"
+
+#include "sdfg/data_flow/access_node.h"
+#include "sdfg/data_flow/library_nodes/math/cmath/cmath_node.h"
+#include "sdfg/types/type.h"
+
+namespace sdfg {
+namespace math {
+namespace tensor {
+
+LogicalNotNode::LogicalNotNode(
+    size_t element_id,
+    const DebugInfo& debug_info,
+    const graph::Vertex vertex,
+    data_flow::DataFlowGraph& parent,
+    const std::vector<symbolic::Expression>& shape,
+    QuantizationType quantization,
+    const data_flow::ImplementationType& impl_type
+)
+    : ElementWiseDataflowTensorNode(
+          element_id, debug_info, vertex, parent, LibraryNodeType_LogicalNot, shape, "Y", {"X"}, quantization, impl_type
+      ) {}
+
+ElementWiseDataflowTensorNode::ElementOutput LogicalNotNode::expand_operation_dataflow(
+    builder::StructuredSDFGBuilder& builder,
+    Block& block,
+    std::vector<ElementInput>& needed_inputs,
+    types::PrimitiveType expected_type
+) {
+    auto input_type = needed_inputs.at(0).required_type;
+    // baseline for logical_not is to use a tasklet with a comparison to 0, which will yield 1 for false and 0 for true
+    auto& const_0 = builder.add_constant(block, "0", types::Scalar(input_type), this->debug_info());
+
+    data_flow::TaskletCode tasklet_code;
+    if (types::is_integer(input_type)) {
+        tasklet_code = data_flow::TaskletCode::int_eq;
+    } else if (types::is_floating_point(input_type)) {
+        tasklet_code = data_flow::TaskletCode::fp_oeq;
+    } else {
+        throw InvalidSDFGException(&"LogicalNotNode: Unsupported expected type for expand_operation_dataflow: "
+                                       [*types::primitive_type_to_string(input_type)]);
+    }
+
+    auto& tasklet = builder.add_tasklet(block, tasklet_code, "_out", {"_in0", "_in1"}, this->debug_info());
+    builder.add_computational_memlet(block, const_0, tasklet, "_in1", {}, types::Scalar(input_type), this->debug_info());
+    auto& input = needed_inputs.at(0);
+    input.consumer = &tasklet;
+    input.input_conn_index = 0;
+
+    return {.producer = &tasklet, .output_conn_index = 0, .type = types::PrimitiveType::Bool};
+}
+
+void LogicalNotNode::validate(const Function& function) const {
+    auto& graph = this->get_parent();
+
+    validate_target_tensor(graph);
+
+    validate_all_input_tensors(graph);
+
+    validate_non_tensor_inputs(graph);
+}
+
+std::unique_ptr<data_flow::DataFlowNode> LogicalNotNode::
+    clone(size_t element_id, const graph::Vertex vertex, data_flow::DataFlowGraph& parent) const {
+    return std::unique_ptr<data_flow::DataFlowNode>(new LogicalNotNode(
+        element_id, this->debug_info(), vertex, parent, this->shape_, fixed_quantization_, implementation_type_
+    ));
+}
+
+} // namespace tensor
+} // namespace math
+} // namespace sdfg

--- a/sdfg/src/serializer/json_serializer.cpp
+++ b/sdfg/src/serializer/json_serializer.cpp
@@ -11,6 +11,7 @@
 #include "sdfg/data_flow/library_nodes/invoke_node.h"
 #include "sdfg/data_flow/library_nodes/math/math.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/cmath_node.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/logical_not_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/tasklet_node.h"
 #include "sdfg/data_flow/library_nodes/metadata_node.h"
 #include "sdfg/data_flow/library_nodes/stdlib/stdlib.h"
@@ -1558,6 +1559,10 @@ void register_default_serializers() {
     LibraryNodeSerializerRegistry::instance()
         .register_library_node_serializer(math::tensor::LibraryNodeType_LeakyReLU.value(), []() {
             return std::make_unique<math::tensor::LeakyReLUNodeSerializer>();
+        });
+    LibraryNodeSerializerRegistry::instance()
+        .register_library_node_serializer(math::tensor::LibraryNodeType_LogicalNot.value(), []() {
+            return std::make_unique<math::tensor::LogicalNotNodeSerializer>();
         });
     LibraryNodeSerializerRegistry::instance()
         .register_library_node_serializer(math::tensor::LibraryNodeType_Mul.value(), []() {

--- a/sdfg/tests/data_flow/library_nodes/math/tensor/elementwise_test.cpp
+++ b/sdfg/tests/data_flow/library_nodes/math/tensor/elementwise_test.cpp
@@ -12,6 +12,7 @@
 #include "sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/exp_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/hard_sigmoid_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/leaky_relu_node.h"
+#include "sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/logical_not_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/mul_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/pow_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/relu_node.h"
@@ -424,3 +425,120 @@ REGISTER_CAST_TEST(Int64, Int32, 1)
 REGISTER_CAST_TEST(Int64, Int32, 2)
 REGISTER_CAST_TEST(Int64, Int32, 3)
 REGISTER_CAST_TEST(Int64, Int32, 4)
+
+// LogicalNot tests - input of arbitrary type, Bool output
+template<types::PrimitiveType SourceType>
+void TestLogicalNot(std::vector<size_t> shape_dims) {
+    builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+
+    types::Scalar source_desc(SourceType);
+    types::Scalar bool_desc(types::PrimitiveType::Bool);
+    types::Pointer source_ptr(source_desc);
+    types::Pointer bool_ptr(bool_desc);
+
+    builder.add_container("a", source_ptr);
+    builder.add_container("b", bool_ptr);
+
+    auto& block = builder.add_block(sdfg.root());
+
+    auto& a_node = builder.add_access(block, "a");
+    auto& b_node = builder.add_access(block, "b");
+
+    std::vector<symbolic::Expression> shape;
+    for (auto d : shape_dims) {
+        shape.push_back(symbolic::integer(d));
+    }
+    types::Tensor tensor_type_source(SourceType, shape);
+    types::Tensor tensor_type_bool(types::PrimitiveType::Bool, shape);
+
+    auto& node = static_cast<math::tensor::LogicalNotNode&>(builder.add_library_node<
+                                                            math::tensor::LogicalNotNode>(block, DebugInfo(), shape));
+
+    builder.add_computational_memlet(block, a_node, node, "X", {}, tensor_type_source, block.debug_info());
+    builder.add_computational_memlet(block, b_node, node, "Y", {}, tensor_type_bool, block.debug_info());
+
+    sdfg.validate();
+    auto outcome = passes::expansion::expand_single_math_node(builder, block, node);
+    EXPECT_TRUE(outcome.expanded);
+    EXPECT_TRUE(outcome.block_removed);
+
+    auto& new_sequence = dyn_cast<structured_control_flow::Sequence&>(sdfg.root().at(0));
+
+    // Navigate to the innermost map
+    structured_control_flow::Sequence* current_scope = &new_sequence;
+    for (size_t i = 0; i < shape_dims.size(); ++i) {
+        auto map_loop = dyn_cast<structured_control_flow::Map*>(&current_scope->at(0));
+        ASSERT_NE(map_loop, nullptr);
+        current_scope = &map_loop->root();
+    }
+
+    auto code_block = dyn_cast<structured_control_flow::Block*>(&current_scope->at(0));
+    ASSERT_NE(code_block, nullptr);
+
+    // Check that the block is not empty (contains either tasklets or library nodes)
+    bool has_content = !code_block->dataflow().tasklets().empty() || !code_block->dataflow().library_nodes().empty();
+    EXPECT_TRUE(has_content) << "Inner block is empty for LogicalNotNode";
+
+    data_flow::DataFlowNode* inner_node = nullptr;
+    if (!code_block->dataflow().library_nodes().empty()) {
+        inner_node = *code_block->dataflow().library_nodes().begin();
+    } else if (!code_block->dataflow().tasklets().empty()) {
+        inner_node = *code_block->dataflow().tasklets().begin();
+    }
+    ASSERT_NE(inner_node, nullptr);
+
+    auto& dataflow = inner_node->get_parent();
+
+    // Check input edges
+    for (auto& edge : dataflow.in_edges(*inner_node)) {
+        if (dynamic_cast<data_flow::ConstantNode*>(&edge.src()) != nullptr) {
+            continue; // Skip constant nodes
+        }
+        if (auto* src_access = dynamic_cast<data_flow::AccessNode*>(&edge.src())) {
+            if (src_access->data() == "a") {
+                EXPECT_EQ(edge.subset().size(), shape_dims.size())
+                    << "Input subset size is not " << shape_dims.size() << " for LogicalNotNode";
+                EXPECT_EQ(edge.result_type(sdfg)->primitive_type(), SourceType);
+            }
+        }
+    }
+
+    // Check output edges
+    for (auto& edge : dataflow.out_edges(*inner_node)) {
+        if (auto* dst_access = dynamic_cast<data_flow::AccessNode*>(&edge.dst())) {
+            if (dst_access->data() == "b") {
+                EXPECT_EQ(edge.subset().size(), shape_dims.size())
+                    << "Output subset size is not " << shape_dims.size() << " for LogicalNotNode";
+                EXPECT_EQ(edge.result_type(sdfg)->primitive_type(), types::PrimitiveType::Bool);
+            }
+        }
+    }
+}
+
+#define REGISTER_LOGICAL_NOT_TEST(SourceType, Dim)                  \
+    TEST(ElementWiseTest, LogicalNotNode_##SourceType##_##Dim##D) { \
+        std::vector<size_t> dims;                                   \
+        for (int i = 0; i < Dim; ++i) dims.push_back(32);           \
+        TestLogicalNot<types::PrimitiveType::SourceType>(dims);     \
+    }
+
+REGISTER_LOGICAL_NOT_TEST(Bool, 1)
+REGISTER_LOGICAL_NOT_TEST(Bool, 2)
+REGISTER_LOGICAL_NOT_TEST(Bool, 3)
+REGISTER_LOGICAL_NOT_TEST(Bool, 4)
+
+REGISTER_LOGICAL_NOT_TEST(Int32, 1)
+REGISTER_LOGICAL_NOT_TEST(Int32, 2)
+REGISTER_LOGICAL_NOT_TEST(Int32, 3)
+REGISTER_LOGICAL_NOT_TEST(Int32, 4)
+
+REGISTER_LOGICAL_NOT_TEST(Float, 1)
+REGISTER_LOGICAL_NOT_TEST(Float, 2)
+REGISTER_LOGICAL_NOT_TEST(Float, 3)
+REGISTER_LOGICAL_NOT_TEST(Float, 4)
+
+REGISTER_LOGICAL_NOT_TEST(Double, 1)
+REGISTER_LOGICAL_NOT_TEST(Double, 2)
+REGISTER_LOGICAL_NOT_TEST(Double, 3)
+REGISTER_LOGICAL_NOT_TEST(Double, 4)


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill out this template to help reviewers
understand your changes. Remove sections that are not relevant.
-->

## Description
Adds a new library node for logical not operations on integers and floats. 
Adds support for the aten.logical_not operation to the pytorch frontend.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal change (no functional change)
- [ ] Documentation update

## Quality Checklist
*Please ensure the following are completed before requesting review:*

* [x] Runtime-compatible (no externally visible existing method has its parameters changed, was deleted or has its exception behavior changed)
* [x] Compile-time compatible (new arguments & properties added have default values, but users need to recompile against the new version to work)

IR:
* [x] Introduces new types into the SDFG IR
* [ ]  Changed / added properties on SDFG IR Elements (LibraryNodes, ControlFlowNodes DataFlowNodes etc.)
  *  [ ] New / modified types have serialization / deserialization support
  *  [ ] Deserialization is backward compatible (new serialization can deserialize old format and represent it in the new format if applicable)
  *  [ ] Serialized format is backward compatible (previous deserializer can read new serialized format without incorrectness (just lacking additional guarantees that are optional or did not exist before)
  *  [ ] Serializer has an option to emit the previous format

### Unit Tests
- [x] New unit tests have been added for the changes.
- [x] Existing unit tests pass locally.
- [x] Edge cases and error paths are covered.

### Integration Tests
- [x] New integration tests have been added (or existing ones updated).
- [x] Integration tests pass locally.
- [ ] Interactions with other components/services are verified.

### Documentation
- [ ] Public APIs, options, and behavior changes are documented.
- [ ] README / docs site / inline comments updated where applicable.
- [ ] Changelog / release notes updated (if applicable).

### Test Coverage
- [ ] Test coverage has not decreased as a result of this change.
- [ ] Coverage report reviewed and acceptable.
- [ ] Critical / new code paths are covered.

## How Has This Been Tested?
Describe the tests you ran to verify your changes and provide instructions to reproduce.
Include relevant details for your test configuration (OS, Python/LLVM/Docc version, hardware/target).

## Additional Context
Add any other context about the PR here (design decisions, trade-offs, follow-ups).
