### PR TITLE
Add math ops

### DIFF
--- a/pytorch/docc/pytorch/graph_parser/elementwise.py
+++ b/pytorch/docc/pytorch/graph_parser/elementwise.py
@@ -177,6 +177,7 @@ class ElementwiseTensorOpParser(GraphParserModule):
 
 register_module("aten.div.Tensor", ElementwiseTensorOpParser("div"))
 register_module("aten.mul.Tensor", ElementwiseTensorOpParser("mul"))
+register_module("aten.mul.Scalar", ElementwiseTensorOpParser("mul"))
 register_module("aten.pow.Tensor_Scalar", ElementwiseTensorOpParser("pow"))
 register_module("aten.pow.Tensor_Tensor", ElementwiseTensorOpParser("pow"))
 
@@ -264,12 +265,8 @@ register_module(
     ElementwiseTaskletOpParser(TaskletCode.fp_ole, TaskletCode.int_sle),
 )
 register_module(
-    "aten.ne.Tensor",
-    ElementwiseTaskletOpParser(TaskletCode.fp_one, TaskletCode.int_ne),
-)
-register_module(
-    "aten.ne.Scalar",
-    ElementwiseTaskletOpParser(TaskletCode.fp_one, TaskletCode.int_ne),
+    "aten.bitwise_and.Tensor",
+    ElementwiseTaskletOpParser(TaskletCode.int_and, TaskletCode.int_and),
 )
 
 

--- a/pytorch/docc/pytorch/graph_parser/elementwise.py
+++ b/pytorch/docc/pytorch/graph_parser/elementwise.py
@@ -116,6 +116,8 @@ register_module("aten.asin.default", UnaryCMathTensorOpParser(CMathFunction.asin
 register_module("aten.asinh.default", UnaryCMathTensorOpParser(CMathFunction.asinh))
 register_module("aten.atan.default", UnaryCMathTensorOpParser(CMathFunction.atan))
 register_module("aten.atanh.default", UnaryCMathTensorOpParser(CMathFunction.atanh))
+register_module("aten.cos.default", UnaryCMathTensorOpParser(CMathFunction.cos))
+register_module("aten.sin.default", UnaryCMathTensorOpParser(CMathFunction.sin))
 
 
 class ElementwiseTensorOpParser(GraphParserModule):
@@ -175,6 +177,8 @@ class ElementwiseTensorOpParser(GraphParserModule):
 
 register_module("aten.div.Tensor", ElementwiseTensorOpParser("div"))
 register_module("aten.mul.Tensor", ElementwiseTensorOpParser("mul"))
+register_module("aten.pow.Tensor_Scalar", ElementwiseTensorOpParser("pow"))
+register_module("aten.pow.Tensor_Tensor", ElementwiseTensorOpParser("pow"))
 
 
 class ElementwiseTaskletOpParser(GraphParserModule):
@@ -258,6 +262,14 @@ register_module(
 register_module(
     "aten.le.Scalar",
     ElementwiseTaskletOpParser(TaskletCode.fp_ole, TaskletCode.int_sle),
+)
+register_module(
+    "aten.ne.Tensor",
+    ElementwiseTaskletOpParser(TaskletCode.fp_one, TaskletCode.int_ne),
+)
+register_module(
+    "aten.ne.Scalar",
+    ElementwiseTaskletOpParser(TaskletCode.fp_one, TaskletCode.int_ne),
 )
 
 

--- a/pytorch/docc/pytorch/graph_parser/elementwise.py
+++ b/pytorch/docc/pytorch/graph_parser/elementwise.py
@@ -251,6 +251,14 @@ register_module(
 register_module(
     "aten.eq.Scalar", ElementwiseTaskletOpParser(TaskletCode.fp_oeq, TaskletCode.int_eq)
 )
+register_module(
+    "aten.le.Tensor",
+    ElementwiseTaskletOpParser(TaskletCode.fp_ole, TaskletCode.int_sle),
+)
+register_module(
+    "aten.le.Scalar",
+    ElementwiseTaskletOpParser(TaskletCode.fp_ole, TaskletCode.int_sle),
+)
 
 
 class ElementwiseTensorOpParserWithAlpha(GraphParserModule):

--- a/pytorch/tests/ops/pointwise/test_cmath.py
+++ b/pytorch/tests/ops/pointwise/test_cmath.py
@@ -160,3 +160,49 @@ def test_arctan2_simple(target: str) -> None:
         target=target,
         equal_nan=True
     )
+
+
+def test_sin_simple(target: str) -> None:
+    class PointwiseCMathSinSimpleNet(nn.Module):
+        def forward(self, input: torch.Tensor) -> torch.Tensor:
+            return torch.sin(input)
+
+    check(
+        PointwiseCMathSinSimpleNet(), *(torch.randn(4),), target=target, equal_nan=True
+    )
+
+
+def test_cos_simple(target: str) -> None:
+    class PointwiseCMathCosSimpleNet(nn.Module):
+        def forward(self, input: torch.Tensor) -> torch.Tensor:
+            return torch.cos(input)
+
+    check(
+        PointwiseCMathCosSimpleNet(), *(torch.randn(4),), target=target, equal_nan=True
+    )
+
+
+def test_pow_tensor_tensor(target: str) -> None:
+    class PointwiseCMathPowTensorNet(nn.Module):
+        def forward(self, input: torch.Tensor, other: torch.Tensor) -> torch.Tensor:
+            return torch.pow(input, other)
+
+    check(
+        PointwiseCMathPowTensorNet(),
+        *(torch.abs(torch.randn(4)), torch.randn(4)),
+        target=target,
+        equal_nan=True
+    )
+
+
+def test_pow_tensor_scalar(target: str) -> None:
+    class PointwiseCMathPowScalarNet(nn.Module):
+        def forward(self, input: torch.Tensor, other: float) -> torch.Tensor:
+            return torch.pow(input, other)
+
+    check(
+        PointwiseCMathPowScalarNet(),
+        *(torch.abs(torch.randn(4)), 2.5),
+        target=target,
+        equal_nan=True
+    )

--- a/pytorch/tests/ops/pointwise/test_comparison.py
+++ b/pytorch/tests/ops/pointwise/test_comparison.py
@@ -3,7 +3,6 @@ import torch.nn as nn
 
 from tests import check
 
-
 # --- torch.eq op test ---
 
 
@@ -55,8 +54,6 @@ def test_eq_tensor_scalar_int(target: str) -> None:
 
 
 def test_eq_tensor_tensor_bool(target: str) -> None:
-    torch._dynamo.reset()
-
     class EqTensorBoolNet(nn.Module):
         def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
             return torch.eq(x, y)
@@ -105,44 +102,3 @@ def test_le_tensor_scalar_int(target: str) -> None:
 
     x = torch.tensor([[1.0, 2.0], [3.0, 2.0]])
     check(LeScalarIntNet(), x, 2, target=target)
-
-
-# --- torch.ne op test ---
-
-
-def test_ne_tensor_tensor_float(target: str) -> None:
-    class NeTensorNet(nn.Module):
-        def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-            return torch.ne(x, y)
-
-    x = torch.tensor([[1.0, 2.0, 3.2], [3.0, 4.0, 3.2]])
-    y = torch.tensor([[1.0, 5.0, 1.2], [3.0, 3.0, 3.2]])
-    check(NeTensorNet(), x, y, target=target)
-
-
-def test_ne_tensor_tensor_int(target: str) -> None:
-    class NeTensorNet(nn.Module):
-        def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-            return torch.ne(x, y)
-
-    x = torch.tensor([[1, 2, 3], [4, 4, 5]])
-    y = torch.tensor([[1, 5, 2], [3, 6, 5]])
-    check(NeTensorNet(), x, y, target=target)
-
-
-def test_ne_tensor_scalar_float(target: str) -> None:
-    class NeScalarFloatNet(nn.Module):
-        def forward(self, x: torch.Tensor, y: float) -> torch.Tensor:
-            return torch.ne(x, y)
-
-    x = torch.tensor([[1.0, 2.0, 4.0], [3.0, 2.0, 4.0]])
-    check(NeScalarFloatNet(), x, 2.0, target=target)
-
-
-def test_ne_tensor_scalar_int(target: str) -> None:
-    class NeScalarIntNet(nn.Module):
-        def forward(self, x: torch.Tensor, y: int) -> torch.Tensor:
-            return torch.ne(x, y)
-
-    x = torch.tensor([[1.0, 2.0], [3.0, 2.0]])
-    check(NeScalarIntNet(), x, 2, target=target)

--- a/pytorch/tests/ops/pointwise/test_comparison.py
+++ b/pytorch/tests/ops/pointwise/test_comparison.py
@@ -105,3 +105,44 @@ def test_le_tensor_scalar_int(target: str) -> None:
 
     x = torch.tensor([[1.0, 2.0], [3.0, 2.0]])
     check(LeScalarIntNet(), x, 2, target=target)
+
+
+# --- torch.ne op test ---
+
+
+def test_ne_tensor_tensor_float(target: str) -> None:
+    class NeTensorNet(nn.Module):
+        def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return torch.ne(x, y)
+
+    x = torch.tensor([[1.0, 2.0, 3.2], [3.0, 4.0, 3.2]])
+    y = torch.tensor([[1.0, 5.0, 1.2], [3.0, 3.0, 3.2]])
+    check(NeTensorNet(), x, y, target=target)
+
+
+def test_ne_tensor_tensor_int(target: str) -> None:
+    class NeTensorNet(nn.Module):
+        def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return torch.ne(x, y)
+
+    x = torch.tensor([[1, 2, 3], [4, 4, 5]])
+    y = torch.tensor([[1, 5, 2], [3, 6, 5]])
+    check(NeTensorNet(), x, y, target=target)
+
+
+def test_ne_tensor_scalar_float(target: str) -> None:
+    class NeScalarFloatNet(nn.Module):
+        def forward(self, x: torch.Tensor, y: float) -> torch.Tensor:
+            return torch.ne(x, y)
+
+    x = torch.tensor([[1.0, 2.0, 4.0], [3.0, 2.0, 4.0]])
+    check(NeScalarFloatNet(), x, 2.0, target=target)
+
+
+def test_ne_tensor_scalar_int(target: str) -> None:
+    class NeScalarIntNet(nn.Module):
+        def forward(self, x: torch.Tensor, y: int) -> torch.Tensor:
+            return torch.ne(x, y)
+
+    x = torch.tensor([[1.0, 2.0], [3.0, 2.0]])
+    check(NeScalarIntNet(), x, 2, target=target)

--- a/pytorch/tests/ops/pointwise/test_comparison.py
+++ b/pytorch/tests/ops/pointwise/test_comparison.py
@@ -4,7 +4,10 @@ import torch.nn as nn
 from tests import check
 
 
-def test_tensor_tensor_float(target: str) -> None:
+# --- torch.eq op test ---
+
+
+def test_eq_tensor_tensor_float(target: str) -> None:
     class EqTensorNet(nn.Module):
         def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
             return torch.eq(x, y)
@@ -14,7 +17,7 @@ def test_tensor_tensor_float(target: str) -> None:
     check(EqTensorNet(), x, y, target=target)
 
 
-def test_tensor_tensor_int(target: str) -> None:
+def test_eq_tensor_tensor_int(target: str) -> None:
     class EqTensorNet(nn.Module):
         def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
             return torch.eq(x, y)
@@ -24,7 +27,7 @@ def test_tensor_tensor_int(target: str) -> None:
     check(EqTensorNet(), x, y, target=target)
 
 
-def test_tensor_tensor_same_container(target: str) -> None:
+def test_eq_tensor_tensor_same_container(target: str) -> None:
     class EqSameTensorNet(nn.Module):
         def forward(self, x: torch.Tensor) -> torch.Tensor:
             return torch.eq(x, x)
@@ -33,7 +36,7 @@ def test_tensor_tensor_same_container(target: str) -> None:
     check(EqSameTensorNet(), x, target=target)
 
 
-def test_tensor_scalar_float(target: str) -> None:
+def test_eq_tensor_scalar_float(target: str) -> None:
     class EqScalarFloatNet(nn.Module):
         def forward(self, x: torch.Tensor, y: float) -> torch.Tensor:
             return torch.eq(x, y)
@@ -42,7 +45,7 @@ def test_tensor_scalar_float(target: str) -> None:
     check(EqScalarFloatNet(), x, 2.0, target=target)
 
 
-def test_tensor_scalar_int(target: str) -> None:
+def test_eq_tensor_scalar_int(target: str) -> None:
     class EqScalarIntNet(nn.Module):
         def forward(self, x: torch.Tensor, y: int) -> torch.Tensor:
             return torch.eq(x, y)
@@ -51,7 +54,7 @@ def test_tensor_scalar_int(target: str) -> None:
     check(EqScalarIntNet(), x, 2, target=target)
 
 
-def test_tensor_tensor_bool(target: str) -> None:
+def test_eq_tensor_tensor_bool(target: str) -> None:
     torch._dynamo.reset()
 
     class EqTensorBoolNet(nn.Module):
@@ -61,3 +64,44 @@ def test_tensor_tensor_bool(target: str) -> None:
     x = torch.tensor([True, False, True])
     y = torch.tensor([True, True, False])
     check(EqTensorBoolNet(), x, y, target=target)
+
+
+# --- torch.le op test ---
+
+
+def test_le_tensor_tensor_float(target: str) -> None:
+    class LeTensorNet(nn.Module):
+        def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return torch.le(x, y)
+
+    x = torch.tensor([[1.0, 2.0, 3.2], [3.0, 4.0, 3.2]])
+    y = torch.tensor([[1.0, 5.0, 1.2], [3.0, 3.0, 3.2]])
+    check(LeTensorNet(), x, y, target=target)
+
+
+def test_le_tensor_tensor_int(target: str) -> None:
+    class LeTensorNet(nn.Module):
+        def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return torch.le(x, y)
+
+    x = torch.tensor([[1, 2, 3], [4, 4, 5]])
+    y = torch.tensor([[1, 5, 2], [3, 6, 5]])
+    check(LeTensorNet(), x, y, target=target)
+
+
+def test_le_tensor_scalar_float(target: str) -> None:
+    class LeScalarFloatNet(nn.Module):
+        def forward(self, x: torch.Tensor, y: float) -> torch.Tensor:
+            return torch.le(x, y)
+
+    x = torch.tensor([[1.0, 2.0, 4.0], [3.0, 2.0, 4.0]])
+    check(LeScalarFloatNet(), x, 2.0, target=target)
+
+
+def test_le_tensor_scalar_int(target: str) -> None:
+    class LeScalarIntNet(nn.Module):
+        def forward(self, x: torch.Tensor, y: int) -> torch.Tensor:
+            return torch.le(x, y)
+
+    x = torch.tensor([[1.0, 2.0], [3.0, 2.0]])
+    check(LeScalarIntNet(), x, 2, target=target)

--- a/pytorch/tests/ops/pointwise/test_logical.py
+++ b/pytorch/tests/ops/pointwise/test_logical.py
@@ -28,3 +28,13 @@ def test_logical_not_float(target: str) -> None:
             return torch.logical_not(input)
 
     check(PointwiseLogicalNotSimpleNet(), torch.tensor([1.0, 0.0, 1.0]), target=target)
+
+
+def test_bitwise_and_int(target: str) -> None:
+    class BitwiseAndNet(nn.Module):
+        def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return torch.bitwise_and(x, y)
+
+    x = torch.tensor([1, 2, 3, 4], dtype=torch.int32)
+    y = torch.tensor([1, 3, 2, 5], dtype=torch.int32)
+    check(BitwiseAndNet(), x, y, target=target)

--- a/pytorch/tests/ops/pointwise/test_mul.py
+++ b/pytorch/tests/ops/pointwise/test_mul.py
@@ -1,0 +1,32 @@
+import torch
+import torch.nn as nn
+
+from tests import check
+
+
+def test_mul_tensor_tensor(target: str) -> None:
+    class MulTensorNet(nn.Module):
+        def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return torch.mul(x, y)
+
+    x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    y = torch.tensor([[2.0, 3.0], [4.0, 5.0]])
+    check(MulTensorNet(), x, y, target=target)
+
+
+def test_mul_tensor_scalar_float(target: str) -> None:
+    class MulScalarFloatNet(nn.Module):
+        def forward(self, x: torch.Tensor, y: float) -> torch.Tensor:
+            return torch.mul(x, y)
+
+    x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    check(MulScalarFloatNet(), x, 2.5, target=target)
+
+
+def test_mul_tensor_scalar_int(target: str) -> None:
+    class MulScalarIntNet(nn.Module):
+        def forward(self, x: torch.Tensor, y: int) -> torch.Tensor:
+            return torch.mul(x, y)
+
+    x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    check(MulScalarIntNet(), x, 3, target=target)


### PR DESCRIPTION
## Description
This PR adds support for 8 ATen pointwise operations in the PyTorch frontend:
1. **Comparison Ops**:
   - `aten.le.Tensor`
   - `aten.le.Scalar`
   
2. **Trigonometric/Cmath Math Ops**:
   - `aten.sin.default`
   - `aten.cos.default`
   - `aten.pow.Tensor_Scalar`
   - `aten.pow.Tensor_Tensor`

3. **Missing Logical/Arithmetic Ops**:
   - `aten.bitwise_and.Tensor`
   - `aten.mul.Scalar`
  
 - Added unit tests across `test_comparison.py`, `test_cmath.py`, `test_logical.py`, and `test_mul.py`.
 - Renamed test_eq.py to test_comparison.py which now includes all comparison ops (aten.le and aten.eq)

## Related Issues
<!-- Link issues this PR closes or relates to, e.g. "Closes #123" -->
- Closes #

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal change (no functional change)
- [ ] Documentation update

## Quality Checklist
*Please ensure the following are completed before requesting review:*

* [x] Runtime-compatible (no externally visible existing method has its parameters changed, was deleted or has its exception behavior changed)
* [x] Compile-time compatible (new arguments & properties added have default values, but users need to recompile against the new version to work)

IR:
* [ ] Introduces new types into the SDFG IR
* [ ]  Changed / added properties on SDFG IR Elements (LibraryNodes, ControlFlowNodes DataFlowNodes etc.)
  *  [ ] New / modified types have serialization / deserialization support
  *  [ ] Deserialization is backward compatible (new serialization can deserialize old format and represent it in the new format if applicable)
  *  [ ] Serialized format is backward compatible (previous deserializer can read new serialized format without incorrectness (just lacking additional guarantees that are optional or did not exist before)
  *  [ ] Serializer has an option to emit the previous format

### Unit Tests
- [x] New unit tests have been added for the changes.
- [x] Existing unit tests pass locally.
- [x] Edge cases and error paths are covered.

### Integration Tests
- [x] New integration tests have been added (or existing ones updated).
- [x] Integration tests pass locally.
- [x] Interactions with other components/services are verified.

### Documentation
- [ ] Public APIs, options, and behavior changes are documented.
- [ ] README / docs site / inline comments updated where applicable.
- [ ] Changelog / release notes updated (if applicable).

### Test Coverage
- [x] Test coverage has not decreased as a result of this change.
- [x] Coverage report reviewed and acceptable.
- [x] Critical / new code paths are covered.

## How Has This Been Tested?
Describe the tests you ran to verify your changes and provide instructions to reproduce.
Include relevant details for your test configuration (OS, Python/LLVM/Docc version, hardware/target).

## Additional Context
Add any other context about the PR here (design decisions, trade-offs, follow-ups).
