### PR TITLE
Disallow Imperfect Collapse and Nested Parallelism with Data Dependencies

### DIFF
--- a/opt/include/sdfg/passes/normalization/normalization.h
+++ b/opt/include/sdfg/passes/normalization/normalization.h
@@ -17,8 +17,8 @@ inline passes::Pipeline loop_normalization() {
     passes::Pipeline pipeline("Loop Normalization");
 
     // Register passes for loop normalization
-    pipeline.register_pass<normalization::PerfectLoopDistributionPass>();
-    pipeline.register_pass<normalization::StrideMinimization>();
+    // pipeline.register_pass<normalization::PerfectLoopDistributionPass>();
+    // pipeline.register_pass<normalization::StrideMinimization>();
 
     return pipeline;
 }

--- a/opt/include/sdfg/passes/normalization/normalization.h
+++ b/opt/include/sdfg/passes/normalization/normalization.h
@@ -17,8 +17,8 @@ inline passes::Pipeline loop_normalization() {
     passes::Pipeline pipeline("Loop Normalization");
 
     // Register passes for loop normalization
-    // pipeline.register_pass<normalization::PerfectLoopDistributionPass>();
-    // pipeline.register_pass<normalization::StrideMinimization>();
+    pipeline.register_pass<normalization::PerfectLoopDistributionPass>();
+    pipeline.register_pass<normalization::StrideMinimization>();
 
     return pipeline;
 }

--- a/opt/include/sdfg/targets/gpu/gpu_map_utils.h
+++ b/opt/include/sdfg/targets/gpu/gpu_map_utils.h
@@ -94,6 +94,35 @@ template<typename ScheduleT>
 std::vector<structured_control_flow::Map*>
 get_gpu_maps(structured_control_flow::Map& node, analysis::AnalysisManager& analysis_manager, GPUDimension dimension);
 
+/**
+ * @brief Whether parallelizing @p loop to a new GPU grid dimension would replicate a
+ *        sibling accumulation that races on a shared container.
+ *
+ * Adding a grid dimension for @p loop folds the whole enclosing GPU kernel into a
+ * single flattened launch: only @p loop 's own subtree is guarded by the new
+ * dimension's thread id, so every sibling of @p loop (and of its ancestors up to the
+ * outermost GPU map) is re-executed by every thread of the new dimension. A sibling
+ * that merely stores is idempotent under this replication, but a read-modify-write -
+ * an accumulation/reduction such as `acc[i] += x` - folds its update in once per
+ * replicated thread and races on the shared buffer.
+ *
+ * The accumulation is a hazard only when its target escapes the kernel (a function
+ * argument/external or a transient that lives outside, per ArgumentsAnalysis); a
+ * container confined to the kernel is privatized per thread and races nothing. A
+ * sibling that is itself a GPU map is exempt: it is already parallelized, so codegen
+ * maps it onto its own threads instead of replicating it.
+ *
+ * This helper is schedule-agnostic (a map is "parallelized" iff its schedule is not
+ * Sequential), so it serves both the CUDA and ROCm nested-map transformations.
+ *
+ * @param loop The sequential map that a nested-parallelization transform wants to promote.
+ * @param analysis_manager Analysis manager (LoopAnalysis, Users, ArgumentsAnalysis).
+ * @return true if a replicated sibling would perform an unsafe accumulation.
+ */
+bool nested_parallelization_replicates_accumulation(
+    structured_control_flow::Map& loop, analysis::AnalysisManager& analysis_manager
+);
+
 // Extern template declarations to prevent implicit instantiation
 extern template symbolic::Expression find_nested_gpu_blocksize<
     cuda::ScheduleType_CUDA>(structured_control_flow::Map&, analysis::AnalysisManager&, GPUDimension);

--- a/opt/include/sdfg/transformations/map_collapse.h
+++ b/opt/include/sdfg/transformations/map_collapse.h
@@ -48,9 +48,14 @@ class MapCollapse : public Transformation {
     ///
     /// The collapse is therefore rejected only for hazards replication cannot
     /// resolve: a container written by a collapsible map and accessed by any other
-    /// body element (its writes vary across the inner index), or a write-write
-    /// conflict between two different body elements on the same container.
-    bool check_imperfect(analysis::AnalysisManager& analysis_manager);
+    /// body element (its writes vary across the inner index), a write-write
+    /// conflict between two different body elements on the same container, or a
+    /// skipped element that performs a read-modify-write (e.g. a reduction
+    /// accumulator) that cannot be safely recomputed by every replicated inner
+    /// thread. A skipped element that merely stores a value - even to a function
+    /// argument, and even if the value is read again in the nest - is idempotent
+    /// under replication and remains allowed.
+    bool check_imperfect(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager);
 
     /// @brief Whether a direct-child map can participate in the flattened
     /// iteration space (contiguous, closed-form bound independent of the outer

--- a/opt/include/sdfg/transformations/map_collapse.h
+++ b/opt/include/sdfg/transformations/map_collapse.h
@@ -51,10 +51,11 @@ class MapCollapse : public Transformation {
     /// body element (its writes vary across the inner index), a write-write
     /// conflict between two different body elements on the same container, or a
     /// skipped element that performs a read-modify-write (e.g. a reduction
-    /// accumulator) that cannot be safely recomputed by every replicated inner
-    /// thread. A skipped element that merely stores a value - even to a function
-    /// argument, and even if the value is read again in the nest - is idempotent
-    /// under replication and remains allowed.
+    /// accumulator) on a container that escapes the loop. A read-modify-write on a
+    /// local (a container whose lifetime is confined to the loop, as reported by
+    /// ArgumentsAnalysis) is privatized per thread and does not violate parallel
+    /// access, so it - like a plain store, even to a function argument - remains
+    /// allowed.
     bool check_imperfect(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager);
 
     /// @brief Whether a direct-child map can participate in the flattened

--- a/opt/include/sdfg/transformations/map_collapse.h
+++ b/opt/include/sdfg/transformations/map_collapse.h
@@ -56,7 +56,7 @@ class MapCollapse : public Transformation {
     /// ArgumentsAnalysis) is privatized per thread and does not violate parallel
     /// access, so it - like a plain store, even to a function argument - remains
     /// allowed.
-    bool check_imperfect(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager);
+    bool check_imperfect(analysis::AnalysisManager& analysis_manager);
 
     /// @brief Whether a direct-child map can participate in the flattened
     /// iteration space (contiguous, closed-form bound independent of the outer

--- a/opt/src/targets/gpu/gpu_map_utils.cpp
+++ b/opt/src/targets/gpu/gpu_map_utils.cpp
@@ -1,7 +1,13 @@
 #include "sdfg/targets/gpu/gpu_map_utils.h"
 
+#include <string>
+#include <unordered_set>
+
+#include "sdfg/analysis/arguments_analysis.h"
 #include "sdfg/analysis/assumptions_analysis.h"
 #include "sdfg/analysis/loop_analysis.h"
+#include "sdfg/analysis/users.h"
+#include "sdfg/structured_control_flow/sequence.h"
 #include "sdfg/targets/cuda/cuda.h"
 #include "sdfg/targets/rocm/rocm.h"
 
@@ -158,6 +164,108 @@ get_gpu_maps(structured_control_flow::Map& node, analysis::AnalysisManager& anal
     }
     return maps;
 }
+
+bool nested_parallelization_replicates_accumulation(
+    structured_control_flow::Map& loop, analysis::AnalysisManager& analysis_manager
+) {
+    auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();
+
+    // The outermost enclosing GPU map is the kernel scope. Everything below it is
+    // folded into a single flattened launch, so adding a dimension for `loop`
+    // replicates its siblings (and the siblings of any ancestor up to this map)
+    // across the new dimension's threads.
+    auto is_parallelized = [](structured_control_flow::Map* map) {
+        return map->schedule_type().value() != structured_control_flow::ScheduleType_Sequential::value();
+    };
+
+    structured_control_flow::Map* outermost = nullptr;
+    for (auto* ancestor = loop_analysis.parent_loop(&loop); ancestor != nullptr;
+         ancestor = loop_analysis.parent_loop(ancestor)) {
+        if (auto* map = dyn_cast<structured_control_flow::Map*>(ancestor)) {
+            if (is_parallelized(map)) {
+                outermost = map;
+            }
+        }
+    }
+    if (outermost == nullptr) {
+        // No enclosing GPU map: nothing is folded, hence nothing is replicated.
+        return false;
+    }
+
+    auto& users = analysis_manager.get<analysis::Users>();
+    auto& arguments_analysis = analysis_manager.get<analysis::ArgumentsAnalysis>();
+    // Containers whose entire lifetime is confined to the kernel are privatized per
+    // thread (registers/stack, per-thread allocation), so a read-modify-write on one
+    // races nothing. Only an accumulation on a container that escapes the kernel
+    // (function argument/external or a transient living outside) is a hazard. Loop
+    // induction variables are locals by definition, so this subsumes loop-control
+    // bookkeeping without any special-casing.
+    const auto& locals = arguments_analysis.locals(analysis_manager, *outermost);
+    auto is_local = [&locals](const std::string& container) { return locals.count(container) != 0; };
+
+    // A subtree performs an unsafe accumulation if it reads and writes the same
+    // non-local container (e.g. `acc[i] += x`). A plain store is idempotent under
+    // replication and therefore allowed.
+    auto accumulates_on_shared = [&](structured_control_flow::ControlFlowNode& node) {
+        analysis::UsersView view(users, node);
+        std::unordered_set<std::string> writes;
+        std::unordered_set<std::string> reads;
+        for (auto* u : view.writes()) {
+            writes.insert(u->container());
+        }
+        for (auto* u : view.moves()) {
+            writes.insert(u->container());
+        }
+        // Views alias memory; treat conservatively as both a read and a write.
+        for (auto* u : view.views()) {
+            writes.insert(u->container());
+            reads.insert(u->container());
+        }
+        for (auto* u : view.reads()) {
+            reads.insert(u->container());
+        }
+        for (const auto& container : writes) {
+            if (reads.count(container) != 0 && !is_local(container)) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    // Walk from `loop` up to (but excluding) the outermost GPU map, inspecting the
+    // siblings at each level. Siblings above the kernel are not replicated and are
+    // therefore not considered.
+    structured_control_flow::ControlFlowNode* node = &loop;
+    while (node != outermost) {
+        auto* sequence = dynamic_cast<structured_control_flow::Sequence*>(node->get_parent());
+        if (sequence == nullptr) {
+            break;
+        }
+        for (size_t i = 0; i < sequence->size(); ++i) {
+            auto& sibling = sequence->at(i);
+            if (&sibling == node) {
+                continue;
+            }
+            // A sibling that is itself a GPU map is already parallelized: codegen maps
+            // it onto its own threads, so its accumulation is not replicated.
+            if (auto* sibling_map = dyn_cast<structured_control_flow::Map*>(&sibling)) {
+                if (is_parallelized(sibling_map)) {
+                    continue;
+                }
+            }
+            if (accumulates_on_shared(sibling)) {
+                return true;
+            }
+        }
+        node = sequence->get_parent();
+        if (node == nullptr) {
+            break;
+        }
+    }
+
+    return false;
+}
+
 
 // Explicit template instantiations for CUDA
 template symbolic::Expression find_nested_gpu_blocksize<cuda::ScheduleType_CUDA>(

--- a/opt/src/transformations/map_collapse.cpp
+++ b/opt/src/transformations/map_collapse.cpp
@@ -4,6 +4,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "sdfg/analysis/arguments_analysis.h"
 #include "sdfg/analysis/users.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
 #include "sdfg/structured_control_flow/if_else.h"
@@ -186,42 +187,31 @@ bool MapCollapse::check_imperfect(builder::StructuredSDFGBuilder& /*builder*/, a
     //     container: ordering across threads is no longer guaranteed.
     auto& users = analysis_manager.get<analysis::Users>();
 
-    // Loop-control accesses (a for/map loop's init, condition and update on its own
-    // induction variable) are not data hazards: the induction variable is loop-local
-    // and privatized, so every replicated inner thread runs the loop over its own copy.
-    // Counting the indvar's init/update as a "write" and the condition/update as a
-    // "read" would otherwise make every skipped loop look like a read-modify-write and
-    // reject an otherwise safe collapse. Skip these ForUser bookkeeping accesses.
-    auto is_loop_control = [](analysis::User* u) { return dynamic_cast<analysis::ForUser*>(u) != nullptr; };
+    // Containers whose entire lifetime is confined to the outer map are locals: they
+    // are not function arguments/externals and are not used outside this region, so
+    // codegen privatizes them per thread when the collapsed map is parallelized. A
+    // loop induction variable is the canonical example, which is why the indvar's
+    // loop-control accesses need no special handling here - they are simply locals.
+    auto& arguments_analysis = analysis_manager.get<analysis::ArgumentsAnalysis>();
+    const auto& locals = arguments_analysis.locals(analysis_manager, loop_);
+    auto is_local = [&locals](const std::string& container) { return locals.count(container) != 0; };
 
     std::vector<std::unordered_set<std::string>> writes(n);
     std::vector<std::unordered_set<std::string>> reads(n);
     for (size_t idx = 0; idx < n; ++idx) {
         analysis::UsersView view(users, body.at(idx));
         for (auto* u : view.writes()) {
-            if (is_loop_control(u)) {
-                continue;
-            }
             writes[idx].insert(u->container());
         }
         for (auto* u : view.moves()) {
-            if (is_loop_control(u)) {
-                continue;
-            }
             writes[idx].insert(u->container());
         }
         // Views alias memory; treat conservatively as both a read and a write.
         for (auto* u : view.views()) {
-            if (is_loop_control(u)) {
-                continue;
-            }
             writes[idx].insert(u->container());
             reads[idx].insert(u->container());
         }
         for (auto* u : view.reads()) {
-            if (is_loop_control(u)) {
-                continue;
-            }
             reads[idx].insert(u->container());
         }
     }
@@ -239,18 +229,20 @@ bool MapCollapse::check_imperfect(builder::StructuredSDFGBuilder& /*builder*/, a
     // skipped element (e.g. an argument that is not read in the nest) is safe and
     // must be allowed.
     //
-    // The one update replication cannot reproduce is a *read-modify-write*: if a
-    // skipped element reads a container it also writes (e.g. a reduction
-    // accumulator), every replicated inner thread re-runs the update on the shared
-    // buffer, racing and folding the contribution in multiple times. That is only
-    // safe if the container's lifetime were restricted to a single (privatizable)
-    // iteration, so it is rejected here.
+    // The one update replication cannot reproduce is a *read-modify-write* on a
+    // *shared* container: if a skipped element reads a container it also writes (e.g. a
+    // reduction accumulator), every replicated inner thread re-runs the update on the
+    // same buffer, racing and folding the contribution in multiple times. This only
+    // matters for containers that escape the loop (function arguments/externals or
+    // transients live outside the region): a local is privatized per thread, so its
+    // read-modify-write happens on a private copy and does not violate parallel access
+    // or interleaving. Reject only a read-modify-write on a non-local container.
     for (size_t idx = 0; idx < n; ++idx) {
         if (is_collapsible[idx]) {
             continue;
         }
         for (const auto& container : writes[idx]) {
-            if (reads[idx].count(container) != 0) {
+            if (reads[idx].count(container) != 0 && !is_local(container)) {
                 return false;
             }
         }

--- a/opt/src/transformations/map_collapse.cpp
+++ b/opt/src/transformations/map_collapse.cpp
@@ -32,7 +32,7 @@ bool MapCollapse::can_be_applied(builder::StructuredSDFGBuilder& builder, analys
     }
 
     // Imperfect (CUDA-style) collapse is performed one level at a time.
-    if (count_ == 2 && this->check_imperfect(builder, analysis_manager)) {
+    if (count_ == 2 && this->check_imperfect(analysis_manager)) {
         return true;
     }
 
@@ -126,7 +126,7 @@ bool MapCollapse::is_collapsible_inner_map(structured_control_flow::Map& map, co
     return true;
 }
 
-bool MapCollapse::check_imperfect(builder::StructuredSDFGBuilder& /*builder*/, analysis::AnalysisManager& analysis_manager) {
+bool MapCollapse::check_imperfect(analysis::AnalysisManager& analysis_manager) {
     // The outer map must itself be collapsible (contiguous, closed-form bound
     // that does not depend on its own induction variable).
     auto outer_indvar = loop_.indvar();

--- a/opt/src/transformations/map_collapse.cpp
+++ b/opt/src/transformations/map_collapse.cpp
@@ -31,7 +31,7 @@ bool MapCollapse::can_be_applied(builder::StructuredSDFGBuilder& builder, analys
     }
 
     // Imperfect (CUDA-style) collapse is performed one level at a time.
-    if (count_ == 2 && this->check_imperfect(analysis_manager)) {
+    if (count_ == 2 && this->check_imperfect(builder, analysis_manager)) {
         return true;
     }
 
@@ -125,7 +125,7 @@ bool MapCollapse::is_collapsible_inner_map(structured_control_flow::Map& map, co
     return true;
 }
 
-bool MapCollapse::check_imperfect(analysis::AnalysisManager& analysis_manager) {
+bool MapCollapse::check_imperfect(builder::StructuredSDFGBuilder& /*builder*/, analysis::AnalysisManager& analysis_manager) {
     // The outer map must itself be collapsible (contiguous, closed-form bound
     // that does not depend on its own induction variable).
     auto outer_indvar = loop_.indvar();
@@ -186,23 +186,73 @@ bool MapCollapse::check_imperfect(analysis::AnalysisManager& analysis_manager) {
     //     container: ordering across threads is no longer guaranteed.
     auto& users = analysis_manager.get<analysis::Users>();
 
+    // Loop-control accesses (a for/map loop's init, condition and update on its own
+    // induction variable) are not data hazards: the induction variable is loop-local
+    // and privatized, so every replicated inner thread runs the loop over its own copy.
+    // Counting the indvar's init/update as a "write" and the condition/update as a
+    // "read" would otherwise make every skipped loop look like a read-modify-write and
+    // reject an otherwise safe collapse. Skip these ForUser bookkeeping accesses.
+    auto is_loop_control = [](analysis::User* u) { return dynamic_cast<analysis::ForUser*>(u) != nullptr; };
+
     std::vector<std::unordered_set<std::string>> writes(n);
     std::vector<std::unordered_set<std::string>> reads(n);
     for (size_t idx = 0; idx < n; ++idx) {
         analysis::UsersView view(users, body.at(idx));
         for (auto* u : view.writes()) {
+            if (is_loop_control(u)) {
+                continue;
+            }
             writes[idx].insert(u->container());
         }
         for (auto* u : view.moves()) {
+            if (is_loop_control(u)) {
+                continue;
+            }
             writes[idx].insert(u->container());
         }
         // Views alias memory; treat conservatively as both a read and a write.
         for (auto* u : view.views()) {
+            if (is_loop_control(u)) {
+                continue;
+            }
             writes[idx].insert(u->container());
             reads[idx].insert(u->container());
         }
         for (auto* u : view.reads()) {
+            if (is_loop_control(u)) {
+                continue;
+            }
             reads[idx].insert(u->container());
+        }
+    }
+
+    // Replication safety gate (read-modify-write model).
+    //
+    // A skipped element is replicated on every inner thread of an outer iteration.
+    // Being a sibling of the inner maps it cannot reference the inner index, so it
+    // is a pure function of the outer index and every inner thread executes it
+    // identically. A skipped element that only *stores* to a container is therefore
+    // idempotent under replication: every thread writes the same value, leaving the
+    // same result as a single execution. This holds regardless of whether the
+    // target is a loop-local transient or a function argument, and regardless of
+    // whether the value is read again later in the nest - so a plain store from a
+    // skipped element (e.g. an argument that is not read in the nest) is safe and
+    // must be allowed.
+    //
+    // The one update replication cannot reproduce is a *read-modify-write*: if a
+    // skipped element reads a container it also writes (e.g. a reduction
+    // accumulator), every replicated inner thread re-runs the update on the shared
+    // buffer, racing and folding the contribution in multiple times. That is only
+    // safe if the container's lifetime were restricted to a single (privatizable)
+    // iteration, so it is rejected here.
+    for (size_t idx = 0; idx < n; ++idx) {
+        if (is_collapsible[idx]) {
+            continue;
+        }
+        for (const auto& container : writes[idx]) {
+            if (reads[idx].count(container) != 0) {
+                return false;
+            }
         }
     }
 

--- a/opt/src/transformations/offloading/cuda_parallelize_nested_map.cpp
+++ b/opt/src/transformations/offloading/cuda_parallelize_nested_map.cpp
@@ -4,6 +4,7 @@
 #include "sdfg/exceptions.h"
 #include "sdfg/symbolic/symbolic.h"
 #include "sdfg/targets/cuda/cuda.h"
+#include "sdfg/targets/gpu/gpu_map_utils.h"
 
 namespace sdfg {
 namespace transformations {
@@ -57,6 +58,15 @@ bool CUDAParallelizeNestedMap::
     // emits `<map.indvar> = init + thread_flat_id * stride`, so the body sees
     // the natural strided value; `num_iterations()` accounts for both when
     // computing the grid geometry.
+
+    // Condition: Parallelizing this map must not replicate a sibling accumulation.
+    // Folding a new grid dimension re-runs every unguarded sibling on each thread of
+    // the new dimension; a sibling read-modify-write on a shared (non-privatizable)
+    // container would then race. Such a reduction must either be parallelized itself
+    // or block nested parallelism of its siblings.
+    if (gpu::nested_parallelization_replicates_accumulation(loop_, analysis_manager)) {
+        return false;
+    }
 
     // Condition: Resulting CUDA grid dimension must not exceed hardware limits.
     // Y and Z grid dimensions are limited to 65535.

--- a/opt/src/transformations/offloading/rocm_parallelize_nested_map.cpp
+++ b/opt/src/transformations/offloading/rocm_parallelize_nested_map.cpp
@@ -3,6 +3,7 @@
 #include <sdfg/analysis/loop_analysis.h>
 #include "sdfg/exceptions.h"
 #include "sdfg/symbolic/symbolic.h"
+#include "sdfg/targets/gpu/gpu_map_utils.h"
 #include "sdfg/targets/rocm/rocm.h"
 
 namespace sdfg {
@@ -57,6 +58,15 @@ bool ROCMParallelizeNestedMap::
     // emits `<map.indvar> = init + thread_flat_id * stride`, so the body sees
     // the natural strided value; `num_iterations()` accounts for both when
     // computing the grid geometry.
+
+    // Condition: Parallelizing this map must not replicate a sibling accumulation.
+    // Folding a new grid dimension re-runs every unguarded sibling on each thread of
+    // the new dimension; a sibling read-modify-write on a shared (non-privatizable)
+    // container would then race. Such a reduction must either be parallelized itself
+    // or block nested parallelism of its siblings.
+    if (gpu::nested_parallelization_replicates_accumulation(loop_, analysis_manager)) {
+        return false;
+    }
 
     // Condition: Resulting ROCm grid dimension must not exceed hardware limits.
     // Y and Z grid dimensions are limited to 65535.

--- a/opt/tests/transformations/map_collapse_test.cpp
+++ b/opt/tests/transformations/map_collapse_test.cpp
@@ -1939,7 +1939,9 @@ build_imperfect_producer_then_map(builder::StructuredSDFGBuilder& builder) {
     types::Pointer opaque_desc;
     types::Scalar sym_desc(types::PrimitiveType::UInt64);
 
-    builder.add_container("X", opaque_desc, true);
+    // X is a transient (loop-local) scratch buffer: the skipped producer may write
+    // it under the replication model. Y and Z are arguments.
+    builder.add_container("X", opaque_desc);
     builder.add_container("Y", opaque_desc, true);
     builder.add_container("Z", opaque_desc, true);
     builder.add_container("N", sym_desc, true);
@@ -2183,6 +2185,377 @@ TEST(MapCollapseTest, CannotApply_Imperfect_WriteWriteConflict) {
 }
 
 // ---------------------------------------------------------------------------
+// Imperfect — replication safety (loop-local write model)
+// ---------------------------------------------------------------------------
+
+TEST(MapCollapseTest, CannotApply_Imperfect_SkippedReductionRecomputed) {
+    // Softmax-style hazard. A skipped sequential reduction accumulates sum[i] (a
+    // read-modify-write into a shared transient buffer), and the collapsible inner
+    // map divides by sum[i]. Flattening replicates the reduction on every inner
+    // thread, re-running the accumulation on the shared buffer and recomputing the
+    // reduction multiple times -> wrong results. Must be rejected. It would only be
+    // safe if sum's lifetime were restricted to a single (privatizable) iteration.
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+    auto& root = builder.subject().root();
+
+    types::Scalar float_desc(types::PrimitiveType::Float);
+    types::Pointer ptr_desc(float_desc);
+    types::Pointer opaque_desc;
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+
+    builder.add_container("A", opaque_desc, true); // argument (input)
+    builder.add_container("out", opaque_desc, true); // argument (result)
+    builder.add_container("sum", opaque_desc); // transient accumulator (shared buffer)
+    builder.add_container("N", sym_desc, true);
+    builder.add_container("M", sym_desc, true);
+    builder.add_container("i", sym_desc);
+    builder.add_container("j", sym_desc);
+    builder.add_container("k", sym_desc);
+
+    auto i = symbolic::symbol("i");
+    auto j = symbolic::symbol("j");
+    auto k = symbolic::symbol("k");
+    auto N = symbolic::symbol("N");
+    auto M = symbolic::symbol("M");
+
+    auto& outer = builder.add_map(
+        root,
+        i,
+        symbolic::Lt(i, N),
+        symbolic::integer(0),
+        symbolic::add(i, symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+
+    // Skipped sequential reduction: for k in [0, M): sum[i] = sum[i] + A[i*M + k]
+    auto& loop_k =
+        builder
+            .add_for(outer.root(), k, symbolic::Lt(k, M), symbolic::integer(0), symbolic::add(k, symbolic::integer(1)));
+    {
+        auto idx = symbolic::add(symbolic::mul(i, M), k);
+        auto& block = builder.add_block(loop_k.root());
+        auto& sum_in = builder.add_access(block, "sum");
+        auto& a_in = builder.add_access(block, "A");
+        auto& sum_out = builder.add_access(block, "sum");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+        builder.add_computational_memlet(block, sum_in, tk, "_in1", {i}, ptr_desc);
+        builder.add_computational_memlet(block, a_in, tk, "_in2", {idx}, ptr_desc);
+        builder.add_computational_memlet(block, tk, "_out", sum_out, {i}, ptr_desc);
+    }
+
+    // Collapsible inner map j in [0, M): out[i*M + j] = A[i*M + j] / sum[i]
+    auto& map_j = builder.add_map(
+        outer.root(),
+        j,
+        symbolic::Lt(j, M),
+        symbolic::integer(0),
+        symbolic::add(j, symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+    {
+        auto idx = symbolic::add(symbolic::mul(i, M), j);
+        auto& block = builder.add_block(map_j.root());
+        auto& a_in = builder.add_access(block, "A");
+        auto& sum_in = builder.add_access(block, "sum");
+        auto& out_node = builder.add_access(block, "out");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::fp_div, "_out", {"_in1", "_in2"});
+        builder.add_computational_memlet(block, a_in, tk, "_in1", {idx}, ptr_desc);
+        builder.add_computational_memlet(block, sum_in, tk, "_in2", {i}, ptr_desc);
+        builder.add_computational_memlet(block, tk, "_out", out_node, {idx}, ptr_desc);
+    }
+
+    analysis::AnalysisManager am(builder.subject());
+    transformations::MapCollapse t(outer, 2);
+    EXPECT_FALSE(t.can_be_applied(builder, am));
+}
+
+TEST(MapCollapseTest, CanBeApplied_Imperfect_SkippedWriteToArgument) {
+    // A skipped block writes a function argument G[i] with a plain store (no RMW).
+    // The store does not depend on the inner index, so every replicated inner
+    // thread writes the same value to G[i]: the write is idempotent under
+    // replication and produces the same result as a single execution. A plain
+    // store - even to an argument that is not read in the nest - is therefore safe
+    // to replicate, so the collapse must be allowed.
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+    auto& root = builder.subject().root();
+
+    types::Scalar float_desc(types::PrimitiveType::Float);
+    types::Pointer ptr_desc(float_desc);
+    types::Pointer opaque_desc;
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+
+    builder.add_container("G", opaque_desc, true); // argument written by skipped block
+    builder.add_container("Y", opaque_desc, true); // argument (input)
+    builder.add_container("Z", opaque_desc, true); // argument written by collapsible map
+    builder.add_container("W", opaque_desc, true); // argument (input)
+    builder.add_container("N", sym_desc, true);
+    builder.add_container("M", sym_desc, true);
+    builder.add_container("i", sym_desc);
+    builder.add_container("j", sym_desc);
+
+    auto i = symbolic::symbol("i");
+    auto j = symbolic::symbol("j");
+    auto N = symbolic::symbol("N");
+    auto M = symbolic::symbol("M");
+
+    auto& outer = builder.add_map(
+        root,
+        i,
+        symbolic::Lt(i, N),
+        symbolic::integer(0),
+        symbolic::add(i, symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+
+    // Skipped block A: G[i] = Y[i]  (writes an argument)
+    auto& block_a = builder.add_block(outer.root());
+    {
+        auto& y_in = builder.add_access(block_a, "Y");
+        auto& g_out = builder.add_access(block_a, "G");
+        auto& tk = builder.add_tasklet(block_a, data_flow::TaskletCode::assign, "_out", {"_in"});
+        builder.add_computational_memlet(block_a, y_in, tk, "_in", {i}, ptr_desc);
+        builder.add_computational_memlet(block_a, tk, "_out", g_out, {i}, ptr_desc);
+    }
+
+    // Collapsible inner map j in [0, M): Z[i*M + j] = W[i*M + j]
+    auto& map_j = builder.add_map(
+        outer.root(),
+        j,
+        symbolic::Lt(j, M),
+        symbolic::integer(0),
+        symbolic::add(j, symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+    {
+        auto idx = symbolic::add(symbolic::mul(i, M), j);
+        auto& block = builder.add_block(map_j.root());
+        auto& w_in = builder.add_access(block, "W");
+        auto& z_out = builder.add_access(block, "Z");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+        builder.add_computational_memlet(block, w_in, tk, "_in", {idx}, ptr_desc);
+        builder.add_computational_memlet(block, tk, "_out", z_out, {idx}, ptr_desc);
+    }
+
+    analysis::AnalysisManager am(builder.subject());
+    transformations::MapCollapse t(outer, 2);
+    EXPECT_TRUE(t.can_be_applied(builder, am));
+}
+
+TEST(MapCollapseTest, CanBeApplied_Imperfect_SkippedWriteToTransientScratch) {
+    // A skipped block writes a transient scratch buffer T[i] with a plain store
+    // (not a RMW). This is loop-local storage that is safe to replicate, so the
+    // collapse remains allowed - the new gate must not over-reject.
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+    auto& root = builder.subject().root();
+
+    types::Scalar float_desc(types::PrimitiveType::Float);
+    types::Pointer ptr_desc(float_desc);
+    types::Pointer opaque_desc;
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+
+    builder.add_container("T", opaque_desc); // transient scratch (loop-local)
+    builder.add_container("Y", opaque_desc, true); // argument (input)
+    builder.add_container("Z", opaque_desc, true); // argument written by collapsible map
+    builder.add_container("W", opaque_desc, true); // argument (input)
+    builder.add_container("N", sym_desc, true);
+    builder.add_container("M", sym_desc, true);
+    builder.add_container("i", sym_desc);
+    builder.add_container("j", sym_desc);
+
+    auto i = symbolic::symbol("i");
+    auto j = symbolic::symbol("j");
+    auto N = symbolic::symbol("N");
+    auto M = symbolic::symbol("M");
+
+    auto& outer = builder.add_map(
+        root,
+        i,
+        symbolic::Lt(i, N),
+        symbolic::integer(0),
+        symbolic::add(i, symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+
+    // Skipped block A: T[i] = Y[i]  (writes a transient, plain store)
+    auto& block_a = builder.add_block(outer.root());
+    {
+        auto& y_in = builder.add_access(block_a, "Y");
+        auto& t_out = builder.add_access(block_a, "T");
+        auto& tk = builder.add_tasklet(block_a, data_flow::TaskletCode::assign, "_out", {"_in"});
+        builder.add_computational_memlet(block_a, y_in, tk, "_in", {i}, ptr_desc);
+        builder.add_computational_memlet(block_a, tk, "_out", t_out, {i}, ptr_desc);
+    }
+
+    // Collapsible inner map j in [0, M): Z[i*M + j] = W[i*M + j]
+    auto& map_j = builder.add_map(
+        outer.root(),
+        j,
+        symbolic::Lt(j, M),
+        symbolic::integer(0),
+        symbolic::add(j, symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+    {
+        auto idx = symbolic::add(symbolic::mul(i, M), j);
+        auto& block = builder.add_block(map_j.root());
+        auto& w_in = builder.add_access(block, "W");
+        auto& z_out = builder.add_access(block, "Z");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+        builder.add_computational_memlet(block, w_in, tk, "_in", {idx}, ptr_desc);
+        builder.add_computational_memlet(block, tk, "_out", z_out, {idx}, ptr_desc);
+    }
+
+    analysis::AnalysisManager am(builder.subject());
+    transformations::MapCollapse t(outer, 2);
+    EXPECT_TRUE(t.can_be_applied(builder, am));
+}
+
+TEST(MapCollapseTest, CanBeApplied_Imperfect_CollapsibleMapWritesArgument) {
+    // The collapsible (fused) inner map writes a function argument Z[i*M + j] with
+    // an inner-varying store that is not read anywhere in the loop nest. This is
+    // the fused map's normal output and is exactly the parallel work the collapse
+    // exposes, so it must be allowed - the safety gates only concern collapsible
+    // outputs that another body element consumes.
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+    auto& root = builder.subject().root();
+
+    types::Scalar float_desc(types::PrimitiveType::Float);
+    types::Pointer ptr_desc(float_desc);
+    types::Pointer opaque_desc;
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+
+    builder.add_container("Z", opaque_desc, true); // argument written by collapsible map
+    builder.add_container("V", opaque_desc, true); // argument written by the skipped block
+    builder.add_container("W", opaque_desc, true); // argument (input)
+    builder.add_container("N", sym_desc, true);
+    builder.add_container("M", sym_desc, true);
+    builder.add_container("i", sym_desc);
+    builder.add_container("j", sym_desc);
+
+    auto i = symbolic::symbol("i");
+    auto j = symbolic::symbol("j");
+    auto N = symbolic::symbol("N");
+    auto M = symbolic::symbol("M");
+
+    auto& outer = builder.add_map(
+        root,
+        i,
+        symbolic::Lt(i, N),
+        symbolic::integer(0),
+        symbolic::add(i, symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+
+    // Skipped block A: a plain store into a distinct output argument, V[i] = W[i].
+    // It writes a different container than the collapsible map, so there is no
+    // write-write conflict with the fused output.
+    auto& block_a = builder.add_block(outer.root());
+    {
+        auto& w_in = builder.add_access(block_a, "W");
+        auto& v_out = builder.add_access(block_a, "V");
+        auto& tk = builder.add_tasklet(block_a, data_flow::TaskletCode::assign, "_out", {"_in"});
+        builder.add_computational_memlet(block_a, w_in, tk, "_in", {i}, ptr_desc);
+        builder.add_computational_memlet(block_a, tk, "_out", v_out, {i}, ptr_desc);
+    }
+
+    // Collapsible inner map j in [0, M): Z[i*M + j] = W[i*M + j]
+    auto& map_j = builder.add_map(
+        outer.root(),
+        j,
+        symbolic::Lt(j, M),
+        symbolic::integer(0),
+        symbolic::add(j, symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+    {
+        auto idx = symbolic::add(symbolic::mul(i, M), j);
+        auto& block = builder.add_block(map_j.root());
+        auto& w_in = builder.add_access(block, "W");
+        auto& z_out = builder.add_access(block, "Z");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+        builder.add_computational_memlet(block, w_in, tk, "_in", {idx}, ptr_desc);
+        builder.add_computational_memlet(block, tk, "_out", z_out, {idx}, ptr_desc);
+    }
+
+    analysis::AnalysisManager am(builder.subject());
+    transformations::MapCollapse t(outer, 2);
+    EXPECT_TRUE(t.can_be_applied(builder, am));
+}
+
+TEST(MapCollapseTest, CannotApply_Imperfect_SkippedArgumentReadModifyWrite) {
+    // A skipped block accumulates into a function argument G[i] = G[i] + Y[i]: it
+    // reads the container it writes, so it is a read-modify-write rather than a
+    // plain store. Replicating it across inner threads folds the update in multiple
+    // times (racing on the shared buffer), which replication cannot reproduce, so
+    // it must be rejected - the hazard is the RMW, not the argument being written.
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+    auto& root = builder.subject().root();
+
+    types::Scalar float_desc(types::PrimitiveType::Float);
+    types::Pointer ptr_desc(float_desc);
+    types::Pointer opaque_desc;
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+
+    builder.add_container("G", opaque_desc, true); // argument read-modified-written by skipped block
+    builder.add_container("Y", opaque_desc, true); // argument (input)
+    builder.add_container("Z", opaque_desc, true); // argument written by collapsible map
+    builder.add_container("W", opaque_desc, true); // argument (input)
+    builder.add_container("N", sym_desc, true);
+    builder.add_container("M", sym_desc, true);
+    builder.add_container("i", sym_desc);
+    builder.add_container("j", sym_desc);
+
+    auto i = symbolic::symbol("i");
+    auto j = symbolic::symbol("j");
+    auto N = symbolic::symbol("N");
+    auto M = symbolic::symbol("M");
+
+    auto& outer = builder.add_map(
+        root,
+        i,
+        symbolic::Lt(i, N),
+        symbolic::integer(0),
+        symbolic::add(i, symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+
+    // Skipped block A: G[i] = G[i] + Y[i]  (read-modify-write of an argument)
+    auto& block_a = builder.add_block(outer.root());
+    {
+        auto& g_in = builder.add_access(block_a, "G");
+        auto& y_in = builder.add_access(block_a, "Y");
+        auto& g_out = builder.add_access(block_a, "G");
+        auto& tk = builder.add_tasklet(block_a, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+        builder.add_computational_memlet(block_a, g_in, tk, "_in1", {i}, ptr_desc);
+        builder.add_computational_memlet(block_a, y_in, tk, "_in2", {i}, ptr_desc);
+        builder.add_computational_memlet(block_a, tk, "_out", g_out, {i}, ptr_desc);
+    }
+
+    // Collapsible inner map j in [0, M): Z[i*M + j] = W[i*M + j]
+    auto& map_j = builder.add_map(
+        outer.root(),
+        j,
+        symbolic::Lt(j, M),
+        symbolic::integer(0),
+        symbolic::add(j, symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+    {
+        auto idx = symbolic::add(symbolic::mul(i, M), j);
+        auto& block = builder.add_block(map_j.root());
+        auto& w_in = builder.add_access(block, "W");
+        auto& z_out = builder.add_access(block, "Z");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+        builder.add_computational_memlet(block, w_in, tk, "_in", {idx}, ptr_desc);
+        builder.add_computational_memlet(block, tk, "_out", z_out, {idx}, ptr_desc);
+    }
+
+    analysis::AnalysisManager am(builder.subject());
+    transformations::MapCollapse t(outer, 2);
+    EXPECT_FALSE(t.can_be_applied(builder, am));
+}
+
+// ---------------------------------------------------------------------------
 // Inlining of recovered induction variables (no SymbolPropagation required)
 // ---------------------------------------------------------------------------
 
@@ -2367,6 +2740,7 @@ TEST(MapCollapseTest, Apply_Imperfect_InlinesRecoveredIndvars) {
 
     builder.add_container("A", opaque_desc, true);
     builder.add_container("B", opaque_desc, true);
+    builder.add_container("C", opaque_desc, true);
     builder.add_container("N", sym_desc, true);
     builder.add_container("M", sym_desc, true);
     builder.add_container("i", sym_desc);
@@ -2386,13 +2760,16 @@ TEST(MapCollapseTest, Apply_Imperfect_InlinesRecoveredIndvars) {
         structured_control_flow::ScheduleType_Sequential::create()
     );
 
-    // Skipped block: B[i] = B[i]  (replicated on every inner thread; references i only).
+    // Skipped block: B[i] = C[i]  (a plain store replicated on every inner thread;
+    // references i only). It reads a different container than it writes, so it is a
+    // pure store rather than a read-modify-write and remains valid under the
+    // replication safety gate.
     auto& skipped = builder.add_block(outer.root());
     {
-        auto& b_in = builder.add_access(skipped, "B");
+        auto& c_in = builder.add_access(skipped, "C");
         auto& b_out = builder.add_access(skipped, "B");
         auto& tk = builder.add_tasklet(skipped, data_flow::TaskletCode::assign, "_out", {"_in"});
-        builder.add_computational_memlet(skipped, b_in, tk, "_in", {i}, ptr_desc);
+        builder.add_computational_memlet(skipped, c_in, tk, "_in", {i}, ptr_desc);
         builder.add_computational_memlet(skipped, tk, "_out", b_out, {i}, ptr_desc);
     }
 

--- a/opt/tests/transformations/map_collapse_test.cpp
+++ b/opt/tests/transformations/map_collapse_test.cpp
@@ -2191,10 +2191,13 @@ TEST(MapCollapseTest, CannotApply_Imperfect_WriteWriteConflict) {
 TEST(MapCollapseTest, CannotApply_Imperfect_SkippedReductionRecomputed) {
     // Softmax-style hazard. A skipped sequential reduction accumulates sum[i] (a
     // read-modify-write into a shared transient buffer), and the collapsible inner
-    // map divides by sum[i]. Flattening replicates the reduction on every inner
-    // thread, re-running the accumulation on the shared buffer and recomputing the
-    // reduction multiple times -> wrong results. Must be rejected. It would only be
-    // safe if sum's lifetime were restricted to a single (privatizable) iteration.
+    // map divides by sum[i]. The buffer escapes the loop (it is consumed by a node
+    // after the collapsed region, exactly like the softmax normaliser _tmp_17), so
+    // ArgumentsAnalysis classifies it as an argument and codegen cannot privatize
+    // it. Flattening then replicates the reduction on every inner thread, re-running
+    // the accumulation on the shared buffer and folding the reduction in multiple
+    // times -> wrong results. Must be rejected. It would only be safe if sum's
+    // lifetime were confined to the loop (a privatizable local).
     builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
     auto& root = builder.subject().root();
 
@@ -2205,7 +2208,7 @@ TEST(MapCollapseTest, CannotApply_Imperfect_SkippedReductionRecomputed) {
 
     builder.add_container("A", opaque_desc, true); // argument (input)
     builder.add_container("out", opaque_desc, true); // argument (result)
-    builder.add_container("sum", opaque_desc); // transient accumulator (shared buffer)
+    builder.add_container("sum", opaque_desc); // transient accumulator (escapes the loop -> shared)
     builder.add_container("N", sym_desc, true);
     builder.add_container("M", sym_desc, true);
     builder.add_container("i", sym_desc);
@@ -2264,9 +2267,106 @@ TEST(MapCollapseTest, CannotApply_Imperfect_SkippedReductionRecomputed) {
         builder.add_computational_memlet(block, tk, "_out", out_node, {idx}, ptr_desc);
     }
 
+    // Consumer after the collapsed region: reads sum, so its lifetime is not
+    // confined to the outer map. ArgumentsAnalysis therefore reports sum as an
+    // (escaping) argument rather than a privatizable local, which is what makes the
+    // replicated reduction a genuine cross-thread race.
+    {
+        auto& block = builder.add_block(root);
+        auto& sum_in = builder.add_access(block, "sum");
+        auto& out_node = builder.add_access(block, "out");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+        builder.add_computational_memlet(block, sum_in, tk, "_in", {symbolic::integer(0)}, ptr_desc);
+        builder.add_computational_memlet(block, tk, "_out", out_node, {symbolic::integer(0)}, ptr_desc);
+    }
+
     analysis::AnalysisManager am(builder.subject());
     transformations::MapCollapse t(outer, 2);
     EXPECT_FALSE(t.can_be_applied(builder, am));
+}
+
+TEST(MapCollapseTest, CanBeApplied_Imperfect_SkippedReductionOnLocalPrivatized) {
+    // Same softmax-style shape as CannotApply_Imperfect_SkippedReductionRecomputed,
+    // but the accumulator sum is a transient whose entire lifetime is confined to
+    // the outer map (it is never used outside the region). ArgumentsAnalysis reports
+    // it as a local, so codegen privatizes it per thread: every replicated inner
+    // thread re-runs the full k-reduction into its own private sum and the division
+    // reads that same private (fully accumulated) value. The read-modify-write is on
+    // a privatized copy and does not violate parallel access, so the collapse must
+    // be allowed - this is exactly the relaxation over escaping accumulators.
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+    auto& root = builder.subject().root();
+
+    types::Scalar float_desc(types::PrimitiveType::Float);
+    types::Pointer ptr_desc(float_desc);
+    types::Pointer opaque_desc;
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+
+    builder.add_container("A", opaque_desc, true); // argument (input)
+    builder.add_container("out", opaque_desc, true); // argument (result)
+    builder.add_container("sum", opaque_desc); // transient accumulator (lifetime confined to the loop)
+    builder.add_container("N", sym_desc, true);
+    builder.add_container("M", sym_desc, true);
+    builder.add_container("i", sym_desc);
+    builder.add_container("j", sym_desc);
+    builder.add_container("k", sym_desc);
+
+    auto i = symbolic::symbol("i");
+    auto j = symbolic::symbol("j");
+    auto k = symbolic::symbol("k");
+    auto N = symbolic::symbol("N");
+    auto M = symbolic::symbol("M");
+
+    auto& outer = builder.add_map(
+        root,
+        i,
+        symbolic::Lt(i, N),
+        symbolic::integer(0),
+        symbolic::add(i, symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+
+    // Skipped sequential reduction: for k in [0, M): sum[i] = sum[i] + A[i*M + k]
+    auto& loop_k =
+        builder
+            .add_for(outer.root(), k, symbolic::Lt(k, M), symbolic::integer(0), symbolic::add(k, symbolic::integer(1)));
+    {
+        auto idx = symbolic::add(symbolic::mul(i, M), k);
+        auto& block = builder.add_block(loop_k.root());
+        auto& sum_in = builder.add_access(block, "sum");
+        auto& a_in = builder.add_access(block, "A");
+        auto& sum_out = builder.add_access(block, "sum");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+        builder.add_computational_memlet(block, sum_in, tk, "_in1", {i}, ptr_desc);
+        builder.add_computational_memlet(block, a_in, tk, "_in2", {idx}, ptr_desc);
+        builder.add_computational_memlet(block, tk, "_out", sum_out, {i}, ptr_desc);
+    }
+
+    // Collapsible inner map j in [0, M): out[i*M + j] = A[i*M + j] / sum[i]. sum is
+    // read here but never used outside the outer map, so it stays a local.
+    auto& map_j = builder.add_map(
+        outer.root(),
+        j,
+        symbolic::Lt(j, M),
+        symbolic::integer(0),
+        symbolic::add(j, symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+    {
+        auto idx = symbolic::add(symbolic::mul(i, M), j);
+        auto& block = builder.add_block(map_j.root());
+        auto& a_in = builder.add_access(block, "A");
+        auto& sum_in = builder.add_access(block, "sum");
+        auto& out_node = builder.add_access(block, "out");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::fp_div, "_out", {"_in1", "_in2"});
+        builder.add_computational_memlet(block, a_in, tk, "_in1", {idx}, ptr_desc);
+        builder.add_computational_memlet(block, sum_in, tk, "_in2", {i}, ptr_desc);
+        builder.add_computational_memlet(block, tk, "_out", out_node, {idx}, ptr_desc);
+    }
+
+    analysis::AnalysisManager am(builder.subject());
+    transformations::MapCollapse t(outer, 2);
+    EXPECT_TRUE(t.can_be_applied(builder, am));
 }
 
 TEST(MapCollapseTest, CanBeApplied_Imperfect_SkippedWriteToArgument) {

--- a/opt/tests/transformations/map_collapse_test.cpp
+++ b/opt/tests/transformations/map_collapse_test.cpp
@@ -2192,8 +2192,7 @@ TEST(MapCollapseTest, CannotApply_Imperfect_SkippedReductionRecomputed) {
     // Softmax-style hazard. A skipped sequential reduction accumulates sum[i] (a
     // read-modify-write into a shared transient buffer), and the collapsible inner
     // map divides by sum[i]. The buffer escapes the loop (it is consumed by a node
-    // after the collapsed region, exactly like the softmax normaliser _tmp_17), so
-    // ArgumentsAnalysis classifies it as an argument and codegen cannot privatize
+    // after the collapsed region, so ArgumentsAnalysis classifies it as an argument and codegen cannot privatize
     // it. Flattening then replicates the reduction on every inner thread, re-running
     // the accumulation on the shared buffer and folding the reduction in multiple
     // times -> wrong results. Must be rejected. It would only be safe if sum's

--- a/opt/tests/transformations/offloading/cuda_parallelize_nested_map_test.cpp
+++ b/opt/tests/transformations/offloading/cuda_parallelize_nested_map_test.cpp
@@ -648,4 +648,257 @@ TEST(CUDANestedParallelismTransformation, GridSizeWithinYZLimit) {
     EXPECT_TRUE(transformation.can_be_applied(builder, analysis_manager));
 }
 
+// ---------------------------------------------------------------------------
+// Sibling accumulation replication (softmax-style kernel, cf.
+// kernel___docc_GraphModule_770.cu): an outer X-dimension CUDA map whose body
+// contains a sibling *reduce* loop that accumulates into a shared buffer
+// (`acc[i] = acc[i] + P[...]`, a read-modify-write) next to a plain *map* loop.
+// Folding a new grid dimension for the map loop replicates the reduce across the
+// new dimension's threads, which race on the shared accumulator. Parallelizing the
+// map loop must therefore be rejected - unless the accumulator is privatizable
+// (loop-local) or the reduction is itself parallelized.
+// ---------------------------------------------------------------------------
+
+TEST(CUDANestedParallelismTransformation, SiblingAccumulationBlocksNestedParallelism) {
+    builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
+    auto& root = builder.subject().root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer pointer_type(base_desc);
+    types::Scalar int_desc(types::PrimitiveType::Int32);
+
+    builder.add_container("i", int_desc);
+    builder.add_container("r", int_desc);
+    builder.add_container("m", int_desc);
+    builder.add_container("P", pointer_type, true); // input argument
+    builder.add_container("acc", pointer_type, true); // reduction accumulator (escapes the kernel)
+    builder.add_container("Out", pointer_type, true); // output argument
+
+    auto i = symbolic::symbol("i");
+    auto r = symbolic::symbol("r");
+    auto m = symbolic::symbol("m");
+
+    // Outer X-dimension CUDA map (the kernel scope).
+    ScheduleType outer_schedule = ScheduleType_CUDA::create();
+    ScheduleType_CUDA::dimension(outer_schedule, CUDADimension::X);
+    ScheduleType_CUDA::block_size(outer_schedule, symbolic::integer(32));
+    auto& outer = builder.add_map(
+        root,
+        i,
+        symbolic::Lt(i, symbolic::integer(16384)),
+        symbolic::integer(0),
+        symbolic::add(i, symbolic::integer(1)),
+        outer_schedule
+    );
+
+    // Sibling 1: sequential reduce loop accumulating into acc[i] (read-modify-write).
+    auto& reduce = builder.add_map(
+        outer.root(),
+        r,
+        symbolic::Lt(r, symbolic::integer(32)),
+        symbolic::integer(0),
+        symbolic::add(r, symbolic::integer(1)),
+        ScheduleType_Sequential::create()
+    );
+    {
+        auto& block = builder.add_block(reduce.root());
+        auto& acc_in = builder.add_access(block, "acc");
+        auto& p_in = builder.add_access(block, "P");
+        auto& acc_out = builder.add_access(block, "acc");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+        builder.add_computational_memlet(block, acc_in, tk, "_in1", {i}, pointer_type);
+        builder.add_computational_memlet(
+            block, p_in, tk, "_in2", {symbolic::add(symbolic::mul(i, symbolic::integer(32)), r)}, pointer_type
+        );
+        builder.add_computational_memlet(block, tk, "_out", acc_out, {i}, pointer_type);
+    }
+
+    // Sibling 2 (target): sequential map loop doing a plain store.
+    auto& target = builder.add_map(
+        outer.root(),
+        m,
+        symbolic::Lt(m, symbolic::integer(32)),
+        symbolic::integer(0),
+        symbolic::add(m, symbolic::integer(1)),
+        ScheduleType_Sequential::create()
+    );
+    {
+        auto& block = builder.add_block(target.root());
+        auto& p_in = builder.add_access(block, "P");
+        auto& out = builder.add_access(block, "Out");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::assign, "out_", {"in_"});
+        auto idx = symbolic::add(symbolic::mul(i, symbolic::integer(32)), m);
+        builder.add_computational_memlet(block, p_in, tk, "in_", {idx}, pointer_type);
+        builder.add_computational_memlet(block, tk, "out_", out, {idx}, pointer_type);
+    }
+
+    transformations::CUDAParallelizeNestedMap transformation(target, 4);
+    analysis::AnalysisManager analysis_manager(builder.subject());
+
+    // The sibling reduce accumulates on an escaping buffer; replicating it is unsafe.
+    EXPECT_FALSE(transformation.can_be_applied(builder, analysis_manager));
+}
+
+TEST(CUDANestedParallelismTransformation, SiblingAccumulationOnLocalAllowsNestedParallelism) {
+    builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
+    auto& root = builder.subject().root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer pointer_type(base_desc);
+    types::Scalar int_desc(types::PrimitiveType::Int32);
+
+    builder.add_container("i", int_desc);
+    builder.add_container("r", int_desc);
+    builder.add_container("m", int_desc);
+    builder.add_container("P", pointer_type, true); // input argument
+    builder.add_container("acc", pointer_type); // transient used only inside the kernel -> privatizable local
+    builder.add_container("Out", pointer_type, true); // output argument
+
+    auto i = symbolic::symbol("i");
+    auto r = symbolic::symbol("r");
+    auto m = symbolic::symbol("m");
+
+    ScheduleType outer_schedule = ScheduleType_CUDA::create();
+    ScheduleType_CUDA::dimension(outer_schedule, CUDADimension::X);
+    ScheduleType_CUDA::block_size(outer_schedule, symbolic::integer(32));
+    auto& outer = builder.add_map(
+        root,
+        i,
+        symbolic::Lt(i, symbolic::integer(16384)),
+        symbolic::integer(0),
+        symbolic::add(i, symbolic::integer(1)),
+        outer_schedule
+    );
+
+    // Sibling 1: reduce accumulating into a loop-local accumulator acc[i].
+    auto& reduce = builder.add_map(
+        outer.root(),
+        r,
+        symbolic::Lt(r, symbolic::integer(32)),
+        symbolic::integer(0),
+        symbolic::add(r, symbolic::integer(1)),
+        ScheduleType_Sequential::create()
+    );
+    {
+        auto& block = builder.add_block(reduce.root());
+        auto& acc_in = builder.add_access(block, "acc");
+        auto& p_in = builder.add_access(block, "P");
+        auto& acc_out = builder.add_access(block, "acc");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+        builder.add_computational_memlet(block, acc_in, tk, "_in1", {i}, pointer_type);
+        builder.add_computational_memlet(
+            block, p_in, tk, "_in2", {symbolic::add(symbolic::mul(i, symbolic::integer(32)), r)}, pointer_type
+        );
+        builder.add_computational_memlet(block, tk, "_out", acc_out, {i}, pointer_type);
+    }
+
+    // Sibling 2 (target): plain-store map loop.
+    auto& target = builder.add_map(
+        outer.root(),
+        m,
+        symbolic::Lt(m, symbolic::integer(32)),
+        symbolic::integer(0),
+        symbolic::add(m, symbolic::integer(1)),
+        ScheduleType_Sequential::create()
+    );
+    {
+        auto& block = builder.add_block(target.root());
+        auto& p_in = builder.add_access(block, "P");
+        auto& out = builder.add_access(block, "Out");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::assign, "out_", {"in_"});
+        auto idx = symbolic::add(symbolic::mul(i, symbolic::integer(32)), m);
+        builder.add_computational_memlet(block, p_in, tk, "in_", {idx}, pointer_type);
+        builder.add_computational_memlet(block, tk, "out_", out, {idx}, pointer_type);
+    }
+
+    transformations::CUDAParallelizeNestedMap transformation(target, 4);
+    analysis::AnalysisManager analysis_manager(builder.subject());
+
+    // acc is privatized per thread, so its read-modify-write races nothing.
+    EXPECT_TRUE(transformation.can_be_applied(builder, analysis_manager));
+}
+
+TEST(CUDANestedParallelismTransformation, ParallelizedSiblingReductionAllowsNestedParallelism) {
+    builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
+    auto& root = builder.subject().root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer pointer_type(base_desc);
+    types::Scalar int_desc(types::PrimitiveType::Int32);
+
+    builder.add_container("i", int_desc);
+    builder.add_container("r", int_desc);
+    builder.add_container("m", int_desc);
+    builder.add_container("P", pointer_type, true); // input argument
+    builder.add_container("acc", pointer_type, true); // escapes, but the reduce is parallelized
+    builder.add_container("Out", pointer_type, true); // output argument
+
+    auto i = symbolic::symbol("i");
+    auto r = symbolic::symbol("r");
+    auto m = symbolic::symbol("m");
+
+    ScheduleType outer_schedule = ScheduleType_CUDA::create();
+    ScheduleType_CUDA::dimension(outer_schedule, CUDADimension::X);
+    ScheduleType_CUDA::block_size(outer_schedule, symbolic::integer(32));
+    auto& outer = builder.add_map(
+        root,
+        i,
+        symbolic::Lt(i, symbolic::integer(16384)),
+        symbolic::integer(0),
+        symbolic::add(i, symbolic::integer(1)),
+        outer_schedule
+    );
+
+    // Sibling 1: reduce that is itself parallelized (a CUDA map) - codegen maps it
+    // onto its own threads, so it is not replicated by the target's new dimension.
+    ScheduleType reduce_schedule = ScheduleType_CUDA::create();
+    ScheduleType_CUDA::dimension(reduce_schedule, CUDADimension::Y);
+    ScheduleType_CUDA::block_size(reduce_schedule, symbolic::integer(8));
+    auto& reduce = builder.add_map(
+        outer.root(),
+        r,
+        symbolic::Lt(r, symbolic::integer(32)),
+        symbolic::integer(0),
+        symbolic::add(r, symbolic::integer(1)),
+        reduce_schedule
+    );
+    {
+        auto& block = builder.add_block(reduce.root());
+        auto& acc_in = builder.add_access(block, "acc");
+        auto& p_in = builder.add_access(block, "P");
+        auto& acc_out = builder.add_access(block, "acc");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+        builder.add_computational_memlet(block, acc_in, tk, "_in1", {i}, pointer_type);
+        builder.add_computational_memlet(
+            block, p_in, tk, "_in2", {symbolic::add(symbolic::mul(i, symbolic::integer(32)), r)}, pointer_type
+        );
+        builder.add_computational_memlet(block, tk, "_out", acc_out, {i}, pointer_type);
+    }
+
+    // Sibling 2 (target): plain-store map loop.
+    auto& target = builder.add_map(
+        outer.root(),
+        m,
+        symbolic::Lt(m, symbolic::integer(32)),
+        symbolic::integer(0),
+        symbolic::add(m, symbolic::integer(1)),
+        ScheduleType_Sequential::create()
+    );
+    {
+        auto& block = builder.add_block(target.root());
+        auto& p_in = builder.add_access(block, "P");
+        auto& out = builder.add_access(block, "Out");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::assign, "out_", {"in_"});
+        auto idx = symbolic::add(symbolic::mul(i, symbolic::integer(32)), m);
+        builder.add_computational_memlet(block, p_in, tk, "in_", {idx}, pointer_type);
+        builder.add_computational_memlet(block, tk, "out_", out, {idx}, pointer_type);
+    }
+
+    transformations::CUDAParallelizeNestedMap transformation(target, 4);
+    analysis::AnalysisManager analysis_manager(builder.subject());
+
+    // The accumulating sibling is already parallelized, so it is not replicated.
+    EXPECT_TRUE(transformation.can_be_applied(builder, analysis_manager));
+}
+
 } // namespace sdfg::cuda

--- a/opt/tests/transformations/offloading/rocm_parallelize_nested_map_test.cpp
+++ b/opt/tests/transformations/offloading/rocm_parallelize_nested_map_test.cpp
@@ -123,4 +123,249 @@ TEST(ROCMNestedParallelismTransformation, GridSizeWithinYZLimit) {
     EXPECT_TRUE(transformation.can_be_applied(builder, analysis_manager));
 }
 
+// ---------------------------------------------------------------------------
+// Sibling accumulation replication (softmax-style kernel): an outer X-dimension
+// ROCm map whose body contains a sibling *reduce* loop that accumulates into a
+// shared buffer (`acc[i] = acc[i] + P[...]`, a read-modify-write) next to a plain
+// *map* loop. Folding a new grid dimension for the map loop replicates the reduce
+// across the new dimension's threads, which race on the shared accumulator.
+// Parallelizing the map loop must therefore be rejected - unless the accumulator
+// is privatizable (loop-local) or the reduction is itself parallelized.
+// ---------------------------------------------------------------------------
+
+TEST(ROCMNestedParallelismTransformation, SiblingAccumulationBlocksNestedParallelism) {
+    builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
+    auto& root = builder.subject().root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer pointer_type(base_desc);
+    types::Scalar int_desc(types::PrimitiveType::Int32);
+
+    builder.add_container("i", int_desc);
+    builder.add_container("r", int_desc);
+    builder.add_container("m", int_desc);
+    builder.add_container("P", pointer_type, true); // input argument
+    builder.add_container("acc", pointer_type, true); // reduction accumulator (escapes the kernel)
+    builder.add_container("Out", pointer_type, true); // output argument
+
+    auto i = symbolic::symbol("i");
+    auto r = symbolic::symbol("r");
+    auto m = symbolic::symbol("m");
+
+    ScheduleType outer_schedule = ScheduleType_ROCM::create();
+    ScheduleType_ROCM::dimension(outer_schedule, ROCMDimension::X);
+    ScheduleType_ROCM::block_size(outer_schedule, symbolic::integer(64));
+    auto& outer = builder.add_map(
+        root,
+        i,
+        symbolic::Lt(i, symbolic::integer(16384)),
+        symbolic::integer(0),
+        symbolic::add(i, symbolic::integer(1)),
+        outer_schedule
+    );
+
+    // Sibling 1: sequential reduce loop accumulating into acc[i] (read-modify-write).
+    auto& reduce = builder.add_map(
+        outer.root(),
+        r,
+        symbolic::Lt(r, symbolic::integer(32)),
+        symbolic::integer(0),
+        symbolic::add(r, symbolic::integer(1)),
+        ScheduleType_Sequential::create()
+    );
+    {
+        auto& block = builder.add_block(reduce.root());
+        auto& acc_in = builder.add_access(block, "acc");
+        auto& p_in = builder.add_access(block, "P");
+        auto& acc_out = builder.add_access(block, "acc");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+        builder.add_computational_memlet(block, acc_in, tk, "_in1", {i}, pointer_type);
+        builder.add_computational_memlet(
+            block, p_in, tk, "_in2", {symbolic::add(symbolic::mul(i, symbolic::integer(32)), r)}, pointer_type
+        );
+        builder.add_computational_memlet(block, tk, "_out", acc_out, {i}, pointer_type);
+    }
+
+    // Sibling 2 (target): sequential map loop doing a plain store.
+    auto& target = builder.add_map(
+        outer.root(),
+        m,
+        symbolic::Lt(m, symbolic::integer(32)),
+        symbolic::integer(0),
+        symbolic::add(m, symbolic::integer(1)),
+        ScheduleType_Sequential::create()
+    );
+    {
+        auto& block = builder.add_block(target.root());
+        auto& p_in = builder.add_access(block, "P");
+        auto& out = builder.add_access(block, "Out");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::assign, "out_", {"in_"});
+        auto idx = symbolic::add(symbolic::mul(i, symbolic::integer(32)), m);
+        builder.add_computational_memlet(block, p_in, tk, "in_", {idx}, pointer_type);
+        builder.add_computational_memlet(block, tk, "out_", out, {idx}, pointer_type);
+    }
+
+    transformations::ROCMParallelizeNestedMap transformation(target, 4);
+    analysis::AnalysisManager analysis_manager(builder.subject());
+
+    EXPECT_FALSE(transformation.can_be_applied(builder, analysis_manager));
+}
+
+TEST(ROCMNestedParallelismTransformation, SiblingAccumulationOnLocalAllowsNestedParallelism) {
+    builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
+    auto& root = builder.subject().root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer pointer_type(base_desc);
+    types::Scalar int_desc(types::PrimitiveType::Int32);
+
+    builder.add_container("i", int_desc);
+    builder.add_container("r", int_desc);
+    builder.add_container("m", int_desc);
+    builder.add_container("P", pointer_type, true); // input argument
+    builder.add_container("acc", pointer_type); // transient used only inside the kernel -> privatizable local
+    builder.add_container("Out", pointer_type, true); // output argument
+
+    auto i = symbolic::symbol("i");
+    auto r = symbolic::symbol("r");
+    auto m = symbolic::symbol("m");
+
+    ScheduleType outer_schedule = ScheduleType_ROCM::create();
+    ScheduleType_ROCM::dimension(outer_schedule, ROCMDimension::X);
+    ScheduleType_ROCM::block_size(outer_schedule, symbolic::integer(64));
+    auto& outer = builder.add_map(
+        root,
+        i,
+        symbolic::Lt(i, symbolic::integer(16384)),
+        symbolic::integer(0),
+        symbolic::add(i, symbolic::integer(1)),
+        outer_schedule
+    );
+
+    auto& reduce = builder.add_map(
+        outer.root(),
+        r,
+        symbolic::Lt(r, symbolic::integer(32)),
+        symbolic::integer(0),
+        symbolic::add(r, symbolic::integer(1)),
+        ScheduleType_Sequential::create()
+    );
+    {
+        auto& block = builder.add_block(reduce.root());
+        auto& acc_in = builder.add_access(block, "acc");
+        auto& p_in = builder.add_access(block, "P");
+        auto& acc_out = builder.add_access(block, "acc");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+        builder.add_computational_memlet(block, acc_in, tk, "_in1", {i}, pointer_type);
+        builder.add_computational_memlet(
+            block, p_in, tk, "_in2", {symbolic::add(symbolic::mul(i, symbolic::integer(32)), r)}, pointer_type
+        );
+        builder.add_computational_memlet(block, tk, "_out", acc_out, {i}, pointer_type);
+    }
+
+    auto& target = builder.add_map(
+        outer.root(),
+        m,
+        symbolic::Lt(m, symbolic::integer(32)),
+        symbolic::integer(0),
+        symbolic::add(m, symbolic::integer(1)),
+        ScheduleType_Sequential::create()
+    );
+    {
+        auto& block = builder.add_block(target.root());
+        auto& p_in = builder.add_access(block, "P");
+        auto& out = builder.add_access(block, "Out");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::assign, "out_", {"in_"});
+        auto idx = symbolic::add(symbolic::mul(i, symbolic::integer(32)), m);
+        builder.add_computational_memlet(block, p_in, tk, "in_", {idx}, pointer_type);
+        builder.add_computational_memlet(block, tk, "out_", out, {idx}, pointer_type);
+    }
+
+    transformations::ROCMParallelizeNestedMap transformation(target, 4);
+    analysis::AnalysisManager analysis_manager(builder.subject());
+
+    EXPECT_TRUE(transformation.can_be_applied(builder, analysis_manager));
+}
+
+TEST(ROCMNestedParallelismTransformation, ParallelizedSiblingReductionAllowsNestedParallelism) {
+    builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
+    auto& root = builder.subject().root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer pointer_type(base_desc);
+    types::Scalar int_desc(types::PrimitiveType::Int32);
+
+    builder.add_container("i", int_desc);
+    builder.add_container("r", int_desc);
+    builder.add_container("m", int_desc);
+    builder.add_container("P", pointer_type, true); // input argument
+    builder.add_container("acc", pointer_type, true); // escapes, but the reduce is parallelized
+    builder.add_container("Out", pointer_type, true); // output argument
+
+    auto i = symbolic::symbol("i");
+    auto r = symbolic::symbol("r");
+    auto m = symbolic::symbol("m");
+
+    ScheduleType outer_schedule = ScheduleType_ROCM::create();
+    ScheduleType_ROCM::dimension(outer_schedule, ROCMDimension::X);
+    ScheduleType_ROCM::block_size(outer_schedule, symbolic::integer(64));
+    auto& outer = builder.add_map(
+        root,
+        i,
+        symbolic::Lt(i, symbolic::integer(16384)),
+        symbolic::integer(0),
+        symbolic::add(i, symbolic::integer(1)),
+        outer_schedule
+    );
+
+    // Sibling 1: reduce that is itself parallelized (a ROCm map) - mapped onto its
+    // own threads, so it is not replicated by the target's new dimension.
+    ScheduleType reduce_schedule = ScheduleType_ROCM::create();
+    ScheduleType_ROCM::dimension(reduce_schedule, ROCMDimension::Y);
+    ScheduleType_ROCM::block_size(reduce_schedule, symbolic::integer(8));
+    auto& reduce = builder.add_map(
+        outer.root(),
+        r,
+        symbolic::Lt(r, symbolic::integer(32)),
+        symbolic::integer(0),
+        symbolic::add(r, symbolic::integer(1)),
+        reduce_schedule
+    );
+    {
+        auto& block = builder.add_block(reduce.root());
+        auto& acc_in = builder.add_access(block, "acc");
+        auto& p_in = builder.add_access(block, "P");
+        auto& acc_out = builder.add_access(block, "acc");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+        builder.add_computational_memlet(block, acc_in, tk, "_in1", {i}, pointer_type);
+        builder.add_computational_memlet(
+            block, p_in, tk, "_in2", {symbolic::add(symbolic::mul(i, symbolic::integer(32)), r)}, pointer_type
+        );
+        builder.add_computational_memlet(block, tk, "_out", acc_out, {i}, pointer_type);
+    }
+
+    auto& target = builder.add_map(
+        outer.root(),
+        m,
+        symbolic::Lt(m, symbolic::integer(32)),
+        symbolic::integer(0),
+        symbolic::add(m, symbolic::integer(1)),
+        ScheduleType_Sequential::create()
+    );
+    {
+        auto& block = builder.add_block(target.root());
+        auto& p_in = builder.add_access(block, "P");
+        auto& out = builder.add_access(block, "Out");
+        auto& tk = builder.add_tasklet(block, data_flow::TaskletCode::assign, "out_", {"in_"});
+        auto idx = symbolic::add(symbolic::mul(i, symbolic::integer(32)), m);
+        builder.add_computational_memlet(block, p_in, tk, "in_", {idx}, pointer_type);
+        builder.add_computational_memlet(block, tk, "out_", out, {idx}, pointer_type);
+    }
+
+    transformations::ROCMParallelizeNestedMap transformation(target, 4);
+    analysis::AnalysisManager analysis_manager(builder.subject());
+
+    EXPECT_TRUE(transformation.can_be_applied(builder, analysis_manager));
+}
+
 } // namespace sdfg::rocm


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill out this template to help reviewers
understand your changes. Remove sections that are not relevant.
-->

## Description
Additional repetitions of write accesses can generate flaky or wrong behaviour on later parallel code, by destroying the conditions of maps.
The fix disallows an imperfect collapse where an explicit dependency between structured control flow elements is also an argument to the loop nest.

A similar issue for nested offloading regarding the repetition of accumulations is also fixed.

## Related Issues
<!-- Link issues this PR closes or relates to, e.g. "Closes #123" -->
- Closes #

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal change (no functional change)
- [ ] Documentation update

## Quality Checklist
*Please ensure the following are completed before requesting review:*

* [x] Runtime-compatible (no externally visible existing method has its parameters changed, was deleted or has its exception behavior changed)
* [x] Compile-time compatible (new arguments & properties added have default values, but users need to recompile against the new version to work)

IR:
* [ ] Introduces new types into the SDFG IR
* [ ]  Changed / added properties on SDFG IR Elements (LibraryNodes, ControlFlowNodes DataFlowNodes etc.)
  *  [ ] New / modified types have serialization / deserialization support
  *  [ ] Deserialization is backward compatible (new serialization can deserialize old format and represent it in the new format if applicable)
  *  [ ] Serialized format is backward compatible (previous deserializer can read new serialized format without incorrectness (just lacking additional guarantees that are optional or did not exist before)
  *  [ ] Serializer has an option to emit the previous format

### Unit Tests
- [x] New unit tests have been added for the changes.
- [x] Existing unit tests pass locally.
- [x] Edge cases and error paths are covered.

### Integration Tests
- [x] New integration tests have been added (or existing ones updated).
- [x] Integration tests pass locally.
- [x] Interactions with other components/services are verified.

### Documentation
- [ ] Public APIs, options, and behavior changes are documented.
- [x] README / docs site / inline comments updated where applicable.
- [ ] Changelog / release notes updated (if applicable).

### Test Coverage
- [x] Test coverage has not decreased as a result of this change.
- [x] Coverage report reviewed and acceptable.
- [x] Critical / new code paths are covered.

## How Has This Been Tested?
Extended unit tests and the integration tests for MLP and Segformer.

## Additional Context
Add any other context about the PR here (design decisions, trade-offs, follow-ups).
