### PR TITLE
Better compile stats that supported nested timings

### DIFF
--- a/opt/src/passes/loop_fusion/loop_fusion_pass.cpp
+++ b/opt/src/passes/loop_fusion/loop_fusion_pass.cpp
@@ -1,11 +1,11 @@
 #include "sdfg/passes/loop_fusion/loop_fusion_pass.h"
 
-#include "../../../../sdfg/include/sdfg/symbolic/assumptions.h"
 #include "sdfg/analysis/assumptions_analysis.h"
 #include "sdfg/analysis/base_user_visitor.h"
 #include "sdfg/data_flow/library_nodes/stdlib/malloc.h"
 #include "sdfg/deepcopy/structured_sdfg_deep_copy.h"
 #include "sdfg/structured_sdfg.h"
+#include "sdfg/symbolic/assumptions.h"
 #include "sdfg/symbolic/utils.h"
 #include "sdfg/visitor/structured_sdfg_visitor.h"
 #include "sdfg/visualizer/dot_visualizer.h"
@@ -114,7 +114,7 @@ public:
             auto type = is_a(node.type_id(), ElementType::Map) ? analysis::LocalLoopInfo::LoopType::Map
                                                                : analysis::LocalLoopInfo::LoopType::For;
             auto& candidate = *cand_it->second.get();
-            loop_stack_.emplace_back(&node, type, candidate, get_indvar_placeholder(candidate, loop_stack_.size() - 1));
+            loop_stack_.emplace_back(&node, type, candidate, get_indvar_placeholder(candidate, loop_stack_.size()));
             loop_stack_.back().indvars.emplace(node.indvar()->get_name());
         }
         auto res = BaseUserVisitor::handleStructuredLoop(node);

--- a/opt/src/passes/loop_fusion/loop_fusion_pass.cpp
+++ b/opt/src/passes/loop_fusion/loop_fusion_pass.cpp
@@ -357,6 +357,9 @@ bool LoopFusionPass::run_pass(builder::StructuredSDFGBuilder& builder, analysis:
         state.loop_analysis->dump_to_file(std::filesystem::path(*dir) / "loop_infos.post-fusion.json");
     }
 
+    CompileStatistics::add_metric_if_enabled("fused-by-domain", state.fused_by_domain_count);
+    CompileStatistics::add_metric_if_enabled("fused-by-access", state.fused_by_access_count);
+
     return state.total_fused_count();
 }
 

--- a/opt/src/passes/normalization/normalize.cpp
+++ b/opt/src/passes/normalization/normalize.cpp
@@ -15,7 +15,7 @@ namespace passes {
 namespace normalization {
 
 void normalize(sdfg::StructuredSDFG& sdfg, bool enable_fusion) {
-    sdfg::passes::CompileStatistics::enter_stage_if_enabled("normalize");
+    CompileStatistics::enter_stage_if_enabled("normalize");
     builder::StructuredSDFGBuilder builder(sdfg);
     analysis::AnalysisManager analysis_manager(sdfg);
 
@@ -28,31 +28,31 @@ void normalize(sdfg::StructuredSDFG& sdfg, bool enable_fusion) {
         auto pipeline = stride_minimization();
         pipeline.run(builder, analysis_manager);
 
-        sdfg::passes::Pipeline dce = sdfg::passes::Pipeline::dead_code_elimination();
-        sdfg::passes::DeadDataElimination dde;
+        Pipeline dce = Pipeline::dead_code_elimination();
+        DeadDataElimination dde;
 
         // New Map Fusion, simpler than previous, but what it can do should be cheaper to do
-        sdfg::passes::loop_fusion::LoopFusionPass loop_fusion_pass({.allow_init_hoist = true});
+        loop_fusion::LoopFusionPass loop_fusion_pass({.allow_init_hoist = true});
         loop_fusion_pass.run(builder, analysis_manager);
 
         // Cleanup of artifacts of MapFusion
         dde.run(builder, analysis_manager);
         dce.run(builder, analysis_manager);
-        sdfg::passes::Pipeline block_fusion("BlockFusion");
-        block_fusion.register_pass<sdfg::passes::BlockFusionPass>();
+        Pipeline block_fusion("BlockFusion");
+        block_fusion.register_pass<BlockFusionPass>();
         block_fusion.run(builder, analysis_manager);
 
-        sdfg::passes::RedundantLoadEliminationPass rle;
+        RedundantLoadEliminationPass rle;
         rle.run(builder, analysis_manager);
         dde.run(builder, analysis_manager);
-        sdfg::passes::TaskletFusionPass task_fuse_pass;
+        TaskletFusionPass task_fuse_pass;
         task_fuse_pass.run(builder, analysis_manager);
 
         // Fuse maps (final run: allow init-into-reduction hoisting now that distribution is done)
         auto map_fusion_hoist = map_fusion(true, false);
         map_fusion_hoist.run(builder, analysis_manager);
     }
-    sdfg::passes::CompileStatistics::exit_stage_if_enabled();
+    CompileStatistics::exit_stage_if_enabled();
 }
 
 } // namespace normalization

--- a/opt/src/passes/normalization/normalize.cpp
+++ b/opt/src/passes/normalization/normalize.cpp
@@ -15,6 +15,7 @@ namespace passes {
 namespace normalization {
 
 void normalize(sdfg::StructuredSDFG& sdfg, bool enable_fusion) {
+    sdfg::passes::CompileStatistics::enter_stage_if_enabled("normalize");
     builder::StructuredSDFGBuilder builder(sdfg);
     analysis::AnalysisManager analysis_manager(sdfg);
 
@@ -51,6 +52,7 @@ void normalize(sdfg::StructuredSDFG& sdfg, bool enable_fusion) {
         auto map_fusion_hoist = map_fusion(true, false);
         map_fusion_hoist.run(builder, analysis_manager);
     }
+    sdfg::passes::CompileStatistics::exit_stage_if_enabled();
 }
 
 } // namespace normalization

--- a/opt/tests/sdfg_debug_dump.h
+++ b/opt/tests/sdfg_debug_dump.h
@@ -3,3 +3,6 @@
 #include <sdfg/structured_sdfg.h>
 
 void dump_sdfg(const sdfg::StructuredSDFG& sdfg, const std::string& step);
+
+
+std::optional<std::filesystem::path> get_test_output_dir();

--- a/opt/tests/test.cpp
+++ b/opt/tests/test.cpp
@@ -43,6 +43,19 @@ void dump_sdfg(const sdfg::StructuredSDFG& sdfg, const std::string& step) {
     }
 }
 
+std::optional<std::filesystem::path> get_test_output_dir() {
+    if (test_output_dir) {
+        auto info = ::testing::UnitTest::GetInstance()->current_test_info();
+        auto suite_name = info->test_suite_name();
+        auto test_name = info->name();
+        auto base_path = test_output_dir.value() / suite_name / test_name;
+        std::filesystem::create_directories(base_path);
+        return base_path;
+    } else {
+        return {};
+    }
+}
+
 void dump_loop_info(const sdfg::analysis::LoopAnalysis& analysis, const std::string& step) {
     if (test_output_dir) {
         auto info = ::testing::UnitTest::GetInstance()->current_test_info();

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -987,9 +987,7 @@ PYBIND11_MODULE(_sdfg, m) {
     m.def(
         "_enable_statistics",
         []() {
-            sdfg::passes::PassStatistics::instance().enable();
-            sdfg::passes::PipelineStatistics::instance().enable();
-            sdfg::passes::AnalysisStatistics::instance().enable();
+            sdfg::passes::CompileStatistics::enable();
             sdfg::passes::CodegenStatistics::instance().enable();
         },
         "Enable pass, pipeline, and analysis statistics collection"
@@ -999,13 +997,23 @@ PYBIND11_MODULE(_sdfg, m) {
         &sdfg::passes::statistics_enabled_by_env,
         "Check if DOCC_STATISTICS envvar is set to 1"
     );
+    m.def("_statistics_mode_by_env", &sdfg::passes::statistics_mode_env, "Return int value of DOCC_STATISTICS env var");
+    m.def(
+        "_statistics_report",
+        [](int mode) {
+            std::string result;
+            result += sdfg::passes::CompileStatistics::instance()
+                          .report(static_cast<sdfg::passes::CompileStatistics::ReportLevel>(mode));
+            result += sdfg::passes::CodegenStatistics::instance().summary();
+            return result;
+        },
+        "Get pass and pipeline statistics summary"
+    );
     m.def(
         "_statistics_summary",
         []() {
             std::string result;
-            result += sdfg::passes::PassStatistics::instance().summary();
-            result += sdfg::passes::PipelineStatistics::instance().summary();
-            result += sdfg::passes::AnalysisStatistics::instance().summary();
+            result += sdfg::passes::CompileStatistics::instance().summary();
             result += sdfg::passes::CodegenStatistics::instance().summary();
             return result;
         },

--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -153,6 +153,7 @@ pybind11::dict PyStructuredSDFG::containers() const {
 void PyStructuredSDFG::validate() { sdfg_->validate(); }
 
 void PyStructuredSDFG::einsum() {
+    sdfg::passes::CompileStatistics::enter_stage_if_enabled("einsum");
     sdfg::builder::StructuredSDFGBuilder builder_opt(*sdfg_);
     sdfg::analysis::AnalysisManager analysis_manager(*sdfg_);
 
@@ -171,6 +172,7 @@ void PyStructuredSDFG::einsum() {
     // Convert einsum into blas nodes (best-effort)
     sdfg::passes::EinsumConversionPass einsum_conversion_pass;
     einsum_conversion_pass.run(builder_opt, analysis_manager);
+    sdfg::passes::CompileStatistics::exit_stage_if_enabled();
 }
 
 void PyStructuredSDFG::expand() {
@@ -184,6 +186,7 @@ void PyStructuredSDFG::expand(const std::string& target, const std::string& cate
 }
 
 void PyStructuredSDFG::expand(const docc::target::TargetOptions& options) {
+    sdfg::passes::CompileStatistics::enter_stage_if_enabled("expand");
     sdfg::builder::StructuredSDFGBuilder builder_opt(*sdfg_);
     sdfg::analysis::AnalysisManager analysis_manager(*sdfg_);
 
@@ -212,10 +215,12 @@ void PyStructuredSDFG::expand(const docc::target::TargetOptions& options) {
     // Workaround until built-in targets are supported by the above mechanism
     sdfg::passes::DotExpansionPass dot_expansion_pass;
     dot_expansion_pass.run(builder_opt, analysis_manager);
+    sdfg::passes::CompileStatistics::exit_stage_if_enabled();
 }
 
 
 void PyStructuredSDFG::simplify() {
+    sdfg::passes::CompileStatistics::enter_stage_if_enabled("simplify");
     sdfg::builder::StructuredSDFGBuilder builder_opt(*sdfg_);
     sdfg::analysis::AnalysisManager analysis_manager(*sdfg_);
 
@@ -364,9 +369,11 @@ void PyStructuredSDFG::simplify() {
     // normalize() map-fusion run so loop distribution and fusion do not fight)
     auto map_fusion = sdfg::passes::normalization::map_fusion(false, false);
     map_fusion.run(builder_opt, analysis_manager);
+
+    sdfg::passes::CompileStatistics::exit_stage_if_enabled();
 }
 
-constexpr bool DEBUG_SDFG_DUMPS = false;
+constexpr bool DEBUG_SDFG_DUMPS = true;
 
 void PyStructuredSDFG::dump_debug(const std::string& type, bool dump_dot, bool dump_json) {
     if constexpr (DEBUG_SDFG_DUMPS) {
@@ -427,6 +434,7 @@ void PyStructuredSDFG::schedule(const std::string& target, const std::string& ca
     schedule(topts);
 }
 void PyStructuredSDFG::schedule(const docc::target::TargetOptions& options) {
+    sdfg::passes::CompileStatistics::enter_stage_if_enabled("schedule");
     if (options.target == "none") {
         return;
     }
@@ -482,9 +490,11 @@ void PyStructuredSDFG::schedule(const docc::target::TargetOptions& options) {
         sdfg::passes::DeadCFGElimination dead_cfg_elimination;
         dead_cfg_elimination.run(builder, analysis_manager);
     }
+    sdfg::passes::CompileStatistics::exit_stage_if_enabled();
 }
 
 bool PyStructuredSDFG::promote_device_residency(bool is_rocm) {
+    sdfg::passes::CompileStatistics::enter_stage_if_enabled("promote_device_residency");
     sdfg::builder::StructuredSDFGBuilder builder(*sdfg_);
     sdfg::analysis::AnalysisManager analysis_manager(*sdfg_);
 
@@ -518,6 +528,7 @@ bool PyStructuredSDFG::promote_device_residency(bool is_rocm) {
         dead_data_elimination.run(builder, analysis_manager);
     }
 
+    sdfg::passes::CompileStatistics::exit_stage_if_enabled();
     return promoted;
 }
 

--- a/python/docc/compiler/docc_program.py
+++ b/python/docc/compiler/docc_program.py
@@ -8,8 +8,8 @@ import re
 from docc.sdfg import StructuredSDFG, TargetOptions
 from docc.sdfg._sdfg import (
     _enable_statistics,
-    _statistics_enabled_by_env,
-    _statistics_summary,
+    _statistics_mode_by_env,
+    _statistics_report,
 )
 from docc.compiler.compiled_sdfg import CompiledSDFG
 from docc.compiler.target_registry import (
@@ -153,7 +153,8 @@ class DoccProgram(ABC):
                 sdfg.output_dir = output_folder
 
             # Enable statistics if envvar is set
-            if _statistics_enabled_by_env():
+            stats_mode = _statistics_mode_by_env()
+            if stats_mode > 0:
                 _enable_statistics()
 
             sdfg.validate()
@@ -249,8 +250,8 @@ class DoccProgram(ABC):
             )
 
         # Dump statistics after compile
-        if _statistics_enabled_by_env():
-            print(_statistics_summary(), file=sys.stderr)
+        if stats_mode > 0:
+            print(_statistics_report(stats_mode), file=sys.stderr)
 
         # Record the device-residency decision in the persisted (py4.norm) SDFG
         # metadata. It is computed here (not stored in metadata by the pass) and

--- a/sdfg/include/sdfg/analysis/analysis.h
+++ b/sdfg/include/sdfg/analysis/analysis.h
@@ -35,7 +35,7 @@ private:
 
     std::unordered_map<std::type_index, std::unique_ptr<Analysis>> cache_;
 
-    static constexpr std::string STATS_SCOPE = "AnalysisMgr";
+    static constexpr const char* STATS_SCOPE = "AnalysisMgr";
 
 public:
     AnalysisManager(StructuredSDFG& sdfg);

--- a/sdfg/include/sdfg/analysis/analysis.h
+++ b/sdfg/include/sdfg/analysis/analysis.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <chrono>
-
 #include "sdfg/passes/statistics.h"
 #include "sdfg/structured_sdfg.h"
 
@@ -37,6 +35,8 @@ private:
 
     std::unordered_map<std::type_index, std::unique_ptr<Analysis>> cache_;
 
+    static constexpr std::string STATS_SCOPE = "AnalysisMgr";
+
 public:
     AnalysisManager(StructuredSDFG& sdfg);
     AnalysisManager(StructuredSDFG& sdfg, const symbolic::Assumptions& additional_assumptions);
@@ -55,19 +55,19 @@ public:
         }
 
         // Run a new analysis
-        std::chrono::high_resolution_clock::time_point start;
-        if (passes::AnalysisStatistics::instance().enabled()) {
-            start = std::chrono::high_resolution_clock::now();
-        }
-
         cache_[type] = std::make_unique<T>(this->sdfg_);
         cache_[type]->additional_assumptions_ = this->additional_assumptions_;
+
+        passes::CompileStatistics* stats = nullptr;
+        if (passes::CompileStatistics::enabled()) {
+            stats = &passes::CompileStatistics::instance();
+            stats->enter_scope(cache_[type]->name(), STATS_SCOPE);
+        }
+
         cache_[type]->run(*this);
 
-        if (passes::AnalysisStatistics::instance().enabled()) {
-            auto end = std::chrono::high_resolution_clock::now();
-            auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-            passes::AnalysisStatistics::instance().add_analysis(cache_[type]->name(), duration);
+        if (stats) {
+            stats->exit_scope();
         }
 
         return *static_cast<T*>(cache_[type].get());

--- a/sdfg/include/sdfg/passes/pipeline.h
+++ b/sdfg/include/sdfg/passes/pipeline.h
@@ -25,9 +25,12 @@ class Pipeline : public Pass {
 private:
     std::vector<std::unique_ptr<Pass>> passes_;
     std::string name_;
+    bool debug_logging_ = false;
 
 public:
     Pipeline(const std::string& name);
+
+    void set_debug_logging(bool enable);
 
     virtual std::string name();
 

--- a/sdfg/include/sdfg/passes/statistics.h
+++ b/sdfg/include/sdfg/passes/statistics.h
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include <cstdlib>
+#include <functional>
+#include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace sdfg {
 namespace passes {
@@ -15,66 +19,182 @@ inline bool statistics_enabled_by_env() {
     return val != nullptr && std::string(val) == "1";
 }
 
-class PassStatistics {
-private:
-    bool enabled_ = false;
-    std::unordered_map<std::string, uint64_t> sdfg_count_, sdfg_time_, structured_sdfg_count_, structured_sdfg_time_;
+int statistics_mode_env();
+
+// Generic base class for hierarchical statistics collection.
+// Captures a tree of named scopes; each scope stores an enter/exit timestamp
+// and a map of uint64 metrics (e.g. "loopCount"). The class takes over the
+// timing: enter() and exit() record the timestamps automatically.
+// Not thread-safe by design: one instance is expected to be used per thread.
+class HierarchicalStatistics {
+public:
+    struct Node {
+        std::string scope_type;
+        std::string name;
+        std::chrono::high_resolution_clock::time_point enter_time;
+        std::chrono::high_resolution_clock::time_point exit_time;
+        std::unordered_map<std::string, uint64_t> metrics;
+        Node* parent = nullptr;
+        std::vector<std::unique_ptr<Node>> children;
+
+        uint64_t duration_ms() const;
+    };
+
+protected:
+    std::vector<std::unique_ptr<Node>> roots_;
+    Node* current_ = nullptr;
+
+    enum class RemapAction { Proceed, NoDescend, Skip };
+
+    static void print_node_self(std::ostream& stream, const Node& node, int depth);
+
+    void print_node(std::ostream& stream, const HierarchicalStatistics::Node& node, int depth);
+
+    virtual RemapAction custom_print_node(std::ostream& out, const Node&, int depth);
+
+    std::string report(const std::string& title);
 
 public:
-    static PassStatistics& instance() {
-        static PassStatistics pass_statistics;
-        return pass_statistics;
-    }
+    virtual ~HierarchicalStatistics() = default;
 
-    bool enabled() { return enabled_; }
-    void enable() { enabled_ = true; }
-    void disable() { enabled_ = false; }
+    // Open a new scope as a child of the currently active scope.
+    Node* enter_scope(const std::string& name, const std::string& scope_type);
 
-    void add_sdfg_pass(const std::string& name, uint64_t milliseconds);
-    void add_structured_sdfg_pass(const std::string& name, uint64_t milliseconds);
+    // Close the currently active scope.
+    void exit_scope();
 
-    std::string summary();
+    // Set/accumulate a metric on the currently active scope.
+    void set_metric(const std::string& key, uint64_t value);
+    void add_metric(const std::string& key, uint64_t value);
+
+    void clear();
 };
 
-class PipelineStatistics {
-private:
-    bool enabled_ = false;
-    std::unordered_map<std::string, uint64_t> sdfg_count_, sdfg_time_, structured_sdfg_count_, structured_sdfg_time_;
+class CompileStatistics : public HierarchicalStatistics {
+public:
+    enum class ReportLevel {
+        PipelineTotalsOnly = 0,
+        SummarizePipelineContentsAndAnalysis = 1,
+        All = 2,
+    };
+
+protected:
+    static bool enabled_;
+
+    static constexpr const char* ANALYSIS_SCOPE = "Analysis";
+    static constexpr const char* ANALYSIS_MGR_SCOPE = "AnalysisMgr";
+    static constexpr const char* PASS_SCOPE = "Pass";
+    static constexpr const char* PIPELINE_SCOPE = "Pipeline";
+    static constexpr const char* STAGE_SCOPE = "Stage";
+    ReportLevel report_detail_ = ReportLevel::SummarizePipelineContentsAndAnalysis;
 
 public:
-    static PipelineStatistics& instance() {
-        static PipelineStatistics pipeline_statistics;
-        return pipeline_statistics;
-    }
-
-    bool enabled() { return enabled_; }
-    void enable() { enabled_ = true; }
-    void disable() { enabled_ = false; }
-
-    void add_sdfg_pipeline(const std::string& name, uint64_t milliseconds);
-    void add_structured_sdfg_pipeline(const std::string& name, uint64_t milliseconds);
-
-    std::string summary();
-};
-
-class AnalysisStatistics {
-private:
-    bool enabled_ = false;
-    std::unordered_map<std::string, uint64_t> count_, time_;
-
-public:
-    static AnalysisStatistics& instance() {
-        static AnalysisStatistics analysis_statistics;
+    static CompileStatistics& instance() {
+        static CompileStatistics analysis_statistics;
         return analysis_statistics;
     }
 
-    bool enabled() { return enabled_; }
-    void enable() { enabled_ = true; }
-    void disable() { enabled_ = false; }
+    // Static wrappers that no-op when statistics are disabled.
+    static void enter_analysis_if_enabled(const std::string& name) {
+        if (CompileStatistics::enabled_) {
+            auto& inst = instance();
+            inst.enter_analysis(name);
+        }
+    }
 
-    void add_analysis(const std::string& name, uint64_t milliseconds);
+    void enter_analysis(const std::string& name) { enter_scope(name, ANALYSIS_SCOPE); }
+
+    void exit_analysis() { exit_scope(); }
+
+    static void exit_analysis_if_enabled() {
+        if (CompileStatistics::enabled_) {
+            auto& inst = instance();
+            inst.exit_analysis();
+        }
+    }
+
+    static void enter_pass_if_enabled(const std::string& name) {
+        if (enabled_) {
+            auto& inst = instance();
+            inst.enter_pass(name);
+        }
+    }
+
+    void enter_pass(const std::string& name) { enter_scope(name, PASS_SCOPE); }
+
+    static void exit_pass_if_enabled() {
+        if (enabled_) {
+            auto& inst = instance();
+            inst.exit_pass();
+        }
+    }
+
+    void exit_pass() { exit_scope(); }
+
+    static void enter_pipeline_if_enabled(const std::string& name) {
+        if (enabled_) {
+            auto& inst = instance();
+            inst.enter_pipeline(name);
+        }
+    }
+
+    void enter_pipeline(const std::string& name) { enter_scope(name, PIPELINE_SCOPE); }
+
+    static void exit_pipeline_if_enabled() {
+        if (enabled_) {
+            auto& inst = instance();
+            inst.exit_pipeline();
+        }
+    }
+
+    void exit_pipeline() { exit_scope(); }
+
+    static void enter_stage_if_enabled(const std::string& name) {
+        if (enabled_) {
+            auto& inst = instance();
+            inst.enter_stage(name);
+        }
+    }
+
+    void enter_stage(const std::string& name) { enter_scope(name, STAGE_SCOPE); }
+
+    static void exit_stage_if_enabled() {
+        if (enabled_) {
+            auto& inst = instance();
+            inst.exit_stage();
+        }
+    }
+
+    void exit_stage() { exit_scope(); }
+
+    static void set_metric_if_enabled(const std::string& key, uint64_t value) {
+        if (enabled_) {
+            auto& inst = instance();
+            inst.set_metric(key, value);
+        }
+    }
+
+    static void add_metric_if_enabled(const std::string& key, uint64_t value) {
+        if (enabled_) {
+            auto& inst = instance();
+            inst.add_metric(key, value);
+        }
+    }
+
+    static bool enabled() { return enabled_; }
+    static void enable() { enabled_ = true; }
+    static void disable() { enabled_ = false; }
 
     std::string summary();
+
+    std::string report(ReportLevel detail);
+
+protected:
+    RemapAction custom_print_node(std::ostream& out, const Node& node, int depth) override;
+
+    // Collapse a pipeline scope into a single level: passes are summed per name,
+    // any other scope type is aggregated into an "other" bucket per scope type.
+    static void summarize_pipeline_passes(std::ostream& out, const Node& node, int depth);
 };
 
 class CodegenStatistics {

--- a/sdfg/src/analysis/analysis.cpp
+++ b/sdfg/src/analysis/analysis.cpp
@@ -18,7 +18,23 @@ AnalysisManager::AnalysisManager(StructuredSDFG& sdfg, const symbolic::Assumptio
 
       };
 
-void AnalysisManager::invalidate_all() { cache_.clear(); };
+void AnalysisManager::invalidate_all() {
+    if (cache_.empty()) {
+        return;
+    }
+    passes::CompileStatistics* stats = nullptr;
+    if (passes::CompileStatistics::enabled()) {
+        stats = &passes::CompileStatistics::instance();
+        stats->enter_scope("invalidate_all", STATS_SCOPE);
+        stats->add_metric("invalidations", cache_.size());
+    }
+
+    cache_.clear();
+
+    if (stats) {
+        stats->exit_scope();
+    }
+}
 
 } // namespace analysis
 } // namespace sdfg

--- a/sdfg/src/analysis/loop_carried_dependency_analysis.cpp
+++ b/sdfg/src/analysis/loop_carried_dependency_analysis.cpp
@@ -389,8 +389,10 @@ void LoopCarriedDependencyAnalysis::run(analysis::AnalysisManager& analysis_mana
     //                                       cont(W) = cont(R), Δ ≠ ∅ }
     //            ∪ { (W₁,W₂, WAW, Δ_L(W₁,W₂)) : W₁,W₂ ∈ esc(L),
     //                                           cont(W₁) = cont(W₂), Δ ≠ ∅ }
+    passes::CompileStatistics::enter_analysis_if_enabled("DetailedDDA");
     auto& dda = detailed_dda();
     dda.run(analysis_manager);
+    passes::CompileStatistics::exit_analysis_if_enabled();
     auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();
 
     for (auto* loop_node : loop_analysis.loops()) {

--- a/sdfg/src/passes/pass.cpp
+++ b/sdfg/src/passes/pass.cpp
@@ -9,24 +9,11 @@ namespace sdfg {
 namespace passes {
 
 bool Pass::run(builder::SDFGBuilder& builder, bool create_report) {
-    std::chrono::high_resolution_clock::time_point start;
-    if (PassStatistics::instance().enabled()) {
-        start = std::chrono::high_resolution_clock::now();
-#ifndef NDEBUG
-        DEBUG_PRINTLN("Started SDFG Pass '" << this->name() << "' on '" << builder.subject().name() << "'");
-#endif
-    }
+    CompileStatistics::enter_pass_if_enabled(this->name());
 
     bool applied = this->run_pass(builder);
 
-    if (PassStatistics::instance().enabled()) {
-        auto end = std::chrono::high_resolution_clock::now();
-        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-        PassStatistics::instance().add_sdfg_pass(this->name(), duration);
-#ifndef NDEBUG
-        DEBUG_PRINTLN("Finished SDFG Pass '" << this->name() << "' in " << duration << " ms");
-#endif
-    }
+    CompileStatistics::exit_pass_if_enabled();
 
 #ifndef NDEBUG
     builder.subject().validate();
@@ -36,26 +23,12 @@ bool Pass::run(builder::SDFGBuilder& builder, bool create_report) {
 };
 
 bool Pass::run(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager, bool create_report) {
-    std::chrono::high_resolution_clock::time_point start;
-    if (PassStatistics::instance().enabled()) {
-        start = std::chrono::high_resolution_clock::now();
-#ifndef NDEBUG
-        DEBUG_PRINTLN("Started Structured SDFG Pass '" << this->name() << "' on '" << builder.subject().name() << "'");
-#endif
-    }
+    CompileStatistics::enter_pass_if_enabled(this->name());
 
     bool applied = this->run_pass(builder, analysis_manager);
     this->invalidates(analysis_manager, applied);
 
-    if (PassStatistics::instance().enabled()) {
-        auto end = std::chrono::high_resolution_clock::now();
-        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-        PassStatistics::instance().add_structured_sdfg_pass(this->name(), duration);
-#ifndef NDEBUG
-        DEBUG_PRINTLN("Finished Structured SDFG Pass '" << this->name() << "' in " << duration << " ms");
-#endif
-    }
-
+    CompileStatistics::exit_pass_if_enabled();
 #ifndef NDEBUG
     builder.subject().validate();
 #endif

--- a/sdfg/src/passes/pipeline.cpp
+++ b/sdfg/src/passes/pipeline.cpp
@@ -8,30 +8,25 @@
 #include "sdfg/passes/schedules/expansion_pass.h"
 #include "sdfg/passes/statistics.h"
 #include "sdfg/passes/structured_control_flow/block_fusion.h"
+#include "sdfg/visualizer/dot_visualizer.h"
 
 namespace sdfg {
 namespace passes {
 
-Pipeline::Pipeline(const std::string& name)
-    : Pass(), name_(name) {
+Pipeline::Pipeline(const std::string& name) : Pass(), name_(name) {}
 
-      };
+void Pipeline::set_debug_logging(bool enable) { debug_logging_ = enable; }
 
 std::string Pipeline::name() { return this->name_; };
 
 size_t Pipeline::size() const { return this->passes_.size(); };
 
 bool Pipeline::run(builder::SDFGBuilder& builder) {
-    std::chrono::high_resolution_clock::time_point start;
-    if (PipelineStatistics::instance().enabled()) {
-        start = std::chrono::high_resolution_clock::now();
-#ifndef NDEBUG
-        DEBUG_PRINTLN("Started SDFG Pipeline '" << this->name() << "' on '" << builder.subject().name() << "'");
-#endif
-    }
+    CompileStatistics::enter_pipeline_if_enabled(name_);
 
     bool applied = false;
     bool applied_pipeline;
+    uint32_t pipe_iterations = 0;
     do {
         applied_pipeline = false;
         for (auto& pass : this->passes_) {
@@ -42,51 +37,56 @@ bool Pipeline::run(builder::SDFGBuilder& builder) {
             } while (applied_pass);
         }
         applied |= applied_pipeline;
+        ++pipe_iterations;
     } while (applied_pipeline);
 
-    if (PipelineStatistics::instance().enabled()) {
-        auto end = std::chrono::high_resolution_clock::now();
-        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-        PipelineStatistics::instance().add_sdfg_pipeline(this->name(), duration);
-#ifndef NDEBUG
-        DEBUG_PRINTLN("Finished SDFG Pipeline '" << this->name() << "' in " << duration << " ms");
-#endif
-    }
-
+    CompileStatistics::add_metric_if_enabled("pipeline_iterations", pipe_iterations);
+    CompileStatistics::exit_pipeline_if_enabled();
     return applied;
 };
 
 bool Pipeline::run(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {
-    std::chrono::high_resolution_clock::time_point start;
-    if (PipelineStatistics::instance().enabled()) {
-        start = std::chrono::high_resolution_clock::now();
-#ifndef NDEBUG
-        DEBUG_PRINTLN("Started Structured SDFG Pipeline '" << this->name() << "' on '" << builder.subject().name() << "'");
-#endif
+    CompileStatistics::enter_pipeline_if_enabled(name_);
+
+    static uint32_t runs = 0;
+    auto dir = builder.subject().metadata_if_exists("output_dir");
+    std::optional<std::filesystem::path> output_dir;
+    if (dir) {
+        std::filesystem::path p = *dir;
+        output_dir = p / ("pipeline_" + this->name_ + "_" + std::to_string(runs));
     }
 
     bool applied = false;
     bool applied_pipeline;
+    uint32_t pipe_iterations = 0;
     do {
         applied_pipeline = false;
+        uint32_t pass_idx = 0;
         for (auto& pass : this->passes_) {
             bool applied_pass = false;
+            uint32_t pass_iterations = 0;
             do {
+                if (debug_logging_) {
+                    if (output_dir.has_value())
+                        visualizer::DotVisualizer::writeToFile(
+                            builder.subject(),
+                            output_dir.value() /
+                                ("pipe_" + std::to_string(pass_iterations) + "_" + std::to_string(pass_idx) + "_" +
+                                 pass->name() + "_" + std::to_string(pass_iterations) + ".sdfg.dot")
+                        );
+                }
                 applied_pass = pass->run(builder, analysis_manager);
                 applied_pipeline |= applied_pass;
+                ++pass_iterations;
             } while (applied_pass);
+            ++pass_idx;
         }
         applied |= applied_pipeline;
+        ++pipe_iterations;
     } while (applied_pipeline);
+    CompileStatistics::add_metric_if_enabled("pipeline_iterations", pipe_iterations);
 
-    if (PipelineStatistics::instance().enabled()) {
-        auto end = std::chrono::high_resolution_clock::now();
-        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-        PipelineStatistics::instance().add_structured_sdfg_pipeline(this->name(), duration);
-#ifndef NDEBUG
-        DEBUG_PRINTLN("Finished Structured SDFG Pipeline '" << this->name() << "' in " << duration << " ms");
-#endif
-    }
+    CompileStatistics::exit_pipeline_if_enabled();
 
     return applied;
 };

--- a/sdfg/src/passes/statistics.cpp
+++ b/sdfg/src/passes/statistics.cpp
@@ -2,43 +2,190 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <functional>
+#include <iostream>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
+
+#include "sdfg/helpers/helpers.h"
+#include "sdfg/passes/expansion/lib_node_expander.h"
 
 namespace sdfg {
 namespace passes {
 
-void PassStatistics::add_sdfg_pass(const std::string& name, uint64_t milliseconds) {
-    if (!sdfg_count_.contains(name)) {
-        sdfg_count_.insert({name, 1});
-    } else {
-        sdfg_count_[name]++;
+constexpr bool LOG_SCOPE_ENTRY_EXIT = false;
+
+
+HierarchicalStatistics::Node* HierarchicalStatistics::enter_scope(const std::string& name, const std::string& scope_type) {
+    auto node = std::make_unique<Node>();
+    node->scope_type = scope_type;
+    node->name = name;
+    node->parent = current_;
+    node->enter_time = std::chrono::high_resolution_clock::now();
+
+    if (LOG_SCOPE_ENTRY_EXIT) {
+        DEBUG_PRINTLN("Started " << scope_type << " '" << name);
     }
-    if (!sdfg_time_.contains(name)) {
-        sdfg_time_.insert({name, milliseconds});
+
+    Node* raw = node.get();
+    if (current_ == nullptr) {
+        roots_.push_back(std::move(node));
     } else {
-        sdfg_time_[name] += milliseconds;
+        current_->children.push_back(std::move(node));
+    }
+    current_ = raw;
+    return raw;
+}
+
+void HierarchicalStatistics::exit_scope() {
+    if (current_ == nullptr) {
+        return;
+    }
+    current_->exit_time = std::chrono::high_resolution_clock::now();
+
+    auto duration =
+        std::chrono::duration_cast<std::chrono::milliseconds>(current_->exit_time - current_->enter_time).count();
+
+    if (LOG_SCOPE_ENTRY_EXIT) {
+        DEBUG_PRINTLN("Finished " << current_->scope_type << " '" << current_->name << "' in " << duration << " ms");
+    }
+
+    current_ = current_->parent;
+}
+
+void HierarchicalStatistics::set_metric(const std::string& key, uint64_t value) {
+    if (current_ == nullptr) {
+        return;
+    }
+    current_->metrics[key] = value;
+}
+
+void HierarchicalStatistics::add_metric(const std::string& key, uint64_t value) {
+    if (current_ == nullptr) {
+        return;
+    }
+    current_->metrics[key] += value;
+}
+
+void HierarchicalStatistics::clear() {
+    roots_.clear();
+    current_ = nullptr;
+}
+
+int statistics_mode_env() {
+    const char* val = std::getenv(DOCC_STATISTICS_ENV);
+    if (val == nullptr) {
+        return 0;
+    }
+    return std::stoi(val);
+}
+
+uint64_t HierarchicalStatistics::Node::duration_ms() const {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(this->exit_time - this->enter_time).count();
+}
+
+void HierarchicalStatistics::print_node_self(std::ostream& stream, const HierarchicalStatistics::Node& node, int depth) {
+    std::string indent(2 * (depth + 1), ' ');
+    stream << indent << node.scope_type << " " << node.name << "  " << node.duration_ms() << " ms  ";
+    if (!node.metrics.empty()) {
+        std::vector<std::pair<std::string, uint64_t>> metrics(node.metrics.begin(), node.metrics.end());
+        std::sort(metrics.begin(), metrics.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
+        stream << "  [";
+        for (size_t i = 0; i < metrics.size(); ++i) {
+            if (i > 0) {
+                stream << ", ";
+            }
+            stream << metrics[i].first << "=" << metrics[i].second;
+        }
+        stream << "]";
+    }
+    stream << std::endl;
+}
+
+HierarchicalStatistics::RemapAction HierarchicalStatistics::custom_print_node(std::ostream& out, const Node&, int depth) {
+    return RemapAction::Proceed;
+}
+
+void HierarchicalStatistics::print_node(std::ostream& stream, const HierarchicalStatistics::Node& node, int depth) {
+    bool descend_children = true;
+    RemapAction action = custom_print_node(stream, node, depth);
+    if (action == RemapAction::Skip) {
+        return;
+    } else if (action == RemapAction::NoDescend) {
+        descend_children = false;
+    }
+
+    print_node_self(stream, node, depth);
+    if (descend_children) {
+        for (const auto& child : node.children) {
+            print_node(stream, *child, depth + 1);
+        }
     }
 }
 
-void PassStatistics::add_structured_sdfg_pass(const std::string& name, uint64_t milliseconds) {
-    if (!structured_sdfg_count_.contains(name)) {
-        structured_sdfg_count_.insert({name, 1});
-    } else {
-        structured_sdfg_count_[name]++;
-    }
-    if (!structured_sdfg_time_.contains(name)) {
-        structured_sdfg_time_.insert({name, milliseconds});
-    } else {
-        structured_sdfg_time_[name] += milliseconds;
-    }
-}
-
-std::string PassStatistics::summary() {
-    if (sdfg_count_.empty() && structured_sdfg_count_.empty()) {
+std::string HierarchicalStatistics::report(const std::string& title) {
+    if (roots_.empty()) {
         return "";
+    }
+    std::stringstream stream;
+    stream << title << std::endl;
+    for (const auto& root : roots_) {
+        print_node(stream, *root, 0);
+    }
+    return stream.str();
+}
+
+bool CompileStatistics::enabled_ = false;
+
+std::string CompileStatistics::summary() { return report(ReportLevel::SummarizePipelineContentsAndAnalysis); }
+
+HierarchicalStatistics::RemapAction CompileStatistics::custom_print_node(std::ostream& out, const Node& node, int depth) {
+    auto level = report_detail_;
+    if (node.scope_type == PIPELINE_SCOPE) {
+        if (level == ReportLevel::SummarizePipelineContentsAndAnalysis) {
+            print_node_self(out, node, depth);
+            summarize_pipeline_passes(out, node, depth);
+            return RemapAction::Skip;
+        } else if (level == ReportLevel::PipelineTotalsOnly) {
+            return RemapAction::NoDescend;
+        } else {
+            return RemapAction::Proceed;
+        }
+    } else if (node.scope_type == ANALYSIS_SCOPE || node.scope_type == PASS_SCOPE) {
+        if (level != ReportLevel::All) {
+            return RemapAction::NoDescend;
+        } else {
+            return RemapAction::Proceed;
+        }
+    } else if (node.scope_type == ANALYSIS_MGR_SCOPE && depth < 2 && level != ReportLevel::All) {
+        return RemapAction::Skip;
+    }
+    return RemapAction::Proceed;
+}
+
+void CompileStatistics::summarize_pipeline_passes(std::ostream& out, const HierarchicalStatistics::Node& node, int depth) {
+    // Aggregate direct children only: passes by name, everything else under "other" by scope type.
+    std::unordered_map<std::string, std::pair<uint64_t, uint64_t>> passes;
+    std::vector<std::string> pass_order;
+    std::unordered_map<std::string, std::pair<uint64_t, uint64_t>> others;
+
+    for (const auto& child : node.children) {
+        if (child->scope_type == PASS_SCOPE) {
+            auto [it, inserted] = passes.try_emplace(child->name, 0, 0);
+            if (inserted) {
+                pass_order.push_back(child->name);
+            }
+            it->second.first += 1;
+            it->second.second += child->duration_ms();
+        } else {
+            auto& bucket = others[child->scope_type];
+            bucket.first += 1;
+            bucket.second += child->duration_ms();
+        }
     }
 
     auto compare_data_fn = [](const std::tuple<std::string, uint64_t, uint64_t>& a,
@@ -48,177 +195,31 @@ std::string PassStatistics::summary() {
         return a_milliseconds > b_milliseconds || (a_milliseconds == b_milliseconds && a_count > b_count) ||
                (a_milliseconds == b_milliseconds && a_count == b_count && a_name < b_name);
     };
-    std::stringstream stream;
-    stream << "Pass Statistics:" << std::endl;
 
-    std::vector<std::tuple<std::string, uint64_t, uint64_t>> sdfg_data;
-    uint64_t sdfg_time_sum = 0;
-    for (auto [name, count] : sdfg_count_) {
-        if (sdfg_time_.contains(name)) {
-            auto milliseconds = sdfg_time_[name];
-            sdfg_data.push_back({name, count, milliseconds});
-            sdfg_time_sum += milliseconds;
-        }
-    }
-    std::sort(sdfg_data.begin(), sdfg_data.end(), compare_data_fn);
+    std::string indent(2 * (depth + 2), ' ');
 
-    if (!sdfg_data.empty()) {
-        stream << "  SDFG Passes: " << sdfg_time_sum << " ms" << std::endl;
-        for (auto [name, count, milliseconds] : sdfg_data) {
-            stream << "    " << milliseconds << " ms  " << count << "  " << name << std::endl;
-        }
+    // Passes are reported in first-encounter order, matching the pipeline execution order.
+    for (const auto& name : pass_order) {
+        const auto& entry = passes[name];
+        out << indent << entry.first << " x " << name << "  " << entry.second << " ms" << std::endl;
     }
 
-    std::vector<std::tuple<std::string, uint64_t, uint64_t>> structured_sdfg_data;
-    uint64_t structured_sdfg_time_sum = 0;
-    for (auto [name, count] : structured_sdfg_count_) {
-        if (structured_sdfg_time_.contains(name)) {
-            auto milliseconds = structured_sdfg_time_[name];
-            structured_sdfg_data.push_back({name, count, milliseconds});
-            structured_sdfg_time_sum += milliseconds;
-        }
+    std::vector<std::tuple<std::string, uint64_t, uint64_t>> other_data;
+    for (const auto& [scope_type, entry] : others) {
+        other_data.push_back({scope_type, entry.first, entry.second});
     }
-    std::sort(structured_sdfg_data.begin(), structured_sdfg_data.end(), compare_data_fn);
-
-    if (!structured_sdfg_data.empty()) {
-        stream << "  Structured SDFG Passes: " << structured_sdfg_time_sum << " ms" << std::endl;
-        for (auto [name, count, milliseconds] : structured_sdfg_data) {
-            stream << "    " << milliseconds << " ms  " << count << "  " << name << std::endl;
-        }
-    }
-
-    return stream.str();
-}
-
-void PipelineStatistics::add_sdfg_pipeline(const std::string& name, uint64_t milliseconds) {
-    if (!sdfg_count_.contains(name)) {
-        sdfg_count_.insert({name, 1});
-    } else {
-        sdfg_count_[name]++;
-    }
-    if (!sdfg_time_.contains(name)) {
-        sdfg_time_.insert({name, milliseconds});
-    } else {
-        sdfg_time_[name] += milliseconds;
+    std::sort(other_data.begin(), other_data.end(), compare_data_fn);
+    for (const auto& [scope_type, count, milliseconds] : other_data) {
+        out << indent << "Other: " << milliseconds << " ms  " << count << "  " << scope_type << std::endl;
     }
 }
 
-void PipelineStatistics::add_structured_sdfg_pipeline(const std::string& name, uint64_t milliseconds) {
-    if (!structured_sdfg_count_.contains(name)) {
-        structured_sdfg_count_.insert({name, 1});
-    } else {
-        structured_sdfg_count_[name]++;
-    }
-    if (!structured_sdfg_time_.contains(name)) {
-        structured_sdfg_time_.insert({name, milliseconds});
-    } else {
-        structured_sdfg_time_[name] += milliseconds;
-    }
+std::string CompileStatistics::report(ReportLevel detail) {
+    this->report_detail_ = detail;
+
+    return HierarchicalStatistics::report("DOCC Statistics:");
 }
 
-std::string PipelineStatistics::summary() {
-    if (sdfg_count_.empty() && structured_sdfg_count_.empty()) {
-        return "";
-    }
-
-    auto compare_data_fn = [](const std::tuple<std::string, uint64_t, uint64_t>& a,
-                              const std::tuple<std::string, uint64_t, uint64_t>& b) {
-        auto [a_name, a_count, a_milliseconds] = a;
-        auto [b_name, b_count, b_milliseconds] = b;
-        return a_milliseconds > b_milliseconds || (a_milliseconds == b_milliseconds && a_count > b_count) ||
-               (a_milliseconds == b_milliseconds && a_count == b_count && a_name < b_name);
-    };
-    std::stringstream stream;
-    stream << "Pipeline Statistics:" << std::endl;
-
-    std::vector<std::tuple<std::string, uint64_t, uint64_t>> sdfg_data;
-    uint64_t sdfg_time_sum = 0;
-    for (auto [name, count] : sdfg_count_) {
-        if (sdfg_time_.contains(name)) {
-            auto milliseconds = sdfg_time_[name];
-            sdfg_data.push_back({name, count, milliseconds});
-            sdfg_time_sum += milliseconds;
-        }
-    }
-    std::sort(sdfg_data.begin(), sdfg_data.end(), compare_data_fn);
-
-    if (!sdfg_data.empty()) {
-        stream << "  SDFG Pipelines: " << sdfg_time_sum << " ms" << std::endl;
-        for (auto [name, count, milliseconds] : sdfg_data) {
-            stream << "    " << milliseconds << " ms  " << count << "  " << name << std::endl;
-        }
-    }
-
-    std::vector<std::tuple<std::string, uint64_t, uint64_t>> structured_sdfg_data;
-    uint64_t structured_sdfg_time_sum = 0;
-    for (auto [name, count] : structured_sdfg_count_) {
-        if (structured_sdfg_time_.contains(name)) {
-            auto milliseconds = structured_sdfg_time_[name];
-            structured_sdfg_data.push_back({name, count, milliseconds});
-            structured_sdfg_time_sum += milliseconds;
-        }
-    }
-    std::sort(structured_sdfg_data.begin(), structured_sdfg_data.end(), compare_data_fn);
-
-    if (!structured_sdfg_data.empty()) {
-        stream << "  Structured SDFG Pipelines: " << structured_sdfg_time_sum << " ms" << std::endl;
-        for (auto [name, count, milliseconds] : structured_sdfg_data) {
-            stream << "    " << milliseconds << " ms  " << count << "  " << name << std::endl;
-        }
-    }
-
-    return stream.str();
-}
-
-
-void AnalysisStatistics::add_analysis(const std::string& name, uint64_t milliseconds) {
-    if (!count_.contains(name)) {
-        count_.insert({name, 1});
-    } else {
-        count_[name]++;
-    }
-    if (!time_.contains(name)) {
-        time_.insert({name, milliseconds});
-    } else {
-        time_[name] += milliseconds;
-    }
-}
-
-std::string AnalysisStatistics::summary() {
-    if (count_.empty()) {
-        return "";
-    }
-
-    auto compare_data_fn = [](const std::tuple<std::string, uint64_t, uint64_t>& a,
-                              const std::tuple<std::string, uint64_t, uint64_t>& b) {
-        auto [a_name, a_count, a_milliseconds] = a;
-        auto [b_name, b_count, b_milliseconds] = b;
-        return a_milliseconds > b_milliseconds || (a_milliseconds == b_milliseconds && a_count > b_count) ||
-               (a_milliseconds == b_milliseconds && a_count == b_count && a_name < b_name);
-    };
-    std::stringstream stream;
-    stream << "Analysis Statistics:" << std::endl;
-
-    std::vector<std::tuple<std::string, uint64_t, uint64_t>> data;
-    uint64_t time_sum = 0;
-    for (auto [name, count] : count_) {
-        if (time_.contains(name)) {
-            auto milliseconds = time_[name];
-            data.push_back({name, count, milliseconds});
-            time_sum += milliseconds;
-        }
-    }
-    std::sort(data.begin(), data.end(), compare_data_fn);
-
-    if (!data.empty()) {
-        stream << "  Analyses: " << time_sum << " ms" << std::endl;
-        for (auto [name, count, milliseconds] : data) {
-            stream << "    " << milliseconds << " ms  " << count << "  " << name << std::endl;
-        }
-    }
-
-    return stream.str();
-}
 
 void CodegenStatistics::add_codegen(const std::string& name, uint64_t milliseconds) {
     if (!count_.contains(name)) {


### PR DESCRIPTION
Replaced PassStatistics, PipelineStatistics, AnalysisStatistics with CompileStatistics that simply records nested start and stop times. The default report summarized deeply nested data to about the same format as before, but DOCC_STATISTICS=2 enables the full report, showing nested calls of analyses the exact flow of each pipeline etc.

Also supports KV metrics that can be added to each entered scope and will be shown as well (like fuse-count)

Also throws in support for tests to find the output folder to dump other data.