### PR TITLE
Compile time reporting for CI

### DIFF
--- a/mlir/docc/torch/torch_program.py
+++ b/mlir/docc/torch/torch_program.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from docc.compiler import CompiledSDFG, DoccProgram
 from docc.compiler.target_registry import reset_target_registry
-from docc.sdfg import StructuredSDFG
+from docc.sdfg import StructuredSDFG, DoccMetrics
 from docc.mlir import MLIRModule
 
 
@@ -168,10 +168,12 @@ class TorchProgram(DoccProgram):
     ) -> CompiledSDFG:
         original_output_folder = output_folder
 
-        compile_profile = os.environ.get("DOCC_PROFILE_COMPILE", "")
-        if compile_profile:
-            print("Compiling Torch Model>")
-            compile_start_time = time.perf_counter()
+        metrics = DoccMetrics()
+        compile_start_time = time.perf_counter()
+        metrics.add_metric("target", self.target, "target")
+        metrics.add_metric("category", self.category, "target")
+        metrics.add_metric("model_name", self.name, "source")
+        metrics.add_metric("frontend", "mlir", "source")
 
         # Resolve options
         instrumentation_mode, capture_args, remote_tuning = (
@@ -329,10 +331,20 @@ class TorchProgram(DoccProgram):
             if self._sdfg is None:
                 self._sdfg = self.to_sdfg(output_folder)
 
+            parse_sdfg_time = time.perf_counter() - compile_start_time
+            metrics.add_metric(
+                "parse_to_sdfg_time_ms", round(parse_sdfg_time * 1000), "compile"
+            )
+
             sdfg = self._sdfg
 
             lib_path = self.sdfg_pipe(
-                sdfg, output_folder, instrumentation_mode, capture_args, remote_tuning
+                sdfg,
+                output_folder,
+                instrumentation_mode,
+                capture_args,
+                remote_tuning,
+                metrics=metrics,
             )
 
         # Prepend buffer info for any buffers that torch-mlir left as
@@ -384,9 +396,11 @@ class TorchProgram(DoccProgram):
 
         self._compiled = compiled
 
-        if compile_profile:
-            docc_compile_time = time.perf_counter() - compile_start_time
-            print(f">DOCC compile done: {docc_compile_time:.4f} s")
+        # Record compile time in milliseconds, rounded to the nearest integer.
+        compile_time_ms = round((time.perf_counter() - compile_start_time) * 1000)
+        metrics.add_metric("compile_time_ms", compile_time_ms, "compile_times")
+        metrics.append_to(output_folder)
+
         return compiled
 
     def to_sdfg(

--- a/mlir/docc/torch/torch_program.py
+++ b/mlir/docc/torch/torch_program.py
@@ -170,10 +170,8 @@ class TorchProgram(DoccProgram):
 
         metrics = DoccMetrics()
         compile_start_time = time.perf_counter()
-        metrics.add_metric("target", self.target, "target")
-        metrics.add_metric("category", self.category, "target")
+        metrics.add_frontend_source_info("torch-mlir")
         metrics.add_metric("model_name", self.name, "source")
-        metrics.add_metric("frontend", "mlir", "source")
 
         # Resolve options
         instrumentation_mode, capture_args, remote_tuning = (
@@ -333,7 +331,7 @@ class TorchProgram(DoccProgram):
 
             parse_sdfg_time = time.perf_counter() - compile_start_time
             metrics.add_metric(
-                "parse_to_sdfg_time_ms", round(parse_sdfg_time * 1000), "compile"
+                "parse_to_sdfg_time_ms", round(parse_sdfg_time * 1000), "compile_times"
             )
 
             sdfg = self._sdfg
@@ -396,9 +394,12 @@ class TorchProgram(DoccProgram):
 
         self._compiled = compiled
 
-        # Record compile time in milliseconds, rounded to the nearest integer.
-        compile_time_ms = round((time.perf_counter() - compile_start_time) * 1000)
-        metrics.add_metric("compile_time_ms", compile_time_ms, "compile_times")
+        if not docc_reuse_binaries:
+            # Record compile time in milliseconds, rounded to the nearest integer.
+            compile_time_ms = round((time.perf_counter() - compile_start_time) * 1000)
+            metrics.add_metric("compile_time_ms", compile_time_ms, "compile_times")
+
+        metrics.capture_env_vars()
         metrics.append_to(output_folder)
 
         return compiled

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -14,6 +14,7 @@ set(PYTHON_SOURCES
     bindings/data_flow/py_data_flow_node.cpp
     bindings/data_flow/py_memlet.cpp
     bindings/data_flow/py_tasklet.cpp
+    bindings/metrics/py_metrics.cpp
     bindings/passes/py_passes.cpp
     bindings/py_structured_sdfg.cpp
     bindings/targets/target_mapping.cpp

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -14,6 +14,7 @@ set(PYTHON_SOURCES
     bindings/data_flow/py_data_flow_node.cpp
     bindings/data_flow/py_memlet.cpp
     bindings/data_flow/py_tasklet.cpp
+    bindings/metrics/docc_metrics.cpp
     bindings/metrics/py_metrics.cpp
     bindings/passes/py_passes.cpp
     bindings/py_structured_sdfg.cpp

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -15,6 +15,7 @@
 #include "data_flow/py_data_flow_node.h"
 #include "data_flow/py_memlet.h"
 #include "data_flow/py_tasklet.h"
+#include "metrics/py_metrics.h"
 #include "passes/py_passes.h"
 #include "py_structured_sdfg.h"
 #include "sdfg/data_flow/data_flow_node.h"
@@ -108,6 +109,7 @@ PYBIND11_MODULE(_sdfg, m) {
     register_transformations(m);
     register_passes(m);
     register_cutout(m);
+    register_metrics(m);
 
     py::class_<sdfg::passes::rpc::RpcContext>(m, "RpcContext");
 

--- a/python/bindings/metrics/docc_metrics.cpp
+++ b/python/bindings/metrics/docc_metrics.cpp
@@ -1,0 +1,65 @@
+#include "docc_metrics.h"
+#include <filesystem>
+#include <fstream>
+
+namespace docc::metrics {
+
+void DoccMetrics::add_target_options(const target::TargetOptions& target_options) {
+    add_metric("target", target_options.target, "target");
+    add_metric("category", target_options.category, "target");
+    add_metric("remote_tuning", target_options.remote_tuning ? "true" : "false", "target");
+}
+
+void DoccMetrics::add_frontend_source_info(const std::string& frontend) { add_metric("frontend", frontend, "source"); }
+
+void DoccMetrics::capture_env_vars() {
+    if (auto run_stage_env = std::getenv("DAISY_CI_STAGE")) {
+        add_metric("ci_stage", run_stage_env, "source");
+    }
+    if (auto run_name_env = std::getenv("DAISY_CI_RUN_NAME")) {
+        add_metric("ci_run_name", run_name_env, "source");
+    }
+    if (auto docc_ci_env = std::getenv("DOCC_CI")) {
+        add_metric("ci_level", docc_ci_env, "source");
+    }
+}
+
+void DoccMetrics::add_metric(const std::string& key, const std::string& value, const std::string& section) {
+    if (section.empty()) {
+        global_.emplace_back(key, value);
+        return;
+    }
+    for (auto& sec : sections_) {
+        if (sec.first == section) {
+            sec.second.emplace_back(key, value);
+            return;
+        }
+    }
+    sections_.push_back({section, {{key, value}}});
+}
+
+std::string DoccMetrics::append_to(const std::string& output_dir, const std::string& file_name) const {
+    std::filesystem::path dir(output_dir);
+    std::error_code ec;
+    std::filesystem::create_directories(dir, ec);
+    if (ec) {
+        throw std::runtime_error("Failed to create directory '" + output_dir + "': " + ec.message());
+    }
+    std::filesystem::path path = dir / file_name;
+    std::ofstream out(path, std::ios::out | std::ios::app);
+    if (!out) {
+        throw std::runtime_error("Failed to open metrics file for writing: " + path.string());
+    }
+    for (const auto& kv : global_) {
+        out << kv.first << "=" << kv.second << "\n";
+    }
+    for (const auto& sec : sections_) {
+        out << "[" << sec.first << "]\n";
+        for (const auto& kv : sec.second) {
+            out << kv.first << "=" << kv.second << "\n";
+        }
+    }
+    return path.string();
+}
+
+} // namespace docc::metrics

--- a/python/bindings/metrics/docc_metrics.h
+++ b/python/bindings/metrics/docc_metrics.h
@@ -1,0 +1,65 @@
+#pragma once
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+namespace docc {
+namespace metrics {
+/**
+ * @brief Collects key/value metrics and serializes them to a classic
+ *        ".properties" file ("key=value", with optional "[section-name]"
+ *        headers).
+ *
+ * Metrics are stored in insertion order. Metrics without a section are written
+ * first (before any section header); metrics belonging to a section are grouped
+ * under a "[section]" header in first-seen order.
+ */
+class DoccMetrics {
+public:
+    DoccMetrics() = default;
+    void add_metric(const std::string& key, const std::string& value, const std::string& section = "") {
+        if (section.empty()) {
+            global_.emplace_back(key, value);
+            return;
+        }
+        for (auto& sec : sections_) {
+            if (sec.first == section) {
+                sec.second.emplace_back(key, value);
+                return;
+            }
+        }
+        sections_.push_back({section, {{key, value}}});
+    }
+    std::string append_to(const std::string& output_dir, const std::string& file_name = "docc_metrics.properties")
+        const {
+        std::filesystem::path dir(output_dir);
+        std::error_code ec;
+        std::filesystem::create_directories(dir, ec);
+        if (ec) {
+            throw std::runtime_error("Failed to create directory '" + output_dir + "': " + ec.message());
+        }
+        std::filesystem::path path = dir / file_name;
+        std::ofstream out(path, std::ios::out | std::ios::app);
+        if (!out) {
+            throw std::runtime_error("Failed to open metrics file for writing: " + path.string());
+        }
+        for (const auto& kv : global_) {
+            out << kv.first << "=" << kv.second << "\n";
+        }
+        for (const auto& sec : sections_) {
+            out << "[" << sec.first << "]\n";
+            for (const auto& kv : sec.second) {
+                out << kv.first << "=" << kv.second << "\n";
+            }
+        }
+        return path.string();
+    }
+
+private:
+    std::vector<std::pair<std::string, std::string>> global_;
+    std::vector<std::pair<std::string, std::vector<std::pair<std::string, std::string>>>> sections_;
+};
+} // namespace metrics
+} // namespace docc

--- a/python/bindings/metrics/docc_metrics.h
+++ b/python/bindings/metrics/docc_metrics.h
@@ -1,10 +1,11 @@
 #pragma once
-#include <filesystem>
-#include <fstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include "sdfg/plugins/targets.h"
+
 namespace docc {
 namespace metrics {
 /**
@@ -19,47 +20,22 @@ namespace metrics {
 class DoccMetrics {
 public:
     DoccMetrics() = default;
-    void add_metric(const std::string& key, const std::string& value, const std::string& section = "") {
-        if (section.empty()) {
-            global_.emplace_back(key, value);
-            return;
-        }
-        for (auto& sec : sections_) {
-            if (sec.first == section) {
-                sec.second.emplace_back(key, value);
-                return;
-            }
-        }
-        sections_.push_back({section, {{key, value}}});
-    }
-    std::string append_to(const std::string& output_dir, const std::string& file_name = "docc_metrics.properties")
-        const {
-        std::filesystem::path dir(output_dir);
-        std::error_code ec;
-        std::filesystem::create_directories(dir, ec);
-        if (ec) {
-            throw std::runtime_error("Failed to create directory '" + output_dir + "': " + ec.message());
-        }
-        std::filesystem::path path = dir / file_name;
-        std::ofstream out(path, std::ios::out | std::ios::app);
-        if (!out) {
-            throw std::runtime_error("Failed to open metrics file for writing: " + path.string());
-        }
-        for (const auto& kv : global_) {
-            out << kv.first << "=" << kv.second << "\n";
-        }
-        for (const auto& sec : sections_) {
-            out << "[" << sec.first << "]\n";
-            for (const auto& kv : sec.second) {
-                out << kv.first << "=" << kv.second << "\n";
-            }
-        }
-        return path.string();
-    }
+
+    void add_target_options(const target::TargetOptions& target_options);
+
+    void add_frontend_source_info(const std::string& frontend);
+
+    void capture_env_vars();
+
+    void add_metric(const std::string& key, const std::string& value, const std::string& section = "");
+
+    std::string append_to(const std::string& output_dir, const std::string& file_name = "docc_metrics.properties") const;
 
 private:
     std::vector<std::pair<std::string, std::string>> global_;
     std::vector<std::pair<std::string, std::vector<std::pair<std::string, std::string>>>> sections_;
 };
+
+
 } // namespace metrics
 } // namespace docc

--- a/python/bindings/metrics/py_metrics.cpp
+++ b/python/bindings/metrics/py_metrics.cpp
@@ -1,0 +1,36 @@
+#include "py_metrics.h"
+
+#include <pybind11/stl.h>
+
+#include <string>
+
+#include "docc_metrics.h"
+
+namespace py = pybind11;
+
+void register_metrics(py::module& m) {
+    using docc::metrics::DoccMetrics;
+
+    py::class_<DoccMetrics>(m, "DoccMetrics")
+        .def(py::init<>())
+        .def(
+            "add_metric",
+            [](DoccMetrics& self, const std::string& key, const py::object& value, const std::string& section) {
+                // Accept any Python value (int, float, bool, str, ...) and
+                // stringify it so callers do not need to convert manually.
+                self.add_metric(key, py::str(value), section);
+            },
+            py::arg("key"),
+            py::arg("value"),
+            py::arg("section") = std::string(""),
+            "Add a metric. Optionally assign it to a [section]."
+        )
+        .def(
+            "append_to",
+            &DoccMetrics::append_to,
+            py::arg("output_dir"),
+            py::arg("file_name") = std::string("docc_metrics.properties"),
+            "Append the collected metrics to a .properties file and return the "
+            "written file path."
+        );
+}

--- a/python/bindings/metrics/py_metrics.cpp
+++ b/python/bindings/metrics/py_metrics.cpp
@@ -13,6 +13,19 @@ void register_metrics(py::module& m) {
 
     py::class_<DoccMetrics>(m, "DoccMetrics")
         .def(py::init<>())
+        .def("add_target_options", &DoccMetrics::add_target_options, py::arg("target_options"))
+        .def(
+            "add_frontend_source_info",
+            &DoccMetrics::add_frontend_source_info,
+            py::arg("frontend"),
+            "Add generic info on the source of the SDFG and job, including capturing some env vars"
+        )
+        .def(
+            "capture_env_vars",
+            &DoccMetrics::capture_env_vars,
+            "Capture some env vars relevant to docc. For example DOCC_CI, DAISY_CI_RUN_NAME, DAISY_CI_STAGE that help "
+            "in identifying the outputs"
+        )
         .def(
             "add_metric",
             [](DoccMetrics& self, const std::string& key, const py::object& value, const std::string& section) {

--- a/python/bindings/metrics/py_metrics.h
+++ b/python/bindings/metrics/py_metrics.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+void register_metrics(pybind11::module& m);

--- a/python/docc/compiler/docc_program.py
+++ b/python/docc/compiler/docc_program.py
@@ -169,6 +169,7 @@ class DoccProgram(ABC):
             target_options.target = self.target
             target_options.category = self.category
             target_options.remote_tuning = remote_tuning
+            metrics.add_target_options(target_options)
 
             # Einsum detection
             sdfg.einsum()

--- a/python/docc/compiler/docc_program.py
+++ b/python/docc/compiler/docc_program.py
@@ -4,8 +4,9 @@ from typing import Any, Dict, Optional
 import json
 import os
 import re
+import time
 
-from docc.sdfg import StructuredSDFG, TargetOptions
+from docc.sdfg import StructuredSDFG, TargetOptions, DoccMetrics
 from docc.sdfg._sdfg import (
     _enable_statistics,
     _statistics_enabled_by_env,
@@ -143,7 +144,10 @@ class DoccProgram(ABC):
         capture_args: bool,
         remote_tuning: Optional[bool] = None,
         reuse_sources: bool = False,
+        metrics: Optional[DoccMetrics] = None,
     ) -> str:
+
+        start_time = time.perf_counter()
 
         if not reuse_sources and output_folder:
             if self.debug_dump:
@@ -228,6 +232,13 @@ class DoccProgram(ABC):
 
         self.last_sdfg = sdfg
 
+        compile_end_time = time.perf_counter()
+        sdfg_opt_time = compile_end_time - start_time
+        if metrics is not None:
+            metrics.add_metric(
+                "sdfg_compile_time_ms", round(sdfg_opt_time * 1000), "compile_times"
+            )
+
         custom_compile_fn = get_target_compile_fn(self.target)
         if custom_compile_fn is not None:
             lib_path = custom_compile_fn(
@@ -246,6 +257,12 @@ class DoccProgram(ABC):
                 debug_build=self.debug_build,
                 threads=self.build_thread_count,
                 reuse_sources=reuse_sources,
+            )
+
+        bin_build_time = time.perf_counter() - compile_end_time
+        if metrics is not None:
+            metrics.add_metric(
+                "bin_build_time_ms", round(bin_build_time * 1000), "compile_times"
             )
 
         # Dump statistics after compile

--- a/python/docc/python/python_program.py
+++ b/python/docc/python/python_program.py
@@ -9,6 +9,7 @@ import hashlib
 import ml_dtypes
 import numpy as np
 from typing import Annotated, get_origin, get_args, Any, Optional
+import time
 
 from docc.sdfg import (
     Scalar,
@@ -20,6 +21,7 @@ from docc.sdfg import (
     Tensor,
     StructuredSDFG,
     StructuredSDFGBuilder,
+    DoccMetrics,
 )
 from docc.compiler.docc_program import DoccProgram
 from docc.compiler.compiled_sdfg import CompiledSDFG
@@ -174,6 +176,13 @@ class PythonProgram(DoccProgram):
     ) -> CompiledSDFG:
         original_output_folder = output_folder
 
+        metrics = DoccMetrics()
+        compile_start_time = time.perf_counter()
+        metrics.add_metric("function", self.name, "source")
+        metrics.add_metric("target", self.target, "target")
+        metrics.add_metric("category", self.category, "target")
+        metrics.add_metric("frontend", "python", "source")
+
         # Resolve options
         instrumentation_mode, capture_args, remote_tuning = (
             self._resolve_compile_options(
@@ -288,7 +297,12 @@ class PythonProgram(DoccProgram):
         )
 
         lib_path = self.sdfg_pipe(
-            sdfg, output_folder, instrumentation_mode, capture_args, remote_tuning
+            sdfg,
+            output_folder,
+            instrumentation_mode,
+            capture_args,
+            remote_tuning,
+            metrics=metrics,
         )
 
         # Persist the return-value layout so a later DOCC_REUSE_BINARIES run can
@@ -313,6 +327,10 @@ class PythonProgram(DoccProgram):
         # Cache if using default output folder
         if original_output_folder is None:
             self.cache[mem_cache_key] = compiled
+
+        compile_time_ms = round((time.perf_counter() - compile_start_time) * 1000)
+        metrics.add_metric("compile_time_ms", compile_time_ms, "compile")
+        metrics.append_to(output_folder)
 
         return compiled
 

--- a/python/docc/python/python_program.py
+++ b/python/docc/python/python_program.py
@@ -179,9 +179,7 @@ class PythonProgram(DoccProgram):
         metrics = DoccMetrics()
         compile_start_time = time.perf_counter()
         metrics.add_metric("function", self.name, "source")
-        metrics.add_metric("target", self.target, "target")
-        metrics.add_metric("category", self.category, "target")
-        metrics.add_metric("frontend", "python", "source")
+        metrics.add_frontend_source_info("python")
 
         # Resolve options
         instrumentation_mode, capture_args, remote_tuning = (
@@ -286,6 +284,9 @@ class PythonProgram(DoccProgram):
             if reused is not None:
                 if original_output_folder is None:
                     self.cache[mem_cache_key] = reused
+
+                metrics.capture_env_vars()
+                metrics.append_to(output_folder)
                 return reused
 
         # 4. Build SDFG
@@ -330,6 +331,7 @@ class PythonProgram(DoccProgram):
 
         compile_time_ms = round((time.perf_counter() - compile_start_time) * 1000)
         metrics.add_metric("compile_time_ms", compile_time_ms, "compile")
+        metrics.capture_env_vars()
         metrics.append_to(output_folder)
 
         return compiled

--- a/pytorch/docc/pytorch/pytorch_program.py
+++ b/pytorch/docc/pytorch/pytorch_program.py
@@ -131,10 +131,8 @@ class PyTorchProgram(DoccProgram):
 
         metrics = DoccMetrics()
         compile_start_time = time.perf_counter()
-        metrics.add_metric("target", self.target, "target")
-        metrics.add_metric("category", self.category, "target")
+        metrics.add_frontend_source_info("torch")
         metrics.add_metric("model_name", self.name, "source")
-        metrics.add_metric("frontend", "torch", "source")
 
         # Resolve options
         instrumentation_mode, capture_args, remote_tuning = (
@@ -293,7 +291,7 @@ class PyTorchProgram(DoccProgram):
 
             parse_sdfg_time = time.perf_counter() - compile_start_time
             metrics.add_metric(
-                "parse_to_sdfg_time_ms", round(parse_sdfg_time * 1000), "compile"
+                "parse_to_sdfg_time_ms", round(parse_sdfg_time * 1000), "compile_times"
             )
 
             sdfg = self._sdfg
@@ -388,9 +386,12 @@ class PyTorchProgram(DoccProgram):
 
         self._compiled = compiled
 
-        # Record compile time in milliseconds, rounded to the nearest integer.
-        compile_time_ms = round((time.perf_counter() - compile_start_time) * 1000)
-        metrics.add_metric("compile_time_ms", compile_time_ms, "compile_times")
+        if not docc_reuse_binaries:
+            # Record compile time in milliseconds, rounded to the nearest integer.
+            compile_time_ms = round((time.perf_counter() - compile_start_time) * 1000)
+            metrics.add_metric("compile_time_ms", compile_time_ms, "compile_times")
+
+        metrics.capture_env_vars()
         metrics.append_to(output_folder_path)
 
         return compiled

--- a/pytorch/docc/pytorch/pytorch_program.py
+++ b/pytorch/docc/pytorch/pytorch_program.py
@@ -13,7 +13,7 @@ import shutil
 from typing import Any
 
 from docc.compiler import DoccProgram, CompiledSDFG
-from docc.sdfg import StructuredSDFG
+from docc.sdfg import StructuredSDFG, DoccMetrics
 
 from docc.pytorch.graph_parser import GraphParser
 
@@ -129,10 +129,12 @@ class PyTorchProgram(DoccProgram):
     ) -> CompiledSDFG:
         original_output_folder: str | None = output_folder
 
-        compile_profile: str = os.environ.get("DOCC_PROFILE_COMPILE", "")
-        if compile_profile:
-            print("Compiling Torch Model>")
-            compile_start_time: float = time.perf_counter()
+        metrics = DoccMetrics()
+        compile_start_time = time.perf_counter()
+        metrics.add_metric("target", self.target, "target")
+        metrics.add_metric("category", self.category, "target")
+        metrics.add_metric("model_name", self.name, "source")
+        metrics.add_metric("frontend", "torch", "source")
 
         # Resolve options
         instrumentation_mode, capture_args, remote_tuning = (
@@ -289,6 +291,11 @@ class PyTorchProgram(DoccProgram):
             if self._sdfg is None:
                 self._sdfg = self.to_sdfg(output_folder_path)
 
+            parse_sdfg_time = time.perf_counter() - compile_start_time
+            metrics.add_metric(
+                "parse_to_sdfg_time_ms", round(parse_sdfg_time * 1000), "compile"
+            )
+
             sdfg = self._sdfg
 
             lib_path = self.sdfg_pipe(
@@ -297,6 +304,7 @@ class PyTorchProgram(DoccProgram):
                 instrumentation_mode,
                 capture_args,
                 remote_tuning,
+                metrics=metrics,
             )
 
         # Build shape sources from input info
@@ -380,9 +388,11 @@ class PyTorchProgram(DoccProgram):
 
         self._compiled = compiled
 
-        if compile_profile:
-            docc_compile_time = time.perf_counter() - compile_start_time
-            print(f">DOCC compile done: {docc_compile_time:.4f} s")
+        # Record compile time in milliseconds, rounded to the nearest integer.
+        compile_time_ms = round((time.perf_counter() - compile_start_time) * 1000)
+        metrics.add_metric("compile_time_ms", compile_time_ms, "compile_times")
+        metrics.append_to(output_folder_path)
+
         return compiled
 
     def to_sdfg(self, output_folder: str | None = None) -> StructuredSDFG:


### PR DESCRIPTION
Docc creates a docc_metrics.properties file (for the python, mlir, pytorch frontends) that logs compile time, target, frontend and a few env vars that are captured to allow CI to identify which execution the outputs belong to.

Metrics are appended to, such that a DOCC_REUSE_BINARIES run leaves the compile-time measurements intact, while only adding runtime info as well.

The metrics file is defined as having the last entry of a key be the authoritative value.