### PR TITLE
fixes bugs in post-RPC scheduling and cleanup

### DIFF
--- a/opt/src/passes/scheduler/cuda_scheduler.cpp
+++ b/opt/src/passes/scheduler/cuda_scheduler.cpp
@@ -23,6 +23,10 @@ SchedulerAction CUDAScheduler::find(
     structured_control_flow::StructuredLoop& loop,
     bool offload_unknown_sizes
 ) {
+    if (loop.schedule_type().category() != structured_control_flow::ScheduleTypeCategory::None) {
+        return SKIP;
+    }
+
     if (dyn_cast<structured_control_flow::Map*>(&loop)) {
         return NEXT;
     }

--- a/opt/src/passes/scheduler/cuda_scheduler.cpp
+++ b/opt/src/passes/scheduler/cuda_scheduler.cpp
@@ -23,12 +23,8 @@ SchedulerAction CUDAScheduler::find(
     structured_control_flow::StructuredLoop& loop,
     bool offload_unknown_sizes
 ) {
-    if (loop.schedule_type().category() != structured_control_flow::ScheduleTypeCategory::None) {
-        return SKIP;
-    }
-
     if (dyn_cast<structured_control_flow::Map*>(&loop)) {
-        return NEXT;
+        return APPLY;
     }
 
     auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();

--- a/opt/src/passes/scheduler/loop_scheduling_pass.cpp
+++ b/opt/src/passes/scheduler/loop_scheduling_pass.cpp
@@ -47,13 +47,21 @@ bool LoopSchedulingPass::run_pass_target(
 
         bool found_incompatible = false;
 
+        // Check if the loop is scheduled already
+        if (auto sloop = dyn_cast<structured_control_flow::StructuredLoop*>(loop)) {
+            auto compatible_schedules = scheduler.compatible_types();
+            if (compatible_schedules.find(sloop->schedule_type().category()) == compatible_schedules.end()) {
+                found_incompatible = true;
+            }
+        }
+
         // Check descendants
         if (!found_incompatible) {
             auto descendants = loop_analysis.descendants(loop);
             for (auto descendant : descendants) {
-                if (auto map_node = dyn_cast<structured_control_flow::Map*>(descendant)) {
+                if (auto sloop = dyn_cast<structured_control_flow::StructuredLoop*>(descendant)) {
                     auto compatible_schedules = scheduler.compatible_types();
-                    if (compatible_schedules.find(map_node->schedule_type().category()) == compatible_schedules.end()) {
+                    if (compatible_schedules.find(sloop->schedule_type().category()) == compatible_schedules.end()) {
                         found_incompatible = true;
                         break;
                     }
@@ -80,7 +88,7 @@ bool LoopSchedulingPass::run_pass_target(
             report_->in_outermost_loop(scheduling_info.loop_info.loopnest_index);
         }
 
-        SchedulerAction action;
+        SchedulerAction action = SchedulerAction::NEXT;
         if (auto while_loop = dyn_cast<structured_control_flow::While*>(loop)) {
             action = scheduler.find(builder, analysis_manager, *while_loop, offload_unknown_sizes_);
         } else if (auto structured_loop = dyn_cast<structured_control_flow::StructuredLoop*>(loop)) {
@@ -90,10 +98,13 @@ bool LoopSchedulingPass::run_pass_target(
         }
 
         switch (action) {
-            case SchedulerAction::NEXT: {
+            case SchedulerAction::APPLY: {
                 if (auto structured_loop = dyn_cast<structured_control_flow::StructuredLoop*>(loop)) {
                     applicable_loops.push_back(structured_loop);
                 }
+                break;
+            }
+            case SchedulerAction::NEXT: {
                 break;
             }
             case SchedulerAction::CHILDREN: {
@@ -108,12 +119,8 @@ bool LoopSchedulingPass::run_pass_target(
                 }
                 break;
             }
-            case SchedulerAction::SKIP: {
-                break;
-            }
         }
     }
-
     if (applicable_loops.empty()) {
         return false;
     }

--- a/opt/src/passes/scheduler/loop_scheduling_pass.cpp
+++ b/opt/src/passes/scheduler/loop_scheduling_pass.cpp
@@ -108,6 +108,9 @@ bool LoopSchedulingPass::run_pass_target(
                 }
                 break;
             }
+            case SchedulerAction::SKIP: {
+                break;
+            }
         }
     }
 

--- a/opt/src/passes/scheduler/omp_scheduler.cpp
+++ b/opt/src/passes/scheduler/omp_scheduler.cpp
@@ -17,6 +17,10 @@ SchedulerAction OMPScheduler::find(
     structured_control_flow::StructuredLoop& loop,
     bool offload_unknown_sizes
 ) {
+    if (loop.schedule_type().category() != structured_control_flow::ScheduleTypeCategory::None) {
+        return SKIP;
+    }
+
     if (dyn_cast<structured_control_flow::Map*>(&loop)) {
         return NEXT;
     }

--- a/opt/src/passes/scheduler/omp_scheduler.cpp
+++ b/opt/src/passes/scheduler/omp_scheduler.cpp
@@ -17,12 +17,8 @@ SchedulerAction OMPScheduler::find(
     structured_control_flow::StructuredLoop& loop,
     bool offload_unknown_sizes
 ) {
-    if (loop.schedule_type().category() != structured_control_flow::ScheduleTypeCategory::None) {
-        return SKIP;
-    }
-
     if (dyn_cast<structured_control_flow::Map*>(&loop)) {
-        return NEXT;
+        return APPLY;
     }
 
     auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();

--- a/opt/src/passes/scheduler/rocm_scheduler.cpp
+++ b/opt/src/passes/scheduler/rocm_scheduler.cpp
@@ -22,6 +22,10 @@ SchedulerAction ROCMScheduler::find(
     structured_control_flow::StructuredLoop& loop,
     bool offload_unknown_sizes
 ) {
+    if (loop.schedule_type().category() != structured_control_flow::ScheduleTypeCategory::None) {
+        return SKIP;
+    }
+
     if (dyn_cast<structured_control_flow::Map*>(&loop)) {
         return NEXT;
     }

--- a/opt/src/passes/scheduler/rocm_scheduler.cpp
+++ b/opt/src/passes/scheduler/rocm_scheduler.cpp
@@ -22,12 +22,8 @@ SchedulerAction ROCMScheduler::find(
     structured_control_flow::StructuredLoop& loop,
     bool offload_unknown_sizes
 ) {
-    if (loop.schedule_type().category() != structured_control_flow::ScheduleTypeCategory::None) {
-        return SKIP;
-    }
-
     if (dyn_cast<structured_control_flow::Map*>(&loop)) {
-        return NEXT;
+        return APPLY;
     }
 
     auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();

--- a/opt/src/passes/scheduler/vectorize_scheduler.cpp
+++ b/opt/src/passes/scheduler/vectorize_scheduler.cpp
@@ -14,10 +14,6 @@ SchedulerAction VectorizeScheduler::find(
     structured_control_flow::StructuredLoop& loop,
     bool offload_unknown_sizes
 ) {
-    if (loop.schedule_type().category() != structured_control_flow::ScheduleTypeCategory::None) {
-        return SKIP;
-    }
-
     auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();
 
     bool is_innermost = loop_analysis.children(&loop).empty();
@@ -25,7 +21,7 @@ SchedulerAction VectorizeScheduler::find(
         return CHILDREN;
     }
 
-    return NEXT;
+    return APPLY;
 }
 
 SchedulerAction VectorizeScheduler::find(
@@ -40,7 +36,7 @@ SchedulerAction VectorizeScheduler::find(
     if (!is_innermost) {
         return CHILDREN;
     }
-    return NEXT;
+    return APPLY;
 }
 
 bool VectorizeScheduler::can_apply_schedule(

--- a/opt/src/passes/scheduler/vectorize_scheduler.cpp
+++ b/opt/src/passes/scheduler/vectorize_scheduler.cpp
@@ -14,6 +14,10 @@ SchedulerAction VectorizeScheduler::find(
     structured_control_flow::StructuredLoop& loop,
     bool offload_unknown_sizes
 ) {
+    if (loop.schedule_type().category() != structured_control_flow::ScheduleTypeCategory::None) {
+        return SKIP;
+    }
+
     auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();
 
     bool is_innermost = loop_analysis.children(&loop).empty();

--- a/opt/src/transformations/offloading/offload_transform.cpp
+++ b/opt/src/transformations/offloading/offload_transform.cpp
@@ -36,6 +36,14 @@ bool OffloadTransform::can_be_applied(builder::StructuredSDFGBuilder& builder, a
         return false;
     }
 
+    // Already-scheduled loops (e.g. tuned cutouts returned from remote tuning) must not be
+    // offloaded again, which would nest device buffers (double offloading).
+    if (loop_.schedule_type().category() != structured_control_flow::ScheduleTypeCategory::None) {
+        if (report_) report_->transform_impossible(this, "already scheduled");
+        DEBUG_PRINTLN("Cannot apply transform: loop already carries a non-sequential schedule");
+        return false;
+    }
+
     auto& sdfg = builder.subject();
 
     auto& arguments_analysis = analysis_manager.get<analysis::ArgumentsAnalysis>();

--- a/opt/src/transformations/omp_transform.cpp
+++ b/opt/src/transformations/omp_transform.cpp
@@ -12,7 +12,7 @@ OMPTransform::OMPTransform(structured_control_flow::Map& map) : map_(map) {}
 std::string OMPTransform::name() const { return "OMPTransform"; }
 
 bool OMPTransform::can_be_applied(builder::StructuredSDFGBuilder& builder, analysis::AnalysisManager& analysis_manager) {
-    auto result = map_.schedule_type().value() == structured_control_flow::ScheduleType_Sequential::value();
+    auto result = map_.schedule_type().category() == structured_control_flow::ScheduleTypeCategory::None;
 
     if (report_) {
         if (result) {

--- a/opt/src/transformations/vectorize_transform.cpp
+++ b/opt/src/transformations/vectorize_transform.cpp
@@ -17,7 +17,7 @@ bool VectorizeTransform::
         return false;
     }
 
-    auto result = loop_.schedule_type().value() == structured_control_flow::ScheduleType_Sequential::value();
+    auto result = loop_.schedule_type().category() == structured_control_flow::ScheduleTypeCategory::None;
 
     if (report_) {
         if (result) {

--- a/opt/tests/CMakeLists.txt
+++ b/opt/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TEST_FILES
     passes/offloading/device_buffer_reuse_pass_test.cpp
     transformations/offloading/cuda_parallelize_nested_map_test.cpp
     transformations/offloading/rocm_parallelize_nested_map_test.cpp
+    transformations/offloading/rocm_transform_test.cpp
     transformations/offloading/cuda_transform_im2col_test.cpp
     transformations/offloading/gpu_tiling_test.cpp
     transformations/offloading/kernel_local_storage_test.cpp
@@ -49,6 +50,8 @@ set(TEST_FILES
     passes/offloading/rocm_library_node_rewriter_pass_test.cpp
     passes/scheduler/cuda_scheduler_test.cpp
     passes/scheduler/omp_scheduler_test.cpp
+    passes/scheduler/rocm_scheduler_test.cpp
+    passes/scheduler/vectorize_scheduler_test.cpp
     targets/omp/codegen/omp_map_dispatcher_test.cpp
     targets/omp/schedule_test.cpp
     transformations/collapse_to_depth_test.cpp

--- a/opt/tests/cuda/cuda_kernel_test.cpp
+++ b/opt/tests/cuda/cuda_kernel_test.cpp
@@ -472,15 +472,15 @@ TEST(CudaTransformTest, CudaTransformWithBlocksizeTest) {
 
     analysis::AnalysisManager analysis_manager(builder.subject());
 
-    // Create transform locally
+    // Re-applying CUDATransform to a map that already carries a CUDA schedule is rejected:
+    // this is what prevents double-offloading of remote-tuned cutouts. The schedule (and its
+    // block size) is left untouched.
     auto cuda_transform = CUDATransform(map, 64);
-    if (cuda_transform.can_be_applied(builder, analysis_manager)) {
-        cuda_transform.apply(builder, analysis_manager);
-    }
+    EXPECT_FALSE(cuda_transform.can_be_applied(builder, analysis_manager));
 
     auto transformed_schedule = map.schedule_type();
 
-    EXPECT_TRUE(SymEngine::eq(*ScheduleType_CUDA::block_size(transformed_schedule), *symbolic::integer(64)));
+    EXPECT_TRUE(SymEngine::eq(*ScheduleType_CUDA::block_size(transformed_schedule), *symbolic::integer(32)));
 }
 
 

--- a/opt/tests/passes/scheduler/cuda_scheduler_test.cpp
+++ b/opt/tests/passes/scheduler/cuda_scheduler_test.cpp
@@ -643,3 +643,51 @@ TEST(CUDASchedulerTest, DISABLED_OuterParallelMapWithInnerReduce) {
     EXPECT_EQ(reduce.schedule_type().value(), cuda::ScheduleType_CUDA::value());
     EXPECT_EQ(cuda::ScheduleType_CUDA::dimension(reduce.schedule_type()), cuda::CUDADimension::Y);
 }
+
+// Regression test (remote-tuning double-offload): a lone top-level map that already carries a
+// CUDA schedule (as returned by remote tuning) has no nested maps, so it escapes the
+// descendant-only compatibility filter. The scheduler must still leave it untouched (find()
+// returns SKIP) instead of re-applying CUDATransform, which would nest device buffers.
+TEST(CUDASchedulerTest, SkipsLoneAlreadyCUDAScheduledMap) {
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc_2(base_desc);
+    types::Pointer opaque_desc;
+    builder.add_container("A", opaque_desc, true);
+    builder.add_container("N", sym_desc, true);
+    builder.add_container("i", sym_desc);
+
+    auto indvar = symbolic::symbol("i");
+    auto& map = builder.add_map(
+        root,
+        indvar,
+        symbolic::Lt(indvar, symbolic::symbol("N")),
+        symbolic::integer(0),
+        symbolic::add(indvar, symbolic::integer(1)),
+        cuda::ScheduleType_CUDA::create()
+    );
+    auto& block = builder.add_block(map.root());
+    auto& a_in = builder.add_access(block, "A");
+    auto& a_out = builder.add_access(block, "A");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(block, a_in, tasklet, "_in", {indvar}, desc_2);
+    builder.add_computational_memlet(block, tasklet, "_out", a_out, {indvar}, desc_2);
+
+    analysis::AnalysisManager analysis_manager(builder.subject());
+    passes::scheduler::LoopSchedulingPass loop_scheduling_pass({get_cuda_sched()}, nullptr);
+
+    // The only loop is already scheduled -> no scheduling changes.
+    EXPECT_FALSE(loop_scheduling_pass.run(builder, analysis_manager));
+
+    // Schedule unchanged and no device buffers created (not re-offloaded).
+    EXPECT_EQ(map.schedule_type().value(), cuda::ScheduleType_CUDA::value());
+    for (auto& container : builder.subject().containers()) {
+        std::string name = container;
+        EXPECT_EQ(name.find("__daisy_cuda_"), std::string::npos)
+            << "Unexpected device buffer " << name << " (map was re-offloaded)";
+    }
+}

--- a/opt/tests/passes/scheduler/omp_scheduler_test.cpp
+++ b/opt/tests/passes/scheduler/omp_scheduler_test.cpp
@@ -238,3 +238,41 @@ TEST(OMPSchedulerTest, OuterWhileWithInnerMaps) {
     EXPECT_EQ(loop_2.schedule_type().value(), omp::ScheduleType_OMP::value());
     EXPECT_EQ(loop_3.schedule_type().value(), omp::ScheduleType_OMP::value());
 }
+
+// Regression test: a map that already carries a parallel (non-None) schedule must be left
+// untouched -- the scheduler's find() returns SKIP instead of re-parallelizing it.
+TEST(OMPSchedulerTest, SkipsAlreadyParallelMap) {
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc_2(base_desc);
+    types::Pointer opaque_desc;
+    builder.add_container("A", opaque_desc, true);
+    builder.add_container("N", sym_desc, true);
+    builder.add_container("i", sym_desc);
+
+    auto indvar = symbolic::symbol("i");
+    auto& map = builder.add_map(
+        root,
+        indvar,
+        symbolic::Lt(indvar, symbolic::symbol("N")),
+        symbolic::integer(0),
+        symbolic::add(indvar, symbolic::integer(1)),
+        omp::ScheduleType_OMP::create()
+    );
+    auto& block = builder.add_block(map.root());
+    auto& a_in = builder.add_access(block, "A");
+    auto& a_out = builder.add_access(block, "A");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(block, a_in, tasklet, "_in", {indvar}, desc_2);
+    builder.add_computational_memlet(block, tasklet, "_out", a_out, {indvar}, desc_2);
+
+    analysis::AnalysisManager analysis_manager(builder.subject());
+    passes::scheduler::LoopSchedulingPass loop_scheduling_pass({get_omp_sched()}, nullptr);
+
+    EXPECT_FALSE(loop_scheduling_pass.run(builder, analysis_manager));
+    EXPECT_EQ(map.schedule_type().value(), omp::ScheduleType_OMP::value());
+}

--- a/opt/tests/passes/scheduler/rocm_scheduler_test.cpp
+++ b/opt/tests/passes/scheduler/rocm_scheduler_test.cpp
@@ -1,0 +1,63 @@
+#include "sdfg/passes/scheduler/rocm_scheduler.h"
+
+#include "sdfg/analysis/analysis.h"
+#include "sdfg/passes/scheduler/loop_scheduling_pass.h"
+#include "sdfg/structured_control_flow/map.h"
+#include "sdfg/targets/rocm/rocm.h"
+
+#include <gtest/gtest.h>
+
+using namespace sdfg;
+
+static passes::scheduler::ROCMScheduler* get_rocm_sched() {
+    static passes::scheduler::ROCMScheduler instance;
+    return &instance;
+}
+
+// Regression test (remote-tuning double-offload): a lone top-level map that already carries a
+// ROCM schedule has no nested maps, so it escapes the descendant-only compatibility filter. The
+// scheduler must still leave it untouched (find() returns SKIP) instead of re-applying
+// ROCMTransform, which would nest device buffers.
+TEST(ROCMSchedulerTest, SkipsLoneAlreadyROCMScheduledMap) {
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc_2(base_desc);
+    types::Pointer opaque_desc;
+    builder.add_container("A", opaque_desc, true);
+    builder.add_container("N", sym_desc, true);
+    builder.add_container("i", sym_desc);
+
+    auto indvar = symbolic::symbol("i");
+    auto& map = builder.add_map(
+        root,
+        indvar,
+        symbolic::Lt(indvar, symbolic::symbol("N")),
+        symbolic::integer(0),
+        symbolic::add(indvar, symbolic::integer(1)),
+        rocm::ScheduleType_ROCM::create()
+    );
+    auto& block = builder.add_block(map.root());
+    auto& a_in = builder.add_access(block, "A");
+    auto& a_out = builder.add_access(block, "A");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(block, a_in, tasklet, "_in", {indvar}, desc_2);
+    builder.add_computational_memlet(block, tasklet, "_out", a_out, {indvar}, desc_2);
+
+    analysis::AnalysisManager analysis_manager(builder.subject());
+    passes::scheduler::LoopSchedulingPass loop_scheduling_pass({get_rocm_sched()}, nullptr);
+
+    // The only loop is already scheduled -> no scheduling changes.
+    EXPECT_FALSE(loop_scheduling_pass.run(builder, analysis_manager));
+
+    // Schedule unchanged and no device buffers created (not re-offloaded).
+    EXPECT_EQ(map.schedule_type().value(), rocm::ScheduleType_ROCM::value());
+    for (auto& container : builder.subject().containers()) {
+        std::string name = container;
+        EXPECT_EQ(name.find(rocm::ROCM_DEVICE_PREFIX), std::string::npos)
+            << "Unexpected device buffer " << name << " (map was re-offloaded)";
+    }
+}

--- a/opt/tests/passes/scheduler/vectorize_scheduler_test.cpp
+++ b/opt/tests/passes/scheduler/vectorize_scheduler_test.cpp
@@ -1,0 +1,54 @@
+#include "sdfg/passes/scheduler/vectorize_scheduler.h"
+
+#include "sdfg/analysis/analysis.h"
+#include "sdfg/passes/scheduler/loop_scheduling_pass.h"
+#include "sdfg/structured_control_flow/map.h"
+#include "sdfg/targets/vectorize/schedule.h"
+
+#include <gtest/gtest.h>
+
+using namespace sdfg;
+
+static passes::scheduler::VectorizeScheduler* get_vectorize_sched() {
+    static passes::scheduler::VectorizeScheduler instance;
+    return &instance;
+}
+
+// Regression test: a loop that already carries a vectorize (non-None) schedule must be left
+// untouched -- the scheduler's find() returns SKIP instead of re-vectorizing it.
+TEST(VectorizeSchedulerTest, SkipsAlreadyVectorizedMap) {
+    builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+    auto& root = sdfg.root();
+
+    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer desc_2(base_desc);
+    types::Pointer opaque_desc;
+    builder.add_container("A", opaque_desc, true);
+    builder.add_container("N", sym_desc, true);
+    builder.add_container("i", sym_desc);
+
+    auto indvar = symbolic::symbol("i");
+    auto& map = builder.add_map(
+        root,
+        indvar,
+        symbolic::Lt(indvar, symbolic::symbol("N")),
+        symbolic::integer(0),
+        symbolic::add(indvar, symbolic::integer(1)),
+        vectorize::ScheduleType_Vectorize::create()
+    );
+    auto& block = builder.add_block(map.root());
+    auto& a_in = builder.add_access(block, "A");
+    auto& a_out = builder.add_access(block, "A");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(block, a_in, tasklet, "_in", {indvar}, desc_2);
+    builder.add_computational_memlet(block, tasklet, "_out", a_out, {indvar}, desc_2);
+
+    analysis::AnalysisManager analysis_manager(builder.subject());
+    passes::scheduler::LoopSchedulingPass loop_scheduling_pass({get_vectorize_sched()}, nullptr);
+
+    // The only loop is already scheduled -> no scheduling changes.
+    EXPECT_FALSE(loop_scheduling_pass.run(builder, analysis_manager));
+    EXPECT_EQ(map.schedule_type().value(), vectorize::ScheduleType_Vectorize::value());
+}

--- a/opt/tests/transformations/offloading/rocm_transform_test.cpp
+++ b/opt/tests/transformations/offloading/rocm_transform_test.cpp
@@ -1,0 +1,56 @@
+#include "sdfg/transformations/offloading/rocm_transform.h"
+
+#include <gtest/gtest.h>
+
+using namespace sdfg;
+
+// A sequential map is offloadable to a ROCM kernel.
+TEST(ROCMTransformTest, MapWithSequentialSchedule) {
+    builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
+    auto& root = builder.subject().root();
+
+    types::Scalar int_desc(types::PrimitiveType::Int32);
+    builder.add_container("i", int_desc);
+
+    auto& map = builder.add_map(
+        root,
+        symbolic::symbol("i"),
+        symbolic::Lt(symbolic::symbol("i"), symbolic::integer(100)),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("i"), symbolic::integer(1)),
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+
+    analysis::AnalysisManager analysis_manager(builder.subject());
+    rocm::ROCMTransform transformation(map, 64);
+    EXPECT_TRUE(transformation.can_be_applied(builder, analysis_manager));
+    transformation.apply(builder, analysis_manager);
+
+    EXPECT_EQ(map.schedule_type().value(), rocm::ScheduleType_ROCM::value());
+}
+
+// Regression test (remote-tuning double-offload): re-applying ROCMTransform to a map that
+// already carries a ROCM schedule must be rejected, so tuned cutouts are not offloaded twice.
+TEST(ROCMTransformTest, RejectsAlreadyROCMScheduledMap) {
+    builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
+    auto& root = builder.subject().root();
+
+    types::Scalar int_desc(types::PrimitiveType::Int32);
+    builder.add_container("i", int_desc);
+
+    auto& map = builder.add_map(
+        root,
+        symbolic::symbol("i"),
+        symbolic::Lt(symbolic::symbol("i"), symbolic::integer(100)),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("i"), symbolic::integer(1)),
+        rocm::ScheduleType_ROCM::create()
+    );
+
+    analysis::AnalysisManager analysis_manager(builder.subject());
+    rocm::ROCMTransform transformation(map, 128);
+    EXPECT_FALSE(transformation.can_be_applied(builder, analysis_manager));
+
+    // Schedule left untouched.
+    EXPECT_EQ(map.schedule_type().value(), rocm::ScheduleType_ROCM::value());
+}

--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -468,8 +468,9 @@ void PyStructuredSDFG::schedule(const docc::target::TargetOptions& options) {
     std::vector<sdfg::passes::scheduler::LoopScheduler*> unwrapped_schedulers(mapped.begin(), mapped.end());
 
     sdfg::passes::scheduler::LoopSchedulingPass loop_scheduling_pass(unwrapped_schedulers, nullptr);
-    bool loop_scheduling_changes = loop_scheduling_pass.run(builder, analysis_manager);
-    if (loop_scheduling_changes) {
+    loop_scheduling_pass.run(builder, analysis_manager);
+
+    if (options.target == "cuda" || options.target == "rocm") {
         sdfg::passes::DataTransferMinimizationPass data_transfer_minimization_pass;
         data_transfer_minimization_pass.run(builder, analysis_manager);
         sdfg::passes::DeviceBufferReusePass device_buffer_reuse_pass;

--- a/sdfg/include/sdfg/passes/scheduler/loop_scheduler.h
+++ b/sdfg/include/sdfg/passes/scheduler/loop_scheduler.h
@@ -16,6 +16,7 @@ namespace scheduler {
 enum SchedulerAction {
     NEXT,
     CHILDREN,
+    SKIP,
 };
 
 struct SchedulerLoopInfo {
@@ -39,7 +40,9 @@ public:
      * @brief Phase 1: Determine the action for a loop during loop discovery.
      *
      * Returns NEXT if the loop should be scheduled (added to the applicable set),
-     * or CHILDREN if the scheduler should descend into child loops instead.
+     * CHILDREN if the scheduler should descend into child loops instead, or SKIP
+     * if the loop already carries a non-None schedule and must be left untouched
+     * (neither scheduled nor traversed into).
      */
     virtual SchedulerAction find(
         builder::StructuredSDFGBuilder& builder,

--- a/sdfg/include/sdfg/passes/scheduler/loop_scheduler.h
+++ b/sdfg/include/sdfg/passes/scheduler/loop_scheduler.h
@@ -14,9 +14,9 @@ namespace passes {
 namespace scheduler {
 
 enum SchedulerAction {
+    APPLY,
     NEXT,
     CHILDREN,
-    SKIP,
 };
 
 struct SchedulerLoopInfo {

--- a/targets/tenstorrent/src/tenstorrent/tenstorrent_scheduler.cpp
+++ b/targets/tenstorrent/src/tenstorrent/tenstorrent_scheduler.cpp
@@ -13,7 +13,7 @@ SchedulerAction TenstorrentScheduler::find(
     bool offload_unknown_sizes
 ) {
     if (dyn_cast<structured_control_flow::Map*>(&loop)) {
-        return NEXT;
+        return APPLY;
     }
 
     auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill out this template to help reviewers
understand your changes. Remove sections that are not relevant.
-->

## Description
- RPC scheduling does not report loop nests changed, so post-cleanup is never triggered
- Transforms/schedulers do not respect already-scheduled loops from RPC, so the get double offloaded

## Related Issues
<!-- Link issues this PR closes or relates to, e.g. "Closes #123" -->
- Closes #

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal change (no functional change)
- [ ] Documentation update

## Quality Checklist
*Please ensure the following are completed before requesting review:*

* [ ] Runtime-compatible (no externally visible existing method has its parameters changed, was deleted or has its exception behavior changed)
* [ ] Compile-time compatible (new arguments & properties added have default values, but users need to recompile against the new version to work)

IR:
* [ ] Introduces new types into the SDFG IR
* [ ]  Changed / added properties on SDFG IR Elements (LibraryNodes, ControlFlowNodes DataFlowNodes etc.)
  *  [ ] New / modified types have serialization / deserialization support
  *  [ ] Deserialization is backward compatible (new serialization can deserialize old format and represent it in the new format if applicable)
  *  [ ] Serialized format is backward compatible (previous deserializer can read new serialized format without incorrectness (just lacking additional guarantees that are optional or did not exist before)
  *  [ ] Serializer has an option to emit the previous format

### Unit Tests
- [ ] New unit tests have been added for the changes.
- [ ] Existing unit tests pass locally.
- [ ] Edge cases and error paths are covered.

### Integration Tests
- [ ] New integration tests have been added (or existing ones updated).
- [ ] Integration tests pass locally.
- [ ] Interactions with other components/services are verified.

### Documentation
- [ ] Public APIs, options, and behavior changes are documented.
- [ ] README / docs site / inline comments updated where applicable.
- [ ] Changelog / release notes updated (if applicable).

### Test Coverage
- [ ] Test coverage has not decreased as a result of this change.
- [ ] Coverage report reviewed and acceptable.
- [ ] Critical / new code paths are covered.

## How Has This Been Tested?
Describe the tests you ran to verify your changes and provide instructions to reproduce.
Include relevant details for your test configuration (OS, Python/LLVM/Docc version, hardware/target).

## Additional Context
Add any other context about the PR here (design decisions, trade-offs, follow-ups).
