### PR TITLE
DOCC_BACKEND_COMPILER env to override compiler used

### DIFF
--- a/c-compile/src/target/docc_target.cpp
+++ b/c-compile/src/target/docc_target.cpp
@@ -113,7 +113,7 @@ static DoccTarget openmp_target = {
     .apply_additional_compile_options = [](compile::SrcFileCompilerBuilder& builder) -> bool {
 #if defined(__APPLE__)
         builder.add_common_option("-Xpreprocessor -fopenmp");
-        builder.add_library_path("/opt/homebrew/opt/libomp/lib")
+        builder.add_library_path("/opt/homebrew/opt/libomp/lib");
         builder.add_library_path("/opt/homebrew/opt/libomp/include");
         builder.add_link_option("-lomp");
 #else

--- a/c-compile/src/target/docc_target.cpp
+++ b/c-compile/src/target/docc_target.cpp
@@ -110,6 +110,17 @@ static DoccTarget sequential_target = {
 
 static DoccTarget openmp_target = {
     .short_name = "openmp",
+    .apply_additional_compile_options = [](compile::SrcFileCompilerBuilder& builder) -> bool {
+#if defined(__APPLE__)
+        builder.add_common_option("-Xpreprocessor -fopenmp");
+        builder.add_library_path("/opt/homebrew/opt/libomp/lib")
+        builder.add_library_path("/opt/homebrew/opt/libomp/include");
+        builder.add_link_option("-lomp");
+#else
+        builder.add_common_option("-fopenmp");
+#endif
+        return true;
+    },
     .get_target_loop_schedulers = [](const TargetOptions& options
                                   ) -> std::vector<std::shared_ptr<sdfg::passes::scheduler::LoopScheduler>> {
         std::vector<std::shared_ptr<sdfg::passes::scheduler::LoopScheduler>> schedulers;

--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -78,17 +78,6 @@
 #include <docc/target/et/target.h>
 #endif
 
-// Platform-specific compiler selection
-#ifndef DOCC_CXX_COMPILER
-#if defined(__APPLE__)
-#define DOCC_CXX_COMPILER "clang++"
-#elif defined(__linux__)
-#define DOCC_CXX_COMPILER "clang-19"
-#else
-#error "Unsupported platform"
-#endif
-#endif
-
 namespace fs = std::filesystem;
 using json = nlohmann::json;
 
@@ -543,6 +532,25 @@ struct SnippetMetadata {
     std::string extension;
 };
 
+std::string docc_backend_compiler() {
+    const char* env_compiler = std::getenv("DOCC_BACKEND_COMPILER");
+    if (env_compiler) {
+        return std::string(env_compiler);
+    } else {
+        // Platform-specific compiler selection
+#ifndef DOCC_CXX_COMPILER
+#if defined(__APPLE__)
+#define DOCC_CXX_COMPILER "clang++"
+#elif defined(__linux__)
+#define DOCC_CXX_COMPILER "clang-19"
+#else
+#error "Unsupported platform"
+#endif
+#endif
+        return DOCC_CXX_COMPILER;
+    }
+}
+
 std::string PyStructuredSDFG::compile(
     const std::string& output_folder,
     const std::string& target,
@@ -586,8 +594,11 @@ std::string PyStructuredSDFG::compile(
     std::shared_ptr<docc::util::DefaultDoccPaths> paths =
         docc::util::DefaultDoccPaths::from_lib_location(docc::util::find_lib_location());
 
+    
+    auto backend_compiler_exec = docc_backend_compiler();
+
     docc::compile::SrcFileCompilerBuilder compile_builder;
-    compile_builder.set_compiler(DOCC_CXX_COMPILER)
+    compile_builder.set_compiler(backend_compiler_exec)
         .set_from_paths(paths)
         .set_src_extension("cpp")
         .set_bin_extension("so")
@@ -612,15 +623,10 @@ std::string PyStructuredSDFG::compile(
     }
 
 #if defined(__APPLE__)
-    compile_builder.add_common_option("-Xpreprocessor -fopenmp");
     compile_builder.add_include_path("/opt/homebrew/include");
-    compile_builder.add_library_path("/opt/homebrew/opt/libomp/lib")
-        .add_library_path("/opt/homebrew/opt/libomp/include")
-        .add_library_path("/opt/homebrew/lib");
-    compile_builder.add_link_option("-lomp");
+    compile_builder.add_library_path("/opt/homebrew/lib");
     compile_builder.add_link_option("-framework Accelerate");
 #else
-    compile_builder.add_common_option("-fopenmp");
     compile_builder.add_link_option("-lblas");
 #endif
 

--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -594,7 +594,7 @@ std::string PyStructuredSDFG::compile(
     std::shared_ptr<docc::util::DefaultDoccPaths> paths =
         docc::util::DefaultDoccPaths::from_lib_location(docc::util::find_lib_location());
 
-    
+
     auto backend_compiler_exec = docc_backend_compiler();
 
     docc::compile::SrcFileCompilerBuilder compile_builder;


### PR DESCRIPTION
Moved omp compile options into openmp DoccTarget, no longer linking it by default, because it causes issues once we use a different clang version then the one we used to compile DOCC.